### PR TITLE
feat: build checkout redirect flow (PAY-005)

### DIFF
--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -180,9 +180,7 @@ export default function PricingPage() {
                     <span className="text-gray-600 dark:text-gray-300">No ads</span>
                   </li>
                 </ul>
-                <CheckoutButton className="w-full">
-                  Start 7-Day Free Trial
-                </CheckoutButton>
+                <CheckoutButton className="w-full">Start 7-Day Free Trial</CheckoutButton>
               </CardContent>
             </Card>
           </div>

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -4,6 +4,7 @@ import { Breadcrumbs } from '@/components/layout/breadcrumbs';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { CheckoutButton } from '@/components/checkout';
 import { getEnv } from '@/lib/env';
 
 const pageTitle = 'Pricing';
@@ -142,7 +143,7 @@ export default function PricingPage() {
             {/* Pro Tier */}
             <Card className="relative border-amber-500 dark:border-amber-400">
               <div className="absolute -top-3 left-1/2 -translate-x-1/2">
-                <Badge variant="warning">Coming Soon</Badge>
+                <Badge variant="warning">Most Popular</Badge>
               </div>
               <CardHeader>
                 <CardTitle className="text-2xl">Pro</CardTitle>
@@ -179,9 +180,9 @@ export default function PricingPage() {
                     <span className="text-gray-600 dark:text-gray-300">No ads</span>
                   </li>
                 </ul>
-                <Button className="w-full" disabled>
-                  Coming in Phase 2
-                </Button>
+                <CheckoutButton className="w-full">
+                  Start 7-Day Free Trial
+                </CheckoutButton>
               </CardContent>
             </Card>
           </div>

--- a/src/components/checkout/checkout-button.tsx
+++ b/src/components/checkout/checkout-button.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useState } from 'react';
+import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
+import { Button, type ButtonProps } from '@/components/ui/button';
+
+type CheckoutButtonProps = Omit<ButtonProps, 'onClick' | 'loading' | 'disabled'>;
+
+function CheckoutButton({ children, ...props }: CheckoutButtonProps) {
+  const { status } = useSession();
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleCheckout = async () => {
+    if (status !== 'authenticated') {
+      router.push('/login?callbackUrl=/pricing');
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/checkout', {
+        method: 'POST',
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        setError(data.error || 'Failed to start checkout');
+        return;
+      }
+
+      if (!data.url) {
+        setError('No checkout URL returned');
+        return;
+      }
+
+      window.location.href = data.url;
+    } catch {
+      setError('Failed to start checkout');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div>
+      <Button
+        onClick={handleCheckout}
+        loading={isLoading}
+        disabled={isLoading}
+        {...props}
+      >
+        {children ?? 'Start Free Trial'}
+      </Button>
+      {error && (
+        <p className="mt-2 text-sm text-red-600 dark:text-red-400" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+CheckoutButton.displayName = 'CheckoutButton';
+
+export { CheckoutButton };

--- a/src/components/checkout/checkout-button.tsx
+++ b/src/components/checkout/checkout-button.tsx
@@ -49,12 +49,7 @@ function CheckoutButton({ children, ...props }: CheckoutButtonProps) {
 
   return (
     <div>
-      <Button
-        onClick={handleCheckout}
-        loading={isLoading}
-        disabled={isLoading}
-        {...props}
-      >
+      <Button onClick={handleCheckout} loading={isLoading} disabled={isLoading} {...props}>
         {children ?? 'Start Free Trial'}
       </Button>
       {error && (

--- a/src/components/checkout/index.ts
+++ b/src/components/checkout/index.ts
@@ -1,0 +1,1 @@
+export { CheckoutButton } from './checkout-button';

--- a/tests/unit/app/pricing.test.ts
+++ b/tests/unit/app/pricing.test.ts
@@ -237,5 +237,19 @@ describe('Pricing Page', () => {
         content.includes('unlimited') || content.includes('priority') || content.includes('pro');
       expect(hasProBenefits).toBe(true);
     });
+
+    test('contains checkout button for pro tier', () => {
+      const result = PricingPage();
+
+      const content = extractContent(result);
+      expect(content).toContain('CheckoutButton');
+    });
+
+    test('contains Most Popular badge for pro tier', () => {
+      const result = PricingPage();
+
+      const content = extractContent(result).toLowerCase();
+      expect(content).toContain('most popular');
+    });
   });
 });

--- a/tests/unit/components/checkout/checkout-button.test.tsx
+++ b/tests/unit/components/checkout/checkout-button.test.tsx
@@ -1,0 +1,229 @@
+import { describe, it, expect, afterEach, mock, beforeEach } from 'bun:test';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+
+const mockPush = mock(() => {});
+const mockUseSession = mock(() => ({
+  data: {
+    user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+  },
+  status: 'authenticated' as const,
+}));
+
+mock.module('next-auth/react', () => ({
+  useSession: mockUseSession,
+}));
+
+mock.module('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+const mockFetch = mock(() =>
+  Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve({ url: 'https://checkout.stripe.com/session_123' }),
+  })
+);
+globalThis.fetch = mockFetch as never;
+
+// Mock window.location
+const originalLocation = window.location;
+const mockLocationAssign = mock(() => {});
+
+const { CheckoutButton } = await import('@/components/checkout/checkout-button');
+
+beforeEach(() => {
+  mockPush.mockClear();
+  mockFetch.mockImplementation(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ url: 'https://checkout.stripe.com/session_123' }),
+    } as never)
+  );
+  mockUseSession.mockReturnValue({
+    data: {
+      user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+    },
+    status: 'authenticated' as const,
+  } as never);
+
+  // Reset location mock
+  Object.defineProperty(window, 'location', {
+    writable: true,
+    value: { ...originalLocation, href: '', assign: mockLocationAssign },
+  });
+  mockLocationAssign.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+  Object.defineProperty(window, 'location', {
+    writable: true,
+    value: originalLocation,
+  });
+});
+
+describe('CheckoutButton', () => {
+  it('renders with default text', () => {
+    render(<CheckoutButton />);
+    expect(screen.getByRole('button', { name: 'Start Free Trial' })).toBeDefined();
+  });
+
+  it('renders with custom children', () => {
+    render(<CheckoutButton>Upgrade Now</CheckoutButton>);
+    expect(screen.getByRole('button', { name: 'Upgrade Now' })).toBeDefined();
+  });
+
+  it('passes extra props to Button', () => {
+    render(<CheckoutButton className="w-full" />);
+    const button = screen.getByRole('button');
+    expect(button.className).toContain('w-full');
+  });
+
+  it('redirects to login when unauthenticated', () => {
+    mockUseSession.mockReturnValue({
+      data: null,
+      status: 'unauthenticated' as const,
+    } as never);
+
+    render(<CheckoutButton />);
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(mockPush).toHaveBeenCalledWith('/login?callbackUrl=/pricing');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('redirects to login when session is loading', () => {
+    mockUseSession.mockReturnValue({
+      data: null,
+      status: 'loading' as const,
+    } as never);
+
+    render(<CheckoutButton />);
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(mockPush).toHaveBeenCalledWith('/login?callbackUrl=/pricing');
+  });
+
+  it('calls POST /api/checkout and redirects to Stripe URL on success', async () => {
+    render(<CheckoutButton />);
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('/api/checkout', { method: 'POST' });
+      expect(window.location.href).toBe('https://checkout.stripe.com/session_123');
+    });
+  });
+
+  it('shows error when API returns error', async () => {
+    mockFetch.mockImplementation(() =>
+      Promise.resolve({
+        ok: false,
+        json: () => Promise.resolve({ error: 'Stripe is not configured' }),
+      } as never)
+    );
+
+    render(<CheckoutButton />);
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeDefined();
+      expect(screen.getByText('Stripe is not configured')).toBeDefined();
+    });
+  });
+
+  it('shows default error when API returns error without message', async () => {
+    mockFetch.mockImplementation(() =>
+      Promise.resolve({
+        ok: false,
+        json: () => Promise.resolve({}),
+      } as never)
+    );
+
+    render(<CheckoutButton />);
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to start checkout')).toBeDefined();
+    });
+  });
+
+  it('shows error when no URL is returned', async () => {
+    mockFetch.mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ url: null }),
+      } as never)
+    );
+
+    render(<CheckoutButton />);
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(screen.getByText('No checkout URL returned')).toBeDefined();
+    });
+  });
+
+  it('shows error when fetch throws', async () => {
+    mockFetch.mockImplementation(() => Promise.reject(new Error('Network error')));
+
+    render(<CheckoutButton />);
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to start checkout')).toBeDefined();
+    });
+  });
+
+  it('disables button while loading', async () => {
+    // Use a promise that we can resolve manually to control timing
+    let resolvePromise: (value: unknown) => void;
+    const pendingPromise = new Promise((resolve) => {
+      resolvePromise = resolve;
+    });
+
+    mockFetch.mockImplementation(() => pendingPromise as never);
+
+    render(<CheckoutButton />);
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button')).toBeDisabled();
+    });
+
+    // Resolve to clean up
+    resolvePromise!({
+      ok: true,
+      json: () => Promise.resolve({ url: 'https://checkout.stripe.com/session_123' }),
+    });
+  });
+
+  it('clears previous error on new checkout attempt', async () => {
+    mockFetch.mockImplementation(() =>
+      Promise.resolve({
+        ok: false,
+        json: () => Promise.resolve({ error: 'First error' }),
+      } as never)
+    );
+
+    render(<CheckoutButton />);
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(screen.getByText('First error')).toBeDefined();
+    });
+
+    // Now make a successful request
+    mockFetch.mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ url: 'https://checkout.stripe.com/session_456' }),
+      } as never)
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('First error')).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `CheckoutButton` client component that calls `POST /api/checkout` and redirects to Stripe Checkout URL
- Update pricing page: replace disabled "Coming in Phase 2" button with live `CheckoutButton`, change badge from "Coming Soon" to "Most Popular"
- Handle loading, error, and unauthenticated states (redirects to `/login?callbackUrl=/pricing`)

## Test plan
- [x] 12 unit tests for `CheckoutButton` component (100% coverage)
- [x] 2 new pricing page tests for checkout button integration and badge update
- [x] All 32 related tests pass
- [x] Lint passes
- [x] Pre-existing typecheck errors only (stripe module types)

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)