### PR TITLE
feat: emoji admin interface (EMOJI-P2-003)

### DIFF
--- a/src/app/(dashboard)/admin/emojis/[slug]/page.tsx
+++ b/src/app/(dashboard)/admin/emojis/[slug]/page.tsx
@@ -1,0 +1,28 @@
+import { notFound } from 'next/navigation';
+import { getEmojiBySlug } from '@/lib/emoji-data';
+import { AdminEmojiForm } from '@/components/admin/admin-emoji-form';
+
+interface EditEmojiPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export default async function EditEmojiPage({ params }: EditEmojiPageProps) {
+  const { slug } = await params;
+  const emoji = getEmojiBySlug(slug);
+
+  if (!emoji) {
+    notFound();
+  }
+
+  return (
+    <div className="max-w-4xl">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold">Edit Emoji</h1>
+        <p className="text-muted-foreground mt-1">
+          Update emoji content for {emoji.character} {emoji.name}
+        </p>
+      </div>
+      <AdminEmojiForm emoji={emoji} />
+    </div>
+  );
+}

--- a/src/app/(dashboard)/admin/emojis/new/page.tsx
+++ b/src/app/(dashboard)/admin/emojis/new/page.tsx
@@ -1,0 +1,13 @@
+import { AdminEmojiForm } from '@/components/admin/admin-emoji-form';
+
+export default function NewEmojiPage() {
+  return (
+    <div className="max-w-4xl">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold">Create New Emoji</h1>
+        <p className="text-muted-foreground mt-1">Add a new emoji to the database</p>
+      </div>
+      <AdminEmojiForm />
+    </div>
+  );
+}

--- a/src/app/(dashboard)/admin/emojis/page.tsx
+++ b/src/app/(dashboard)/admin/emojis/page.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link';
+import { getAllEmojis } from '@/lib/emoji-data';
+import { AdminEmojiList } from '@/components/admin/admin-emoji-list';
+
+export default async function AdminEmojiPage() {
+  const emojis = getAllEmojis();
+
+  return (
+    <div>
+      <div className="mb-8 flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold">Emoji Admin</h1>
+          <p className="text-muted-foreground mt-1">Manage emoji content ({emojis.length} total)</p>
+        </div>
+        <Link
+          href="/admin/emojis/new"
+          className="inline-flex items-center justify-center rounded-lg bg-gradient-to-r from-amber-500 to-orange-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:from-amber-600 hover:to-orange-600"
+        >
+          + New Emoji
+        </Link>
+      </div>
+      <AdminEmojiList emojis={emojis} />
+    </div>
+  );
+}

--- a/src/app/(dashboard)/admin/layout.tsx
+++ b/src/app/(dashboard)/admin/layout.tsx
@@ -1,0 +1,10 @@
+import { DashboardSidebar } from '@/components/dashboard/dashboard-sidebar';
+
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-screen">
+      <DashboardSidebar />
+      <main className="flex-1 p-8">{children}</main>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,12 +1,16 @@
 import { DashboardSidebar } from '@/components/dashboard';
+import { Toaster } from '@/components/ui/toast';
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex min-h-[calc(100vh-3.5rem)]">
-      <DashboardSidebar />
-      <div className="flex-1 overflow-auto">
-        <div className="container mx-auto px-4 py-6 md:px-8">{children}</div>
+    <>
+      <div className="flex min-h-[calc(100vh-3.5rem)]">
+        <DashboardSidebar />
+        <div className="flex-1 overflow-auto">
+          <div className="container mx-auto px-4 py-6 md:px-8">{children}</div>
+        </div>
       </div>
-    </div>
+      <Toaster />
+    </>
   );
 }

--- a/src/app/api/admin/emojis/[slug]/route.ts
+++ b/src/app/api/admin/emojis/[slug]/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+import type { Emoji } from '@/types/emoji';
+
+interface RouteParams {
+  params: Promise<{ slug: string }>;
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { slug } = await params;
+    const emojisDir = path.join(process.cwd(), 'src', 'data', 'emojis');
+    const filePath = path.join(emojisDir, `${slug}.json`);
+
+    if (!fs.existsSync(filePath)) {
+      return NextResponse.json({ error: 'Emoji not found' }, { status: 404 });
+    }
+
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const emoji = JSON.parse(content) as Emoji;
+
+    return NextResponse.json({ emoji });
+  } catch (error) {
+    console.error('Error fetching emoji:', error);
+    return NextResponse.json({ error: 'Failed to fetch emoji' }, { status: 500 });
+  }
+}
+
+export async function PUT(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { slug } = await params;
+    const emoji: Emoji = await request.json();
+
+    const emojisDir = path.join(process.cwd(), 'src', 'data', 'emojis');
+    const filePath = path.join(emojisDir, `${slug}.json`);
+
+    if (!fs.existsSync(filePath)) {
+      return NextResponse.json({ error: 'Emoji not found' }, { status: 404 });
+    }
+
+    fs.writeFileSync(filePath, JSON.stringify(emoji, null, 2), 'utf-8');
+
+    return NextResponse.json({ success: true, emoji });
+  } catch (error) {
+    console.error('Error updating emoji:', error);
+    return NextResponse.json({ error: 'Failed to update emoji' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { slug } = await params;
+    const emojisDir = path.join(process.cwd(), 'src', 'data', 'emojis');
+    const filePath = path.join(emojisDir, `${slug}.json`);
+
+    if (!fs.existsSync(filePath)) {
+      return NextResponse.json({ error: 'Emoji not found' }, { status: 404 });
+    }
+
+    fs.unlinkSync(filePath);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error deleting emoji:', error);
+    return NextResponse.json({ error: 'Failed to delete emoji' }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/emojis/route.ts
+++ b/src/app/api/admin/emojis/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+import type { Emoji } from '@/types/emoji';
+
+export async function POST(request: NextRequest) {
+  try {
+    const emoji: Emoji = await request.json();
+
+    // Validate required fields
+    if (!emoji.slug || !emoji.character || !emoji.name) {
+      return NextResponse.json(
+        { error: 'Missing required fields: slug, character, name' },
+        { status: 400 }
+      );
+    }
+
+    // Check if emoji already exists
+    const emojisDir = path.join(process.cwd(), 'src', 'data', 'emojis');
+    const filePath = path.join(emojisDir, `${emoji.slug}.json`);
+
+    if (fs.existsSync(filePath)) {
+      return NextResponse.json({ error: 'Emoji with this slug already exists' }, { status: 409 });
+    }
+
+    // Write the emoji file
+    fs.writeFileSync(filePath, JSON.stringify(emoji, null, 2), 'utf-8');
+
+    return NextResponse.json({ success: true, emoji }, { status: 201 });
+  } catch (error) {
+    console.error('Error creating emoji:', error);
+    return NextResponse.json({ error: 'Failed to create emoji' }, { status: 500 });
+  }
+}
+
+export async function GET() {
+  try {
+    const emojisDir = path.join(process.cwd(), 'src', 'data', 'emojis');
+    const files = fs.readdirSync(emojisDir).filter((file) => file.endsWith('.json'));
+
+    const emojis = files.map((file) => {
+      const filePath = path.join(emojisDir, file);
+      const content = fs.readFileSync(filePath, 'utf-8');
+      return JSON.parse(content) as Emoji;
+    });
+
+    return NextResponse.json({ emojis });
+  } catch (error) {
+    console.error('Error fetching emojis:', error);
+    return NextResponse.json({ error: 'Failed to fetch emojis' }, { status: 500 });
+  }
+}

--- a/src/components/admin/admin-emoji-form.tsx
+++ b/src/components/admin/admin-emoji-form.tsx
@@ -1,0 +1,582 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import type { Emoji, EmojiDraft } from '@/types/emoji';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { toast } from '@/components/ui/toast';
+
+interface AdminEmojiFormProps {
+  emoji?: Emoji;
+}
+
+const CATEGORIES = [
+  { value: 'faces', label: 'Smileys & Faces' },
+  { value: 'people', label: 'People & Body' },
+  { value: 'animals', label: 'Animals & Nature' },
+  { value: 'food', label: 'Food & Drink' },
+  { value: 'travel', label: 'Travel & Places' },
+  { value: 'activities', label: 'Activities' },
+  { value: 'objects', label: 'Objects' },
+  { value: 'symbols', label: 'Symbols' },
+  { value: 'flags', label: 'Flags' },
+];
+
+const CONTEXT_TYPES = [
+  'LITERAL',
+  'SLANG',
+  'IRONIC',
+  'PASSIVE_AGGRESSIVE',
+  'DATING',
+  'WORK',
+  'RED_FLAG',
+];
+const RISK_LEVELS = ['LOW', 'MEDIUM', 'HIGH'];
+const PLATFORMS = ['IMESSAGE', 'INSTAGRAM', 'TIKTOK', 'WHATSAPP', 'SLACK', 'DISCORD', 'TWITTER'];
+const GENERATIONS = ['GEN_Z', 'MILLENNIAL', 'GEN_X', 'BOOMER'];
+
+export function AdminEmojiForm({ emoji }: AdminEmojiFormProps) {
+  const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const [formData, setFormData] = useState<EmojiDraft>({
+    unicode: emoji?.unicode || '',
+    slug: emoji?.slug || '',
+    character: emoji?.character || '',
+    name: emoji?.name || '',
+    shortName: emoji?.shortName || '',
+    category: emoji?.category || 'faces',
+    subcategory: emoji?.subcategory || '',
+    unicodeVersion: emoji?.unicodeVersion || '15.0',
+    baseMeaning: emoji?.baseMeaning || '',
+    tldr: emoji?.tldr || '',
+    contextMeanings: emoji?.contextMeanings || [],
+    platformNotes: emoji?.platformNotes || [],
+    generationalNotes: emoji?.generationalNotes || [],
+    warnings: emoji?.warnings || [],
+    relatedCombos: emoji?.relatedCombos || [],
+    seoTitle: emoji?.seoTitle || '',
+    seoDescription: emoji?.seoDescription || '',
+    skinToneVariations: emoji?.skinToneVariations || [],
+    skinToneBase: emoji?.skinToneBase || '',
+  });
+
+  const updateField = <K extends keyof EmojiDraft>(field: K, value: EmojiDraft[K]) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const addContextMeaning = () => {
+    updateField('contextMeanings', [
+      ...(formData.contextMeanings ?? []),
+      { context: 'SLANG', meaning: '', example: '', riskLevel: 'LOW' },
+    ]);
+  };
+
+  const updateContextMeaning = (index: number, field: string, value: string) => {
+    const updated = [...(formData.contextMeanings ?? [])];
+    updated[index] = { ...updated[index], [field]: value };
+    updateField('contextMeanings', updated);
+  };
+
+  const removeContextMeaning = (index: number) => {
+    updateField(
+      'contextMeanings',
+      (formData.contextMeanings ?? []).filter((_, i) => i !== index)
+    );
+  };
+
+  const addPlatformNote = () => {
+    updateField('platformNotes', [
+      ...(formData.platformNotes ?? []),
+      { platform: 'IMESSAGE', note: '' },
+    ]);
+  };
+
+  const updatePlatformNote = (index: number, field: string, value: string) => {
+    const updated = [...(formData.platformNotes ?? [])];
+    updated[index] = { ...updated[index], [field]: value };
+    updateField('platformNotes', updated);
+  };
+
+  const removePlatformNote = (index: number) => {
+    updateField(
+      'platformNotes',
+      (formData.platformNotes ?? []).filter((_, i) => i !== index)
+    );
+  };
+
+  const addGenerationalNote = () => {
+    updateField('generationalNotes', [
+      ...(formData.generationalNotes ?? []),
+      { generation: 'GEN_Z', note: '' },
+    ]);
+  };
+
+  const updateGenerationalNote = (index: number, field: string, value: string) => {
+    const updated = [...(formData.generationalNotes ?? [])];
+    updated[index] = { ...updated[index], [field]: value };
+    updateField('generationalNotes', updated);
+  };
+
+  const removeGenerationalNote = (index: number) => {
+    updateField(
+      'generationalNotes',
+      (formData.generationalNotes ?? []).filter((_, i) => i !== index)
+    );
+  };
+
+  const addWarning = () => {
+    updateField('warnings', [
+      ...(formData.warnings ?? []),
+      { title: '', description: '', severity: 'LOW' },
+    ]);
+  };
+
+  const updateWarning = (index: number, field: string, value: string) => {
+    const updated = [...(formData.warnings ?? [])];
+    updated[index] = { ...updated[index], [field]: value };
+    updateField('warnings', updated);
+  };
+
+  const removeWarning = (index: number) => {
+    updateField(
+      'warnings',
+      (formData.warnings ?? []).filter((_, i) => i !== index)
+    );
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+
+    try {
+      const endpoint = emoji ? `/api/admin/emojis/${emoji.slug}` : '/api/admin/emojis';
+      const method = emoji ? 'PUT' : 'POST';
+
+      const response = await fetch(endpoint, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formData),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to save emoji');
+      }
+
+      toast({
+        title: 'Success',
+        description: `Emoji ${emoji ? 'updated' : 'created'} successfully!`,
+      });
+      router.push('/admin/emojis');
+    } catch {
+      toast({ title: 'Error', description: 'Failed to save emoji', variant: 'destructive' });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-8">
+      {/* Basic Information */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Basic Information</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium mb-1">Character</label>
+              <Input
+                value={formData.character}
+                onChange={(e) => updateField('character', e.target.value)}
+                placeholder="💀"
+                required
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Name</label>
+              <Input
+                value={formData.name}
+                onChange={(e) => updateField('name', e.target.value)}
+                placeholder="Skull"
+                required
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium mb-1">Unicode</label>
+              <Input
+                value={formData.unicode}
+                onChange={(e) => updateField('unicode', e.target.value)}
+                placeholder="1F480"
+                required
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Slug</label>
+              <Input
+                value={formData.slug}
+                onChange={(e) => updateField('slug', e.target.value)}
+                placeholder="skull"
+                pattern="[a-z0-9-]+"
+                required
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-3 gap-4">
+            <div>
+              <label className="block text-sm font-medium mb-1">Category</label>
+              <Select value={formData.category} onValueChange={(v) => updateField('category', v)}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {CATEGORIES.map((cat) => (
+                    <SelectItem key={cat.value} value={cat.value}>
+                      {cat.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Subcategory</label>
+              <Input
+                value={formData.subcategory}
+                onChange={(e) => updateField('subcategory', e.target.value)}
+                placeholder="face-negative"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Unicode Version</label>
+              <Input
+                value={formData.unicodeVersion}
+                onChange={(e) => updateField('unicodeVersion', e.target.value)}
+                placeholder="15.0"
+                required
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1">Short Name</label>
+            <Input
+              value={formData.shortName}
+              onChange={(e) => updateField('shortName', e.target.value)}
+              placeholder="skull"
+              required
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Meanings */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Meanings</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium mb-1">Base Meaning</label>
+            <Input
+              value={formData.baseMeaning}
+              onChange={(e) => updateField('baseMeaning', e.target.value)}
+              placeholder="A human skull..."
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">TL;DR</label>
+            <Input
+              value={formData.tldr}
+              onChange={(e) => updateField('tldr', e.target.value)}
+              placeholder="Quick summary of real-world usage..."
+              required
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Context Meanings */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle>Context Meanings</CardTitle>
+            <Button type="button" variant="outline" size="sm" onClick={addContextMeaning}>
+              + Add Context
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {(formData.contextMeanings ?? []).map((ctx, index) => (
+            <div
+              key={index}
+              className="flex flex-col gap-2 rounded-lg border border-gray-200/50 dark:border-gray-700/50 p-4"
+            >
+              <div className="flex items-center gap-2">
+                <select
+                  value={ctx.context}
+                  onChange={(e) => updateContextMeaning(index, 'context', e.target.value)}
+                  className="rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+                >
+                  {CONTEXT_TYPES.map((type) => (
+                    <option key={type} value={type}>
+                      {type}
+                    </option>
+                  ))}
+                </select>
+                <select
+                  value={ctx.riskLevel}
+                  onChange={(e) => updateContextMeaning(index, 'riskLevel', e.target.value)}
+                  className="rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+                >
+                  {RISK_LEVELS.map((level) => (
+                    <option key={level} value={level}>
+                      {level}
+                    </option>
+                  ))}
+                </select>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => removeContextMeaning(index)}
+                  className="text-red-500"
+                >
+                  Remove
+                </Button>
+              </div>
+              <Input
+                value={ctx.meaning}
+                onChange={(e) => updateContextMeaning(index, 'meaning', e.target.value)}
+                placeholder="Meaning in this context..."
+              />
+              <Input
+                value={ctx.example}
+                onChange={(e) => updateContextMeaning(index, 'example', e.target.value)}
+                placeholder="Example usage..."
+              />
+            </div>
+          ))}
+          {(formData.contextMeanings ?? []).length === 0 && (
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              No context meanings yet. Click &quot;Add Context&quot; to add one.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Platform Notes */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle>Platform Notes</CardTitle>
+            <Button type="button" variant="outline" size="sm" onClick={addPlatformNote}>
+              + Add Note
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {(formData.platformNotes ?? []).map((note, index) => (
+            <div
+              key={index}
+              className="flex items-center gap-2 rounded-lg border border-gray-200/50 dark:border-gray-700/50 p-4"
+            >
+              <select
+                value={note.platform}
+                onChange={(e) => updatePlatformNote(index, 'platform', e.target.value)}
+                className="rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+              >
+                {PLATFORMS.map((platform) => (
+                  <option key={platform} value={platform}>
+                    {platform}
+                  </option>
+                ))}
+              </select>
+              <Input
+                value={note.note}
+                onChange={(e) => updatePlatformNote(index, 'note', e.target.value)}
+                placeholder="Platform-specific note..."
+                className="flex-1"
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => removePlatformNote(index)}
+                className="text-red-500"
+              >
+                Remove
+              </Button>
+            </div>
+          ))}
+          {(formData.platformNotes ?? []).length === 0 && (
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              No platform notes yet. Click &quot;Add Note&quot; to add one.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Generational Notes */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle>Generational Notes</CardTitle>
+            <Button type="button" variant="outline" size="sm" onClick={addGenerationalNote}>
+              + Add Note
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {(formData.generationalNotes ?? []).map((note, index) => (
+            <div
+              key={index}
+              className="flex items-center gap-2 rounded-lg border border-gray-200/50 dark:border-gray-700/50 p-4"
+            >
+              <select
+                value={note.generation}
+                onChange={(e) => updateGenerationalNote(index, 'generation', e.target.value)}
+                className="rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+              >
+                {GENERATIONS.map((gen) => (
+                  <option key={gen} value={gen}>
+                    {gen}
+                  </option>
+                ))}
+              </select>
+              <Input
+                value={note.note}
+                onChange={(e) => updateGenerationalNote(index, 'note', e.target.value)}
+                placeholder="Generational note..."
+                className="flex-1"
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => removeGenerationalNote(index)}
+                className="text-red-500"
+              >
+                Remove
+              </Button>
+            </div>
+          ))}
+          {(formData.generationalNotes ?? []).length === 0 && (
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              No generational notes yet. Click &quot;Add Note&quot; to add one.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Warnings */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle>Warnings</CardTitle>
+            <Button type="button" variant="outline" size="sm" onClick={addWarning}>
+              + Add Warning
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {(formData.warnings ?? []).map((warning, index) => (
+            <div
+              key={index}
+              className="flex flex-col gap-2 rounded-lg border border-gray-200/50 dark:border-gray-700/50 p-4"
+            >
+              <div className="flex items-center gap-2">
+                <Input
+                  value={warning.title}
+                  onChange={(e) => updateWarning(index, 'title', e.target.value)}
+                  placeholder="Warning title..."
+                  className="flex-1"
+                />
+                <select
+                  value={warning.severity}
+                  onChange={(e) => updateWarning(index, 'severity', e.target.value)}
+                  className="rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+                >
+                  {RISK_LEVELS.map((level) => (
+                    <option key={level} value={level}>
+                      {level}
+                    </option>
+                  ))}
+                </select>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => removeWarning(index)}
+                  className="text-red-500"
+                >
+                  Remove
+                </Button>
+              </div>
+              <Input
+                value={warning.description}
+                onChange={(e) => updateWarning(index, 'description', e.target.value)}
+                placeholder="Warning description..."
+              />
+            </div>
+          ))}
+          {(formData.warnings ?? []).length === 0 && (
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              No warnings yet. Click &quot;Add Warning&quot; to add one.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* SEO */}
+      <Card>
+        <CardHeader>
+          <CardTitle>SEO</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium mb-1">SEO Title</label>
+            <Input
+              value={formData.seoTitle}
+              onChange={(e) => updateField('seoTitle', e.target.value)}
+              placeholder="💀 Skull Emoji Meaning - What Does 💀 Really Mean?"
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">SEO Description</label>
+            <Input
+              value={formData.seoDescription}
+              onChange={(e) => updateField('seoDescription', e.target.value)}
+              placeholder="Learn what the skull emoji 💀 really means..."
+              required
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Submit */}
+      <div className="flex items-center gap-4">
+        <Button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? 'Saving...' : emoji ? 'Update Emoji' : 'Create Emoji'}
+        </Button>
+        <Button type="button" variant="outline" onClick={() => router.push('/admin/emojis')}>
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/admin/admin-emoji-list.tsx
+++ b/src/components/admin/admin-emoji-list.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import type { Emoji } from '@/types/emoji';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+interface AdminEmojiListProps {
+  emojis: Emoji[];
+}
+
+export function AdminEmojiList({ emojis }: AdminEmojiListProps) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedEmoji, setSelectedEmoji] = useState<Emoji | null>(null);
+
+  const filteredEmojis = emojis.filter((emoji) => {
+    const query = searchQuery.toLowerCase();
+    return (
+      emoji.name.toLowerCase().includes(query) ||
+      emoji.character.includes(query) ||
+      emoji.slug.toLowerCase().includes(query)
+    );
+  });
+
+  return (
+    <div className="space-y-4">
+      <Input
+        type="search"
+        placeholder="Search emojis by name, character, or slug..."
+        value={searchQuery}
+        onChange={(e) => setSearchQuery(e.target.value)}
+        className="max-w-md"
+      />
+
+      <div className="rounded-lg border border-gray-200/50 dark:border-gray-700/50">
+        <table className="w-full">
+          <thead className="bg-gray-50 dark:bg-gray-800/50">
+            <tr>
+              <th className="px-4 py-3 text-left text-sm font-medium text-gray-500 dark:text-gray-400">
+                Emoji
+              </th>
+              <th className="px-4 py-3 text-left text-sm font-medium text-gray-500 dark:text-gray-400">
+                Name
+              </th>
+              <th className="px-4 py-3 text-left text-sm font-medium text-gray-500 dark:text-gray-400">
+                Category
+              </th>
+              <th className="px-4 py-3 text-left text-sm font-medium text-gray-500 dark:text-gray-400">
+                Slug
+              </th>
+              <th className="px-4 py-3 text-left text-sm font-medium text-gray-500 dark:text-gray-400">
+                Context Meanings
+              </th>
+              <th className="px-4 py-3 text-right text-sm font-medium text-gray-500 dark:text-gray-400">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200/50 dark:divide-gray-700/50">
+            {filteredEmojis.map((emoji) => (
+              <tr
+                key={emoji.slug}
+                className="hover:bg-gray-50 dark:hover:bg-gray-800/50 cursor-pointer"
+                onClick={() => setSelectedEmoji(emoji)}
+              >
+                <td className="px-4 py-3">
+                  <span className="text-2xl">{emoji.character}</span>
+                </td>
+                <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-white">
+                  {emoji.name}
+                </td>
+                <td className="px-4 py-3">
+                  <Badge variant="secondary">{emoji.category}</Badge>
+                </td>
+                <td className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{emoji.slug}</td>
+                <td className="px-4 py-3">
+                  <Badge variant="outline">{emoji.contextMeanings.length} contexts</Badge>
+                </td>
+                <td className="px-4 py-3 text-right">
+                  <div className="flex items-center justify-end gap-2">
+                    <Link
+                      href={`/admin/emojis/${emoji.slug}`}
+                      className="rounded-md px-3 py-1 text-sm text-amber-600 hover:bg-amber-50 dark:text-amber-400 dark:hover:bg-amber-900/20"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      Edit
+                    </Link>
+                    <Link
+                      href={`/emoji/${emoji.slug}`}
+                      target="_blank"
+                      className="rounded-md px-3 py-1 text-sm text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      View
+                    </Link>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        {filteredEmojis.length === 0 && (
+          <div className="py-12 text-center text-gray-500 dark:text-gray-400">
+            No emojis found matching your search.
+          </div>
+        )}
+      </div>
+
+      {/* Emoji Detail Dialog */}
+      <Dialog open={!!selectedEmoji} onOpenChange={() => setSelectedEmoji(null)}>
+        <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-3">
+              <span className="text-4xl">{selectedEmoji?.character}</span>
+              <span>{selectedEmoji?.name}</span>
+            </DialogTitle>
+            <DialogDescription>Emoji details and preview</DialogDescription>
+          </DialogHeader>
+          {selectedEmoji && (
+            <div className="space-y-4">
+              <div className="grid grid-cols-2 gap-4 text-sm">
+                <div>
+                  <span className="font-medium text-gray-500 dark:text-gray-400">Slug:</span>
+                  <span className="ml-2 text-gray-900 dark:text-white">{selectedEmoji.slug}</span>
+                </div>
+                <div>
+                  <span className="font-medium text-gray-500 dark:text-gray-400">Category:</span>
+                  <Badge variant="secondary" className="ml-2">
+                    {selectedEmoji.category}
+                  </Badge>
+                </div>
+                <div>
+                  <span className="font-medium text-gray-500 dark:text-gray-400">Unicode:</span>
+                  <span className="ml-2 text-gray-900 dark:text-white">
+                    {selectedEmoji.unicode}
+                  </span>
+                </div>
+                <div>
+                  <span className="font-medium text-gray-500 dark:text-gray-400">Version:</span>
+                  <span className="ml-2 text-gray-900 dark:text-white">
+                    {selectedEmoji.unicodeVersion}
+                  </span>
+                </div>
+              </div>
+
+              <div>
+                <h4 className="font-medium text-gray-900 dark:text-white mb-2">Base Meaning</h4>
+                <p className="text-gray-600 dark:text-gray-300">{selectedEmoji.baseMeaning}</p>
+              </div>
+
+              <div>
+                <h4 className="font-medium text-gray-900 dark:text-white mb-2">TL;DR</h4>
+                <p className="text-gray-600 dark:text-gray-300">{selectedEmoji.tldr}</p>
+              </div>
+
+              <div>
+                <h4 className="font-medium text-gray-900 dark:text-white mb-2">
+                  Context Meanings ({selectedEmoji.contextMeanings.length})
+                </h4>
+                <div className="space-y-2">
+                  {selectedEmoji.contextMeanings.map((ctx, idx) => (
+                    <div
+                      key={idx}
+                      className="rounded-lg border border-gray-200/50 dark:border-gray-700/50 p-3"
+                    >
+                      <div className="flex items-center gap-2 mb-1">
+                        <Badge
+                          variant={
+                            ctx.riskLevel === 'HIGH'
+                              ? 'destructive'
+                              : ctx.riskLevel === 'MEDIUM'
+                                ? 'warning'
+                                : 'success'
+                          }
+                        >
+                          {ctx.context}
+                        </Badge>
+                        <span className="text-sm text-gray-500 dark:text-gray-400">
+                          Risk: {ctx.riskLevel}
+                        </span>
+                      </div>
+                      <p className="text-sm text-gray-600 dark:text-gray-300">{ctx.meaning}</p>
+                      {ctx.example && (
+                        <p className="mt-1 text-sm italic text-gray-500 dark:text-gray-400">
+                          Example: {ctx.example}
+                        </p>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -2,7 +2,7 @@
 
 import * as ToastPrimitive from '@radix-ui/react-toast';
 import { cn } from '@/lib/utils';
-import { forwardRef, ComponentPropsWithoutRef, ElementRef } from 'react';
+import { forwardRef, ComponentPropsWithoutRef, ElementRef, useState } from 'react';
 
 const ToastProvider = ToastPrimitive.Provider;
 
@@ -111,6 +111,69 @@ const ToastDescription = forwardRef<
 ToastDescription.displayName = ToastPrimitive.Description.displayName;
 
 type ToastActionElement = React.ReactElement<typeof ToastAction>;
+
+// Toast hook for triggering toasts
+type ToastData = {
+  id: string;
+  title: string;
+  description?: string;
+  variant?: 'default' | 'destructive' | 'success';
+};
+
+let toastListeners: ((toast: ToastData) => void)[] = [];
+
+export function toast({
+  title,
+  description,
+  variant = 'default',
+}: {
+  title: string;
+  description?: string;
+  variant?: 'default' | 'destructive' | 'success';
+}) {
+  const id = Math.random().toString(36).slice(2);
+  toastListeners.forEach((listener) => listener({ id, title, description, variant }));
+}
+
+export function useToast() {
+  const [toasts, setToasts] = useState<ToastData[]>([]);
+
+  // Register listener
+  useState(() => {
+    const addToast = (newToast: ToastData) => {
+      setToasts((prev) => [...prev, newToast]);
+      setTimeout(() => {
+        setToasts((prev) => prev.filter((t) => t.id !== newToast.id));
+      }, 5000);
+    };
+    toastListeners.push(addToast);
+    return () => {
+      toastListeners = toastListeners.filter((l) => l !== addToast);
+    };
+  });
+
+  return { toasts };
+}
+
+// Toaster component - wrap your app with this
+export function Toaster() {
+  const { toasts } = useToast();
+
+  return (
+    <ToastProvider>
+      {toasts.map((t) => (
+        <Toast key={t.id} variant={t.variant}>
+          <div className="flex-1">
+            <ToastTitle>{t.title}</ToastTitle>
+            {t.description && <ToastDescription>{t.description}</ToastDescription>}
+          </div>
+          <ToastClose />
+        </Toast>
+      ))}
+      <ToastViewport />
+    </ToastProvider>
+  );
+}
 
 export {
   type ToastActionElement,

--- a/src/components/ui/use-toast.ts
+++ b/src/components/ui/use-toast.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+
+export type ToastVariant = 'default' | 'destructive' | 'success';
+
+export interface Toast {
+  id: string;
+  title: string;
+  description?: string;
+  variant?: ToastVariant;
+}
+
+let toastListeners: ((toast: Toast) => void)[] = [];
+
+export function toast({ title, description, variant = 'default' }: Omit<Toast, 'id'>) {
+  const id = Math.random().toString(36).slice(2);
+  const newToast = { id, title, description, variant };
+  toastListeners.forEach((listener) => listener(newToast));
+}
+
+export function useToast() {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const addToast = useCallback((toast: Toast) => {
+    setToasts((prev) => [...prev, toast]);
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== toast.id));
+    }, 5000);
+  }, []);
+
+  // Register listener
+  useState(() => {
+    toastListeners.push(addToast);
+    return () => {
+      toastListeners = toastListeners.filter((l) => l !== addToast);
+    };
+  });
+
+  return {
+    toasts,
+    toast: (props: Omit<Toast, 'id'>) =>
+      addToast({ id: Math.random().toString(36).slice(2), ...props }),
+  };
+}

--- a/tests/unit/app/api/webhooks/stripe/route.test.ts
+++ b/tests/unit/app/api/webhooks/stripe/route.test.ts
@@ -470,5 +470,257 @@ describe('Stripe webhook handler', () => {
       const response = await POST(request);
       expect(response.status).toBe(200);
     });
+
+    it('should handle customer.subscription.updated with canceled status', async () => {
+      mockGetEnv.mockReturnValue({
+        appUrl: 'http://localhost:3000',
+        stripeSecretKey: 'sk_test_123',
+        stripeWebhookSecret: 'wh_secret_test',
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const updateMock: any = mock(() => ({
+        set: mock(() => ({ where: mock(() => Promise.resolve({})) })),
+      }));
+      const limitMock = mock(() => Promise.resolve([{ id: 'sub-123', userId: 'user-456' }]));
+      const whereMock = mock(() => ({ limit: limitMock }));
+      const fromMock = mock(() => ({ where: whereMock }));
+      const selectMock = mock(() => ({ from: fromMock }));
+
+      const mockDb = {
+        select: selectMock,
+        update: updateMock,
+      };
+      mockGetDb.mockReturnValue(mockDb);
+
+      const mockEvent = {
+        type: 'customer.subscription.updated',
+        data: {
+          object: {
+            id: 'sub_test123',
+            status: 'canceled',
+            current_period_end: Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60,
+            trial_end: null,
+          },
+        },
+      };
+
+      mockStripeInstance.webhooks.constructEvent.mockReturnValue(mockEvent);
+
+      const request = new Request('http://localhost/api/webhooks/stripe', {
+        method: 'POST',
+        headers: {
+          'stripe-signature': 'sig_test',
+        },
+        body: JSON.stringify(mockEvent),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+    });
+
+    it('should handle customer.subscription.updated with past_due status', async () => {
+      mockGetEnv.mockReturnValue({
+        appUrl: 'http://localhost:3000',
+        stripeSecretKey: 'sk_test_123',
+        stripeWebhookSecret: 'wh_secret_test',
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const updateMock: any = mock(() => ({
+        set: mock(() => ({ where: mock(() => Promise.resolve({})) })),
+      }));
+      const limitMock = mock(() => Promise.resolve([{ id: 'sub-123', userId: 'user-456' }]));
+      const whereMock = mock(() => ({ limit: limitMock }));
+      const fromMock = mock(() => ({ where: whereMock }));
+      const selectMock = mock(() => ({ from: fromMock }));
+
+      const mockDb = {
+        select: selectMock,
+        update: updateMock,
+      };
+      mockGetDb.mockReturnValue(mockDb);
+
+      const mockEvent = {
+        type: 'customer.subscription.updated',
+        data: {
+          object: {
+            id: 'sub_test123',
+            status: 'past_due',
+            current_period_end: Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60,
+            trial_end: null,
+          },
+        },
+      };
+
+      mockStripeInstance.webhooks.constructEvent.mockReturnValue(mockEvent);
+
+      const request = new Request('http://localhost/api/webhooks/stripe', {
+        method: 'POST',
+        headers: {
+          'stripe-signature': 'sig_test',
+        },
+        body: JSON.stringify(mockEvent),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+    });
+
+    it('should handle checkout.session.completed when db is not configured', async () => {
+      mockGetEnv.mockReturnValue({
+        appUrl: 'http://localhost:3000',
+        stripeSecretKey: 'sk_test_123',
+        stripeWebhookSecret: 'wh_secret_test',
+      });
+
+      mockStripeInstance.subscriptions.retrieve.mockResolvedValue({
+        trial_end: Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60,
+        current_period_end: Math.floor(Date.now() / 1000) + 37 * 24 * 60 * 60,
+      });
+
+      // Return null for db to exercise the early return
+      mockGetDb.mockReturnValue(null);
+
+      const mockEvent = {
+        type: 'checkout.session.completed',
+        data: {
+          object: {
+            mode: 'subscription',
+            metadata: { userId: 'user-123' },
+            subscription: 'sub_test123',
+            customer: 'cus_test123',
+          },
+        },
+      };
+
+      mockStripeInstance.webhooks.constructEvent.mockReturnValue(mockEvent);
+
+      const request = new Request('http://localhost/api/webhooks/stripe', {
+        method: 'POST',
+        headers: {
+          'stripe-signature': 'sig_test',
+        },
+        body: JSON.stringify(mockEvent),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+    });
+
+    it('should handle customer.subscription.updated when no subscription found in db', async () => {
+      mockGetEnv.mockReturnValue({
+        appUrl: 'http://localhost:3000',
+        stripeSecretKey: 'sk_test_123',
+        stripeWebhookSecret: 'wh_secret_test',
+      });
+
+      mockStripeInstance.subscriptions.retrieve.mockResolvedValue({
+        id: 'sub_test123',
+        status: 'active',
+      });
+
+      // Return empty array to simulate no subscription found
+      const limitMock = mock(() => Promise.resolve([]));
+      const whereMock = mock(() => ({ limit: limitMock }));
+      const fromMock = mock(() => ({ where: whereMock }));
+      const selectMock = mock(() => ({ from: fromMock }));
+
+      const mockDb = {
+        select: selectMock,
+      };
+      mockGetDb.mockReturnValue(mockDb);
+
+      const mockEvent = {
+        type: 'customer.subscription.updated',
+        data: {
+          object: {
+            id: 'sub_test123',
+            status: 'active',
+            current_period_end: Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60,
+            trial_end: null,
+          },
+        },
+      };
+
+      mockStripeInstance.webhooks.constructEvent.mockReturnValue(mockEvent);
+
+      const request = new Request('http://localhost/api/webhooks/stripe', {
+        method: 'POST',
+        headers: {
+          'stripe-signature': 'sig_test',
+        },
+        body: JSON.stringify(mockEvent),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+    });
+
+    it('should handle customer.subscription.deleted when db is not configured', async () => {
+      mockGetEnv.mockReturnValue({
+        appUrl: 'http://localhost:3000',
+        stripeSecretKey: 'sk_test_123',
+        stripeWebhookSecret: 'wh_secret_test',
+      });
+
+      // Return null for db to exercise the early return
+      mockGetDb.mockReturnValue(null);
+
+      const mockEvent = {
+        type: 'customer.subscription.deleted',
+        data: {
+          object: {
+            id: 'sub_test123',
+          },
+        },
+      };
+
+      mockStripeInstance.webhooks.constructEvent.mockReturnValue(mockEvent);
+
+      const request = new Request('http://localhost/api/webhooks/stripe', {
+        method: 'POST',
+        headers: {
+          'stripe-signature': 'sig_test',
+        },
+        body: JSON.stringify(mockEvent),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+    });
+
+    it('should handle invoice.payment_failed when db is not configured', async () => {
+      mockGetEnv.mockReturnValue({
+        appUrl: 'http://localhost:3000',
+        stripeSecretKey: 'sk_test_123',
+        stripeWebhookSecret: 'wh_secret_test',
+      });
+
+      // Return null for db to exercise the early return
+      mockGetDb.mockReturnValue(null);
+
+      const mockEvent = {
+        type: 'invoice.payment_failed',
+        data: {
+          object: {
+            subscription: 'sub_test123',
+          },
+        },
+      };
+
+      mockStripeInstance.webhooks.constructEvent.mockReturnValue(mockEvent);
+
+      const request = new Request('http://localhost/api/webhooks/stripe', {
+        method: 'POST',
+        headers: {
+          'stripe-signature': 'sig_test',
+        },
+        body: JSON.stringify(mockEvent),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+    });
   });
 });

--- a/tests/unit/app/combo/[slug]/page.test.tsx
+++ b/tests/unit/app/combo/[slug]/page.test.tsx
@@ -18,6 +18,40 @@ mock.module('@/lib/combo-data', () => ({
   getRelatedCombos: mockGetRelatedCombos,
 }));
 
+// Mock env to ensure appName is available
+const mockGetEnv = mock(() => ({
+  appUrl: 'http://localhost:3000',
+  appName: 'KnowYourEmoji',
+  openrouterApiKey: undefined,
+  openrouterModel: 'liquid/lfm2-8b-a1b',
+  enableInterpreter: true,
+  sentryDsn: undefined,
+  sentryDsnPublic: undefined,
+  gaMeasurementId: undefined,
+  posthogKey: undefined,
+  posthogHost: undefined,
+  upstashRedisRestUrl: undefined,
+  upstashRedisRestToken: undefined,
+  authSecret: 'test-secret',
+  googleClientId: undefined,
+  googleClientSecret: undefined,
+  githubClientId: undefined,
+  githubClientSecret: undefined,
+  resendApiKey: undefined,
+  resendFromEmail: undefined,
+  slackBotToken: undefined,
+  slackLogChannelId: undefined,
+  stripeSecretKey: undefined,
+  stripePublishableKey: 'pk_test',
+  stripeWebhookSecret: undefined,
+  stripeProPriceId: undefined,
+  databaseUrl: undefined,
+}));
+
+mock.module('@/lib/env', () => ({
+  getEnv: mockGetEnv,
+}));
+
 // Mock the emoji-data module for emoji lookup
 const mockEmojiData: Record<string, { character: string; name: string }> = {
   skull: { character: '💀', name: 'Skull' },
@@ -82,6 +116,35 @@ describe('ComboPage', () => {
     mockGetAllComboSlugs.mockReset();
     mockGetRelatedCombos.mockReset();
     mockNotFound.mockReset();
+    mockGetEnv.mockReset();
+    mockGetEnv.mockImplementation(() => ({
+      appUrl: 'http://localhost:3000',
+      appName: 'KnowYourEmoji',
+      openrouterApiKey: undefined,
+      openrouterModel: 'liquid/lfm2-8b-a1b',
+      enableInterpreter: true,
+      sentryDsn: undefined,
+      sentryDsnPublic: undefined,
+      gaMeasurementId: undefined,
+      posthogKey: undefined,
+      posthogHost: undefined,
+      upstashRedisRestUrl: undefined,
+      upstashRedisRestToken: undefined,
+      authSecret: 'test-secret',
+      googleClientId: undefined,
+      googleClientSecret: undefined,
+      githubClientId: undefined,
+      githubClientSecret: undefined,
+      resendApiKey: undefined,
+      resendFromEmail: undefined,
+      slackBotToken: undefined,
+      slackLogChannelId: undefined,
+      stripeSecretKey: undefined,
+      stripePublishableKey: 'pk_test',
+      stripeWebhookSecret: undefined,
+      stripeProPriceId: undefined,
+      databaseUrl: undefined,
+    }));
     mockGetAllComboSlugs.mockImplementation(() => ['skull-laughing', 'fire-100']);
   });
 

--- a/tests/unit/components/auth/login-form.test.tsx
+++ b/tests/unit/components/auth/login-form.test.tsx
@@ -255,6 +255,26 @@ describe('LoginForm', () => {
         expect(screen.getByRole('button', { name: /^sign in$/i })).toBeInTheDocument();
       });
     });
+
+    it('does not send magic link with invalid email', async () => {
+      mockFetch.mockClear();
+      render(<LoginForm />);
+      fireEvent.click(screen.getByRole('button', { name: /sign in with magic link instead/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /send magic link/i })).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByLabelText(/email/i), {
+        target: { value: 'not-an-email' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /send magic link/i }));
+
+      // fetch should not be called with invalid email
+      await waitFor(() => {
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('OAuth sign in', () => {
@@ -273,6 +293,16 @@ describe('LoginForm', () => {
 
       await waitFor(() => {
         expect(mockSignIn).toHaveBeenCalledWith('github', { callbackUrl: '/dashboard' });
+      });
+    });
+
+    it('shows error when OAuth sign in throws', async () => {
+      mockSignIn.mockImplementation(() => Promise.reject(new Error('OAuth error')));
+      render(<LoginForm />);
+      fireEvent.click(screen.getByRole('button', { name: /continue with google/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/failed to sign in with provider/i)).toBeInTheDocument();
       });
     });
   });

--- a/tests/unit/components/ui/toast.test.tsx
+++ b/tests/unit/components/ui/toast.test.tsx
@@ -8,6 +8,9 @@ import {
   ToastDescription,
   ToastAction,
   ToastClose,
+  toast,
+  useToast,
+  Toaster,
 } from '@/components/ui/toast';
 
 afterEach(() => {
@@ -249,5 +252,47 @@ describe('ToastClose', () => {
       expect(close).toHaveClass('right-2');
       expect(close).toHaveClass('top-2');
     });
+  });
+});
+
+// Test the toast function and useToast hook
+describe('toast function', () => {
+  it('creates a toast with title only', () => {
+    // The toast function adds a listener and calls it
+    // We test that it doesn't throw
+    expect(() => {
+      toast({ title: 'Test toast' });
+    }).not.toThrow();
+  });
+
+  it('creates a toast with title and description', () => {
+    expect(() => {
+      toast({ title: 'Test', description: 'Description' });
+    }).not.toThrow();
+  });
+
+  it('creates a toast with variant', () => {
+    expect(() => {
+      toast({ title: 'Test', variant: 'destructive' });
+    }).not.toThrow();
+  });
+
+  it('creates a toast with success variant', () => {
+    expect(() => {
+      toast({ title: 'Success', variant: 'success' });
+    }).not.toThrow();
+  });
+});
+
+// Test the Toaster component
+describe('Toaster', () => {
+  it('renders Toaster component without crashing', () => {
+    expect(() => {
+      render(
+        <ToastProvider>
+          <Toaster />
+        </ToastProvider>
+      );
+    }).not.toThrow();
   });
 });

--- a/tests/unit/components/ui/toast.test.tsx
+++ b/tests/unit/components/ui/toast.test.tsx
@@ -295,4 +295,109 @@ describe('Toaster', () => {
       );
     }).not.toThrow();
   });
+
+  it('renders Toaster with toasts', async () => {
+    render(
+      <ToastProvider>
+        <Toaster />
+      </ToastProvider>
+    );
+
+    // Trigger a toast
+    toast({ title: 'Test Toast', description: 'Test Description' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Toast')).toBeInTheDocument();
+      expect(screen.getByText('Test Description')).toBeInTheDocument();
+    });
+  });
+
+  it('renders Toaster with destructive variant toast', async () => {
+    render(
+      <ToastProvider>
+        <Toaster />
+      </ToastProvider>
+    );
+
+    toast({ title: 'Error Toast', variant: 'destructive' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Error Toast')).toBeInTheDocument();
+    });
+  });
+
+  it('renders Toaster with success variant toast', async () => {
+    render(
+      <ToastProvider>
+        <Toaster />
+      </ToastProvider>
+    );
+
+    toast({ title: 'Success Toast', variant: 'success' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Success Toast')).toBeInTheDocument();
+    });
+  });
+
+  it('renders multiple toasts via Toaster', async () => {
+    render(
+      <ToastProvider>
+        <Toaster />
+      </ToastProvider>
+    );
+
+    toast({ title: 'First Toast' });
+    toast({ title: 'Second Toast' });
+
+    await waitFor(() => {
+      expect(screen.getByText('First Toast')).toBeInTheDocument();
+      expect(screen.getByText('Second Toast')).toBeInTheDocument();
+    });
+  });
+});
+
+// Test useToast hook directly
+describe('useToast hook', () => {
+  // Create a test component that uses useToast
+  function TestComponent({ onToasts }: { onToasts?: (toasts: unknown[]) => void }) {
+    const { toasts } = useToast();
+    if (onToasts) {
+      onToasts(toasts);
+    }
+    return (
+      <div>
+        {toasts.map((t) => (
+          <div key={t.id}>{t.title}</div>
+        ))}
+      </div>
+    );
+  }
+
+  it('useToast returns empty toasts initially', async () => {
+    let capturedToasts: unknown[] = [];
+    render(
+      <ToastProvider>
+        <TestComponent onToasts={(t) => (capturedToasts = t)} />
+      </ToastProvider>
+    );
+
+    expect(capturedToasts).toHaveLength(0);
+  });
+
+  it('useToast receives toasts after toast() is called', async () => {
+    let capturedToasts: unknown[] = [];
+    render(
+      <ToastProvider>
+        <TestComponent onToasts={(t) => (capturedToasts = t)} />
+      </ToastProvider>
+    );
+
+    toast({ title: 'Hook Test' });
+
+    await waitFor(() => {
+      expect(capturedToasts).toHaveLength(1);
+      expect(capturedToasts[0]).toHaveProperty('title', 'Hook Test');
+    });
+  });
 });

--- a/tests/unit/lib/response-tones.test.ts
+++ b/tests/unit/lib/response-tones.test.ts
@@ -311,6 +311,28 @@ describe('response-tones', () => {
       const reasoning = generateToneReasoning('CLARIFYING', lowConfMetrics);
       expect(reasoning.toLowerCase()).toContain('ambiguity');
     });
+
+    it('should generate context-specific reasoning for NEUTRAL with passive-aggression > 30', () => {
+      const paMetrics: InterpretationMetrics = {
+        ...baseMetrics,
+        passiveAggressionProbability: 35,
+        overallTone: 'neutral',
+      };
+
+      const reasoning = generateToneReasoning('NEUTRAL', paMetrics);
+      expect(reasoning.toLowerCase()).toContain('neutrality');
+    });
+
+    it('should generate context-specific reasoning for MATCHING with negative tone', () => {
+      const negativeMetrics: InterpretationMetrics = {
+        ...baseMetrics,
+        overallTone: 'negative',
+      };
+
+      const reasoning = generateToneReasoning('MATCHING', negativeMetrics);
+      expect(typeof reasoning).toBe('string');
+      expect(reasoning.length).toBeGreaterThan(0);
+    });
   });
 
   describe('generateToneExamples', () => {


### PR DESCRIPTION
## Summary
- Add emoji admin interface for content editors (CRUD UI)
- Admin layout uses existing DashboardSidebar component
- Emoji list page with search, table view, and detail dialog
- Emoji create/edit form with all fields (basic info, meanings, context meanings, platform notes, generational notes, warnings, SEO)
- REST API endpoints at `/api/admin/emojis` for CRUD operations
- Toast notification system with `toast()` function and `Toaster` component

## Test plan
- [ ] Navigate to `/admin/emojis` to view emoji list
- [ ] Click emoji row to view details in dialog
- [ ] Click "New Emoji" to create a new emoji
- [ ] Click "Edit" to edit existing emoji
- [ ] Test API endpoints with POST/PUT/DELETE operations
- [ ] Verify toast notifications appear on save

🤖 Generated with [Claude Code](https://claude.com/claude-code)