### PR TITLE
feat: add programmatic SEO pages

### DIFF
--- a/src/app/combo/category/[category]/page.tsx
+++ b/src/app/combo/category/[category]/page.tsx
@@ -1,0 +1,161 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import {
+  getAllComboCategories,
+  getComboCategoryInfo,
+  getComboSummariesByCategory,
+} from '@/lib/combo-data';
+import { getEnv } from '@/lib/env';
+import { Card, CardContent } from '@/components/ui/card';
+import { Breadcrumbs } from '@/components/layout/breadcrumbs';
+import { BreadcrumbJsonLd } from '@/components/seo/breadcrumb-json-ld';
+import type { Metadata } from 'next';
+
+interface ComboCategoryPageProps {
+  params: Promise<{ category: string }>;
+}
+
+/**
+ * Revalidate pages every hour (3600 seconds)
+ * This enables Incremental Static Regeneration (ISR) for combo category pages
+ */
+export const revalidate = 3600;
+
+/**
+ * Generate static params for all combo category pages at build time
+ */
+export async function generateStaticParams() {
+  const categories = getAllComboCategories();
+  return categories.map((category) => ({ category }));
+}
+
+/**
+ * Generate metadata for the combo category page
+ */
+export async function generateMetadata({ params }: ComboCategoryPageProps): Promise<Metadata> {
+  const { category } = await params;
+  const categoryInfo = getComboCategoryInfo(category);
+
+  if (!categoryInfo) {
+    return {};
+  }
+
+  const env = getEnv();
+  const pageUrl = `${env.appUrl}/combo/category/${category}`;
+
+  return {
+    title: `${categoryInfo.displayName} Emoji Combos - Best ${categoryInfo.displayName} Combos Explained`,
+    description: categoryInfo.description,
+    keywords: [
+      `${categoryInfo.displayName.toLowerCase()} emoji combos`,
+      `best ${categoryInfo.displayName.toLowerCase()} combos`,
+      'emoji combo meanings',
+      'emoji combinations',
+    ],
+    alternates: {
+      canonical: pageUrl,
+    },
+    openGraph: {
+      title: `${categoryInfo.displayName} Emoji Combos`,
+      description: categoryInfo.description,
+      type: 'website',
+      url: pageUrl,
+      siteName: env.appName,
+    },
+    twitter: {
+      card: 'summary',
+      title: `${categoryInfo.displayName} Emoji Combos`,
+      description: categoryInfo.description,
+    },
+    robots: {
+      index: true,
+      follow: true,
+    },
+  };
+}
+
+/**
+ * Combo category page component
+ * Displays all combos in a category as a grid
+ */
+export default async function ComboCategoryPage({ params }: ComboCategoryPageProps) {
+  const { category } = await params;
+  const categoryInfo = getComboCategoryInfo(category);
+
+  if (!categoryInfo) {
+    notFound();
+  }
+
+  const combos = getComboSummariesByCategory(categoryInfo.slug);
+  const env = getEnv();
+
+  // Breadcrumb items for navigation
+  const breadcrumbItems = [
+    { label: 'Home', href: '/' },
+    { label: 'Combos', href: '/combo' },
+    { label: categoryInfo.displayName },
+  ];
+
+  // Breadcrumb items for JSON-LD (with name instead of label)
+  const breadcrumbJsonLdItems = [
+    { name: 'Home', href: '/' },
+    { name: 'Combos', href: '/combo' },
+    { name: categoryInfo.displayName },
+  ];
+
+  return (
+    <>
+      {/* JSON-LD structured data for breadcrumbs */}
+      <BreadcrumbJsonLd items={breadcrumbJsonLdItems} appUrl={env.appUrl} />
+
+      <main className="container mx-auto px-4 py-8 max-w-6xl">
+        {/* Category Header */}
+        <header className="mb-8">
+          {/* Breadcrumb navigation */}
+          <Breadcrumbs items={breadcrumbItems} className="mb-4" />
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+            {categoryInfo.displayName} Emoji Combos
+          </h1>
+          <p className="text-lg text-muted-foreground">{categoryInfo.description}</p>
+          <p className="text-sm text-muted-foreground mt-2">
+            {categoryInfo.comboCount} combo{categoryInfo.comboCount !== 1 ? 's' : ''} in this
+            category
+          </p>
+        </header>
+
+        {/* Combo Grid */}
+        {combos.length > 0 ? (
+          <section aria-labelledby="combos-heading">
+            <h2 id="combos-heading" className="sr-only">
+              {categoryInfo.displayName} Emoji Combos
+            </h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+              {combos.map((combo) => (
+                <Link
+                  key={combo.slug}
+                  href={`/combo/${combo.slug}`}
+                  className="block"
+                  aria-label={`${combo.name} emoji combo`}
+                >
+                  <Card className="h-full hover:border-primary hover:shadow-md transition-all">
+                    <CardContent className="p-4 text-center">
+                      <span className="text-4xl block mb-2">{combo.combo}</span>
+                      <h3 className="font-semibold text-sm text-gray-900 dark:text-gray-100 mb-1 line-clamp-1">
+                        {combo.name}
+                      </h3>
+                      <p className="text-xs text-muted-foreground line-clamp-2">{combo.meaning}</p>
+                    </CardContent>
+                  </Card>
+                </Link>
+              ))}
+            </div>
+          </section>
+        ) : (
+          <p className="text-center text-muted-foreground py-8">
+            No combos found in this category yet.
+          </p>
+        )}
+      </main>
+    </>
+  );
+}

--- a/src/app/compare/[emoji1]/[emoji2]/page.tsx
+++ b/src/app/compare/[emoji1]/[emoji2]/page.tsx
@@ -1,0 +1,253 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import { getAllComparisonSlugs, getComparisonBySlug } from '@/lib/comparison-data';
+import { getEmojiBySlug } from '@/lib/emoji-data';
+import { getEnv } from '@/lib/env';
+import { Breadcrumbs } from '@/components/layout/breadcrumbs';
+import { BreadcrumbJsonLd } from '@/components/seo/breadcrumb-json-ld';
+import { Card, CardContent } from '@/components/ui/card';
+
+interface ComparePageProps {
+  params: Promise<{ emoji1: string; emoji2: string }>;
+}
+
+/**
+ * Revalidate pages every hour (3600 seconds)
+ * This enables Incremental Static Regeneration (ISR) for comparison pages
+ */
+export const revalidate = 3600;
+
+/**
+ * Generate static params for all comparison pages at build time
+ */
+export async function generateStaticParams() {
+  const slugs = getAllComparisonSlugs();
+  return slugs
+    .map((slug) => {
+      const comparison = getComparisonBySlug(slug);
+      if (!comparison) return null;
+      return {
+        emoji1: comparison.emoji1Slug,
+        emoji2: comparison.emoji2Slug,
+      };
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Generate metadata for the comparison page
+ */
+export async function generateMetadata({ params }: ComparePageProps): Promise<Metadata> {
+  const { emoji1: emoji1Slug, emoji2: emoji2Slug } = await params;
+  const comparison = getComparisonBySlug(`${emoji1Slug}-${emoji2Slug}`);
+
+  if (!comparison) {
+    // Try the reverse order
+    const reversed = getComparisonBySlug(`${emoji2Slug}-${emoji1Slug}`);
+    if (!reversed) {
+      return {};
+    }
+    return {
+      title: reversed.seoTitle,
+      description: reversed.seoDescription,
+      keywords: [
+        `${reversed.emoji1Slug} vs ${reversed.emoji2Slug}`,
+        'emoji comparison',
+        'emoji meaning',
+      ],
+      alternates: {
+        canonical: `${getEnv().appUrl}/compare/${reversed.emoji1Slug}/${reversed.emoji2Slug}`,
+      },
+      openGraph: {
+        title: reversed.seoTitle,
+        description: reversed.seoDescription,
+        type: 'website',
+      },
+      twitter: {
+        card: 'summary',
+        title: reversed.seoTitle,
+        description: reversed.seoDescription,
+      },
+      robots: {
+        index: true,
+        follow: true,
+      },
+    };
+  }
+
+  const env = getEnv();
+  const pageUrl = `${env.appUrl}/compare/${emoji1Slug}/${emoji2Slug}`;
+
+  return {
+    title: comparison.seoTitle,
+    description: comparison.seoDescription,
+    keywords: [`${emoji1Slug} vs ${emoji2Slug}`, 'emoji comparison', 'emoji meaning'],
+    alternates: {
+      canonical: pageUrl,
+    },
+    openGraph: {
+      title: comparison.seoTitle,
+      description: comparison.seoDescription,
+      type: 'website',
+      url: pageUrl,
+      siteName: env.appName,
+    },
+    twitter: {
+      card: 'summary',
+      title: comparison.seoTitle,
+      description: comparison.seoDescription,
+    },
+    robots: {
+      index: true,
+      follow: true,
+    },
+  };
+}
+
+/**
+ * Emoji comparison page component
+ * Displays a curated comparison between two emojis
+ */
+export default async function ComparePage({ params }: ComparePageProps) {
+  const { emoji1: emoji1Slug, emoji2: emoji2Slug } = await params;
+
+  // Try to find comparison in either order
+  let comparison = getComparisonBySlug(`${emoji1Slug}-${emoji2Slug}`);
+  let reversed = false;
+
+  if (!comparison) {
+    comparison = getComparisonBySlug(`${emoji2Slug}-${emoji1Slug}`);
+    reversed = true;
+  }
+
+  if (!comparison) {
+    notFound();
+  }
+
+  const env = getEnv();
+
+  // Get emoji data
+  const emoji1Data = getEmojiBySlug(reversed ? comparison.emoji2Slug : comparison.emoji1Slug);
+  const emoji2Data = getEmojiBySlug(reversed ? comparison.emoji1Slug : comparison.emoji2Slug);
+
+  if (!emoji1Data || !emoji2Data) {
+    notFound();
+  }
+
+  // Breadcrumb items for navigation
+  const breadcrumbItems = [
+    { label: 'Home', href: '/' },
+    { label: 'Compare', href: '/compare' },
+    { label: `${emoji1Data.name} vs ${emoji2Data.name}` },
+  ];
+
+  const breadcrumbJsonLdItems = [
+    { name: 'Home', href: '/' },
+    { name: 'Compare', href: '/compare' },
+    { name: `${emoji1Data.name} vs ${emoji2Data.name}` },
+  ];
+
+  return (
+    <>
+      {/* JSON-LD structured data for breadcrumbs */}
+      <BreadcrumbJsonLd items={breadcrumbJsonLdItems} appUrl={env.appUrl} />
+
+      <main className="container mx-auto px-4 py-8 max-w-4xl">
+        {/* Comparison Header */}
+        <header className="mb-8">
+          <Breadcrumbs items={breadcrumbItems} className="mb-4" />
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-4 text-center">
+            {emoji1Data.character} vs {emoji2Data.character}
+          </h1>
+          <p className="text-lg text-center text-muted-foreground mb-4">
+            {comparison.seoDescription}
+          </p>
+
+          {/* Emoji Cards */}
+          <div className="flex justify-center gap-8 mb-6">
+            <Link
+              href={`/emoji/${emoji1Data.slug}`}
+              className="block"
+              aria-label={`Learn more about ${emoji1Data.name}`}
+            >
+              <Card className="hover:border-primary hover:shadow-md transition-all">
+                <CardContent className="p-4 text-center">
+                  <span className="text-6xl block mb-2">{emoji1Data.character}</span>
+                  <h2 className="font-semibold text-lg">{emoji1Data.name}</h2>
+                </CardContent>
+              </Card>
+            </Link>
+            <div className="flex items-center">
+              <span className="text-3xl font-bold text-muted-foreground">vs</span>
+            </div>
+            <Link
+              href={`/emoji/${emoji2Data.slug}`}
+              className="block"
+              aria-label={`Learn more about ${emoji2Data.name}`}
+            >
+              <Card className="hover:border-primary hover:shadow-md transition-all">
+                <CardContent className="p-4 text-center">
+                  <span className="text-6xl block mb-2">{emoji2Data.character}</span>
+                  <h2 className="font-semibold text-lg">{emoji2Data.name}</h2>
+                </CardContent>
+              </Card>
+            </Link>
+          </div>
+        </header>
+
+        {/* Comparison Points */}
+        <section aria-labelledby="comparison-heading">
+          <h2 id="comparison-heading" className="text-2xl font-bold mb-6 text-center">
+            Key Differences
+          </h2>
+          <div className="space-y-4">
+            {comparison.comparisonPoints.map((point, index) => (
+              <Card key={index}>
+                <CardContent className="p-6">
+                  <h3 className="font-semibold text-lg mb-3">{point.aspect}</h3>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div className="p-4 bg-muted/50 rounded-lg">
+                      <div className="flex items-center gap-2 mb-2">
+                        <span className="text-2xl">{emoji1Data.character}</span>
+                        <span className="font-medium">{emoji1Data.name}</span>
+                      </div>
+                      <p className="text-sm text-muted-foreground">{point.emoji1Note}</p>
+                    </div>
+                    <div className="p-4 bg-muted/50 rounded-lg">
+                      <div className="flex items-center gap-2 mb-2">
+                        <span className="text-2xl">{emoji2Data.character}</span>
+                        <span className="font-medium">{emoji2Data.name}</span>
+                      </div>
+                      <p className="text-sm text-muted-foreground">{point.emoji2Note}</p>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </section>
+
+        {/* Navigation to Individual Emoji Pages */}
+        <section className="mt-8 flex justify-center gap-4">
+          <Link href={`/emoji/${emoji1Data.slug}`}>
+            <Card className="hover:border-primary hover:shadow-md transition-all">
+              <CardContent className="p-4 text-center">
+                <span className="text-2xl block mb-1">{emoji1Data.character}</span>
+                <span className="text-sm">Learn more about {emoji1Data.name}</span>
+              </CardContent>
+            </Card>
+          </Link>
+          <Link href={`/emoji/${emoji2Data.slug}`}>
+            <Card className="hover:border-primary hover:shadow-md transition-all">
+              <CardContent className="p-4 text-center">
+                <span className="text-2xl block mb-1">{emoji2Data.character}</span>
+                <span className="text-sm">Learn more about {emoji2Data.name}</span>
+              </CardContent>
+            </Card>
+          </Link>
+        </section>
+      </main>
+    </>
+  );
+}

--- a/src/app/emoji/context/[context]/page.tsx
+++ b/src/app/emoji/context/[context]/page.tsx
@@ -1,0 +1,161 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import {
+  getPageableContextTypes,
+  getEmojiSummariesByContext,
+  getContextInfo,
+} from '@/lib/emoji-data';
+import { getEnv } from '@/lib/env';
+import { Card, CardContent } from '@/components/ui/card';
+import { Breadcrumbs } from '@/components/layout/breadcrumbs';
+import { BreadcrumbJsonLd } from '@/components/seo/breadcrumb-json-ld';
+
+interface ContextPageProps {
+  params: Promise<{ context: string }>;
+}
+
+/**
+ * Revalidate pages every hour (3600 seconds)
+ * This enables Incremental Static Regeneration (ISR) for context pages
+ */
+export const revalidate = 3600;
+
+/**
+ * Generate static params for all context pages at build time
+ */
+export async function generateStaticParams() {
+  const contexts = getPageableContextTypes();
+  return contexts.map((context) => ({ context }));
+}
+
+/**
+ * Generate metadata for the context page
+ */
+export async function generateMetadata({ params }: ContextPageProps): Promise<Metadata> {
+  const { context } = await params;
+  const contextInfo = getContextInfo(context as never);
+
+  if (!contextInfo) {
+    return {};
+  }
+
+  const env = getEnv();
+  const pageUrl = `${env.appUrl}/emoji/context/${context}`;
+
+  return {
+    title: `${contextInfo.displayName} Emoji Meanings - Emojis for ${contextInfo.displayName} Context`,
+    description: contextInfo.description,
+    keywords: [
+      `${contextInfo.displayName.toLowerCase()} emoji meanings`,
+      `emojis for ${contextInfo.displayName.toLowerCase()} context`,
+      'emoji context meanings',
+      'emoji guide',
+    ],
+    alternates: {
+      canonical: pageUrl,
+    },
+    openGraph: {
+      title: `${contextInfo.displayName} Emoji Meanings`,
+      description: contextInfo.description,
+      type: 'website',
+      url: pageUrl,
+      siteName: env.appName,
+    },
+    twitter: {
+      card: 'summary',
+      title: `${contextInfo.displayName} Emoji Meanings`,
+      description: contextInfo.description,
+    },
+    robots: {
+      index: true,
+      follow: true,
+    },
+  };
+}
+
+/**
+ * Context emoji page component
+ * Displays all emojis with notable context meanings
+ */
+export default async function ContextPage({ params }: ContextPageProps) {
+  const { context } = await params;
+  const contextInfo = getContextInfo(context as never);
+
+  if (!contextInfo) {
+    notFound();
+  }
+
+  const emojis = getEmojiSummariesByContext(contextInfo.slug);
+  const env = getEnv();
+
+  // Breadcrumb items for navigation
+  const breadcrumbItems = [
+    { label: 'Home', href: '/' },
+    { label: 'Emojis', href: '/emoji' },
+    { label: contextInfo.displayName },
+  ];
+
+  // Breadcrumb items for JSON-LD (with name instead of label)
+  const breadcrumbJsonLdItems = [
+    { name: 'Home', href: '/' },
+    { name: 'Emojis', href: '/emoji' },
+    { name: contextInfo.displayName },
+  ];
+
+  return (
+    <>
+      {/* JSON-LD structured data for breadcrumbs */}
+      <BreadcrumbJsonLd items={breadcrumbJsonLdItems} appUrl={env.appUrl} />
+
+      <main className="container mx-auto px-4 py-8 max-w-6xl">
+        {/* Context Header */}
+        <header className="mb-8">
+          {/* Breadcrumb navigation */}
+          <Breadcrumbs items={breadcrumbItems} className="mb-4" />
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+            {contextInfo.displayName} Emoji Meanings
+          </h1>
+          <p className="text-lg text-muted-foreground">{contextInfo.description}</p>
+          <p className="text-sm text-muted-foreground mt-2">
+            {contextInfo.emojiCount} emoji{contextInfo.emojiCount !== 1 ? 's' : ''} with{' '}
+            {contextInfo.displayName} context meanings
+          </p>
+        </header>
+
+        {/* Emoji Grid */}
+        {emojis.length > 0 ? (
+          <section aria-labelledby="emojis-heading">
+            <h2 id="emojis-heading" className="sr-only">
+              {contextInfo.displayName} Emoji Meanings
+            </h2>
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+              {emojis.map((emoji) => (
+                <Link
+                  key={emoji.slug}
+                  href={`/emoji/${emoji.slug}`}
+                  className="block"
+                  aria-label={`${emoji.name} emoji`}
+                >
+                  <Card className="h-full hover:border-primary hover:shadow-md transition-all">
+                    <CardContent className="p-4 text-center">
+                      <span className="text-4xl block mb-2">{emoji.character}</span>
+                      <h3 className="font-semibold text-sm text-gray-900 dark:text-gray-100 mb-1 line-clamp-1">
+                        {emoji.name}
+                      </h3>
+                      <p className="text-xs text-muted-foreground line-clamp-2">{emoji.tldr}</p>
+                    </CardContent>
+                  </Card>
+                </Link>
+              ))}
+            </div>
+          </section>
+        ) : (
+          <p className="text-center text-muted-foreground py-8">
+            No emojis with context meanings found.
+          </p>
+        )}
+      </main>
+    </>
+  );
+}

--- a/src/app/emoji/generation/[generation]/page.tsx
+++ b/src/app/emoji/generation/[generation]/page.tsx
@@ -1,0 +1,161 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import {
+  getAllGenerations,
+  getEmojiSummariesByGeneration,
+  getGenerationInfo,
+} from '@/lib/emoji-data';
+import { getEnv } from '@/lib/env';
+import { Card, CardContent } from '@/components/ui/card';
+import { Breadcrumbs } from '@/components/layout/breadcrumbs';
+import { BreadcrumbJsonLd } from '@/components/seo/breadcrumb-json-ld';
+
+interface GenerationPageProps {
+  params: Promise<{ generation: string }>;
+}
+
+/**
+ * Revalidate pages every hour (3600 seconds)
+ * This enables Incremental Static Regeneration (ISR) for generation pages
+ */
+export const revalidate = 3600;
+
+/**
+ * Generate static params for all generation pages at build time
+ */
+export async function generateStaticParams() {
+  const generations = getAllGenerations();
+  return generations.map((generation) => ({ generation }));
+}
+
+/**
+ * Generate metadata for the generation page
+ */
+export async function generateMetadata({ params }: GenerationPageProps): Promise<Metadata> {
+  const { generation } = await params;
+  const generationInfo = getGenerationInfo(generation as never);
+
+  if (!generationInfo) {
+    return {};
+  }
+
+  const env = getEnv();
+  const pageUrl = `${env.appUrl}/emoji/generation/${generation}`;
+
+  return {
+    title: `${generationInfo.displayName} Emoji Meanings - What Emojis Mean to ${generationInfo.displayName}`,
+    description: generationInfo.description,
+    keywords: [
+      `${generationInfo.displayName.toLowerCase()} emoji meanings`,
+      `emoji guide for ${generationInfo.displayName.toLowerCase()}`,
+      'generational emoji meanings',
+      'emoji interpretation by generation',
+    ],
+    alternates: {
+      canonical: pageUrl,
+    },
+    openGraph: {
+      title: `${generationInfo.displayName} Emoji Meanings`,
+      description: generationInfo.description,
+      type: 'website',
+      url: pageUrl,
+      siteName: env.appName,
+    },
+    twitter: {
+      card: 'summary',
+      title: `${generationInfo.displayName} Emoji Meanings`,
+      description: generationInfo.description,
+    },
+    robots: {
+      index: true,
+      follow: true,
+    },
+  };
+}
+
+/**
+ * Generation emoji page component
+ * Displays all emojis with notable generational notes
+ */
+export default async function GenerationPage({ params }: GenerationPageProps) {
+  const { generation } = await params;
+  const generationInfo = getGenerationInfo(generation as never);
+
+  if (!generationInfo) {
+    notFound();
+  }
+
+  const emojis = getEmojiSummariesByGeneration(generationInfo.slug);
+  const env = getEnv();
+
+  // Breadcrumb items for navigation
+  const breadcrumbItems = [
+    { label: 'Home', href: '/' },
+    { label: 'Emojis', href: '/emoji' },
+    { label: generationInfo.displayName },
+  ];
+
+  // Breadcrumb items for JSON-LD (with name instead of label)
+  const breadcrumbJsonLdItems = [
+    { name: 'Home', href: '/' },
+    { name: 'Emojis', href: '/emoji' },
+    { name: generationInfo.displayName },
+  ];
+
+  return (
+    <>
+      {/* JSON-LD structured data for breadcrumbs */}
+      <BreadcrumbJsonLd items={breadcrumbJsonLdItems} appUrl={env.appUrl} />
+
+      <main className="container mx-auto px-4 py-8 max-w-6xl">
+        {/* Generation Header */}
+        <header className="mb-8">
+          {/* Breadcrumb navigation */}
+          <Breadcrumbs items={breadcrumbItems} className="mb-4" />
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+            {generationInfo.displayName} Emoji Meanings
+          </h1>
+          <p className="text-lg text-muted-foreground">{generationInfo.description}</p>
+          <p className="text-sm text-muted-foreground mt-2">
+            {generationInfo.emojiCount} emoji{generationInfo.emojiCount !== 1 ? 's' : ''} with{' '}
+            {generationInfo.displayName}-specific notes
+          </p>
+        </header>
+
+        {/* Emoji Grid */}
+        {emojis.length > 0 ? (
+          <section aria-labelledby="emojis-heading">
+            <h2 id="emojis-heading" className="sr-only">
+              {generationInfo.displayName} Emoji Meanings
+            </h2>
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+              {emojis.map((emoji) => (
+                <Link
+                  key={emoji.slug}
+                  href={`/emoji/${emoji.slug}`}
+                  className="block"
+                  aria-label={`${emoji.name} emoji`}
+                >
+                  <Card className="h-full hover:border-primary hover:shadow-md transition-all">
+                    <CardContent className="p-4 text-center">
+                      <span className="text-4xl block mb-2">{emoji.character}</span>
+                      <h3 className="font-semibold text-sm text-gray-900 dark:text-gray-100 mb-1 line-clamp-1">
+                        {emoji.name}
+                      </h3>
+                      <p className="text-xs text-muted-foreground line-clamp-2">{emoji.tldr}</p>
+                    </CardContent>
+                  </Card>
+                </Link>
+              ))}
+            </div>
+          </section>
+        ) : (
+          <p className="text-center text-muted-foreground py-8">
+            No emojis with generational notes found.
+          </p>
+        )}
+      </main>
+    </>
+  );
+}

--- a/src/app/emoji/platform/[platform]/page.tsx
+++ b/src/app/emoji/platform/[platform]/page.tsx
@@ -1,0 +1,157 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import { getAllPlatforms, getEmojiSummariesByPlatform, getPlatformInfo } from '@/lib/emoji-data';
+import { getEnv } from '@/lib/env';
+import { Card, CardContent } from '@/components/ui/card';
+import { Breadcrumbs } from '@/components/layout/breadcrumbs';
+import { BreadcrumbJsonLd } from '@/components/seo/breadcrumb-json-ld';
+
+interface PlatformPageProps {
+  params: Promise<{ platform: string }>;
+}
+
+/**
+ * Revalidate pages every hour (3600 seconds)
+ * This enables Incremental Static Regeneration (ISR) for platform pages
+ */
+export const revalidate = 3600;
+
+/**
+ * Generate static params for all platform pages at build time
+ */
+export async function generateStaticParams() {
+  const platforms = getAllPlatforms();
+  return platforms.map((platform) => ({ platform }));
+}
+
+/**
+ * Generate metadata for the platform page
+ */
+export async function generateMetadata({ params }: PlatformPageProps): Promise<Metadata> {
+  const { platform } = await params;
+  const platformInfo = getPlatformInfo(platform as never);
+
+  if (!platformInfo) {
+    return {};
+  }
+
+  const env = getEnv();
+  const pageUrl = `${env.appUrl}/emoji/platform/${platform}`;
+
+  return {
+    title: `${platformInfo.displayName} Emoji Meanings - What Emojis Really Mean on ${platformInfo.displayName}`,
+    description: platformInfo.description,
+    keywords: [
+      `${platformInfo.displayName.toLowerCase()} emojis`,
+      `${platformInfo.displayName.toLowerCase()} emoji meanings`,
+      'emoji platform meanings',
+      'emoji guide',
+    ],
+    alternates: {
+      canonical: pageUrl,
+    },
+    openGraph: {
+      title: `${platformInfo.displayName} Emoji Meanings`,
+      description: platformInfo.description,
+      type: 'website',
+      url: pageUrl,
+      siteName: env.appName,
+    },
+    twitter: {
+      card: 'summary',
+      title: `${platformInfo.displayName} Emoji Meanings`,
+      description: platformInfo.description,
+    },
+    robots: {
+      index: true,
+      follow: true,
+    },
+  };
+}
+
+/**
+ * Platform emoji page component
+ * Displays all emojis with notable platform notes
+ */
+export default async function PlatformPage({ params }: PlatformPageProps) {
+  const { platform } = await params;
+  const platformInfo = getPlatformInfo(platform as never);
+
+  if (!platformInfo) {
+    notFound();
+  }
+
+  const emojis = getEmojiSummariesByPlatform(platformInfo.slug);
+  const env = getEnv();
+
+  // Breadcrumb items for navigation
+  const breadcrumbItems = [
+    { label: 'Home', href: '/' },
+    { label: 'Emojis', href: '/emoji' },
+    { label: platformInfo.displayName },
+  ];
+
+  // Breadcrumb items for JSON-LD (with name instead of label)
+  const breadcrumbJsonLdItems = [
+    { name: 'Home', href: '/' },
+    { name: 'Emojis', href: '/emoji' },
+    { name: platformInfo.displayName },
+  ];
+
+  return (
+    <>
+      {/* JSON-LD structured data for breadcrumbs */}
+      <BreadcrumbJsonLd items={breadcrumbJsonLdItems} appUrl={env.appUrl} />
+
+      <main className="container mx-auto px-4 py-8 max-w-6xl">
+        {/* Platform Header */}
+        <header className="mb-8">
+          {/* Breadcrumb navigation */}
+          <Breadcrumbs items={breadcrumbItems} className="mb-4" />
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+            {platformInfo.displayName} Emoji Meanings
+          </h1>
+          <p className="text-lg text-muted-foreground">{platformInfo.description}</p>
+          <p className="text-sm text-muted-foreground mt-2">
+            {platformInfo.emojiCount} emoji{platformInfo.emojiCount !== 1 ? 's' : ''} with{' '}
+            {platformInfo.displayName}-specific notes
+          </p>
+        </header>
+
+        {/* Emoji Grid */}
+        {emojis.length > 0 ? (
+          <section aria-labelledby="emojis-heading">
+            <h2 id="emojis-heading" className="sr-only">
+              {platformInfo.displayName} Emoji Meanings
+            </h2>
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+              {emojis.map((emoji) => (
+                <Link
+                  key={emoji.slug}
+                  href={`/emoji/${emoji.slug}`}
+                  className="block"
+                  aria-label={`${emoji.name} emoji`}
+                >
+                  <Card className="h-full hover:border-primary hover:shadow-md transition-all">
+                    <CardContent className="p-4 text-center">
+                      <span className="text-4xl block mb-2">{emoji.character}</span>
+                      <h3 className="font-semibold text-sm text-gray-900 dark:text-gray-100 mb-1 line-clamp-1">
+                        {emoji.name}
+                      </h3>
+                      <p className="text-xs text-muted-foreground line-clamp-2">{emoji.tldr}</p>
+                    </CardContent>
+                  </Card>
+                </Link>
+              ))}
+            </div>
+          </section>
+        ) : (
+          <p className="text-center text-muted-foreground py-8">
+            No emojis with platform notes found.
+          </p>
+        )}
+      </main>
+    </>
+  );
+}

--- a/src/data/comparisons/index.json
+++ b/src/data/comparisons/index.json
@@ -1,0 +1,209 @@
+[
+  {
+    "slug": "red-heart-white-heart",
+    "emoji1Slug": "red-heart",
+    "emoji2Slug": "white-heart",
+    "seoTitle": "❤️ vs 🤍 - Red Heart vs White Heart Emoji Meaning",
+    "seoDescription": "Compare the red heart vs white heart emoji. Learn the differences in meaning, usage, and when to use each one.",
+    "comparisonPoints": [
+      {
+        "aspect": "Meaning",
+        "emoji1Note": "Red heart represents passionate love, deep romantic feelings, and intense emotion",
+        "emoji2Note": "White heart represents pure love, spiritual connection, and platonic affection"
+      },
+      {
+        "aspect": "Usage Context",
+        "emoji1Note": "Used for romantic partners, new relationships, and expressing strong attraction",
+        "emoji2Note": "Used for close friends, family, and long-term stable relationships"
+      },
+      {
+        "aspect": "Emotional Intensity",
+        "emoji1Note": "High intensity - shows strong, sometimes new romantic feelings",
+        "emoji2Note": "Moderate intensity - shows stable, enduring affection"
+      },
+      {
+        "aspect": "Platform Differences",
+        "emoji1Note": "Universal across all platforms",
+        "emoji2Note": "May appear as outline heart on some older platforms"
+      }
+    ]
+  },
+  {
+    "slug": "red-heart-pink-heart",
+    "emoji1Slug": "red-heart",
+    "emoji2Slug": "pink-heart",
+    "seoTitle": "❤️ vs 💗 - Red Heart vs Pink Heart Emoji Meaning",
+    "seoDescription": "Compare the red heart vs pink heart emoji. Learn the differences in meaning and when to use each one.",
+    "comparisonPoints": [
+      {
+        "aspect": "Meaning",
+        "emoji1Note": "Red heart represents passionate, intense romantic love",
+        "emoji2Note": "Pink heart represents sweet, playful, and affectionate love"
+      },
+      {
+        "aspect": "Usage Context",
+        "emoji1Note": "Used for serious romantic relationships and deep passion",
+        "emoji2Note": "Used for crushes, new romantic interest, and sweet gestures"
+      },
+      {
+        "aspect": "Tone",
+        "emoji1Note": "Serious and passionate",
+        "emoji2Note": "Playful and cute"
+      }
+    ]
+  },
+  {
+    "slug": "skull-laughing",
+    "emoji1Slug": "skull",
+    "emoji2Slug": "face-with-tears-of-joy",
+    "seoTitle": "💀 vs 😂 - Skull vs Laughing Emoji Meaning",
+    "seoDescription": "Compare the skull vs laughing emoji. Both mean something is funny but have different usage patterns and generational differences.",
+    "comparisonPoints": [
+      {
+        "aspect": "Meaning",
+        "emoji1Note": "Skull means 'I'm dead' from laughing - Gen Z slang for extreme amusement",
+        "emoji2Note": "Face with tears of joy means genuine laughter - universal laughing emoji"
+      },
+      {
+        "aspect": "Generation",
+        "emoji1Note": "Primarily Gen Z usage, rarely used by older generations",
+        "emoji2Note": "Universal across all generations"
+      },
+      {
+        "aspect": "Intensity",
+        "emoji1Note": "Very high intensity humor",
+        "emoji2Note": "High intensity humor"
+      },
+      {
+        "aspect": "Risk of Misunderstanding",
+        "emoji1Note": "Boomers may interpret literally as death reference",
+        "emoji2Note": "Universally understood as laughter"
+      }
+    ]
+  },
+  {
+    "slug": "crying-face-sobbing",
+    "emoji1Slug": "crying-face",
+    "emoji2Slug": "loudly-crying-face",
+    "seoTitle": "😭 vs 🥺 - Crying Face vs Sobbing Face Emoji Meaning",
+    "seoDescription": "Compare the crying face vs sobbing face emoji. Learn the differences in intensity and appropriate usage.",
+    "comparisonPoints": [
+      {
+        "aspect": "Intensity",
+        "emoji1Note": "Crying face - sad or sympathetic tears, moderate distress",
+        "emoji2Note": "Loudly crying face - extreme sadness or overwhelming emotion"
+      },
+      {
+        "aspect": "Usage Context",
+        "emoji1Note": "Mild sadness, sympathy, or dramatic effect",
+        "emoji2Note": "Extreme sadness, heartbreak, or comedic exaggeration"
+      },
+      {
+        "aspect": "Dating Context",
+        "emoji1Note": "Can show vulnerability in a measured way",
+        "emoji2Note": "Shows dramatic emotional expression"
+      }
+    ]
+  },
+  {
+    "slug": "smiling-grinning",
+    "emoji1Slug": "smiling-face",
+    "emoji2Slug": "grinning-face",
+    "seoTitle": "😊 vs 😀 - Smiling vs Grinning Face Emoji Meaning",
+    "seoDescription": "Compare the smiling face vs grinning face emoji. Learn the subtle differences in tone and usage.",
+    "comparisonPoints": [
+      {
+        "aspect": "Expression",
+        "emoji1Note": "Smiling face - gentle, warm smile with closed eyes",
+        "emoji2Note": "Grinning face - big open smile showing teeth"
+      },
+      {
+        "aspect": "Tone",
+        "emoji1Note": "Warm, genuine, friendly",
+        "emoji2Note": "More intense, can be enthusiastic or manic"
+      },
+      {
+        "aspect": "Appropriate Context",
+        "emoji1Note": "Casual conversations, friendly responses, warmth",
+        "emoji2Note": "Excited responses, enthusiasm, or ironic use"
+      }
+    ]
+  },
+  {
+    "slug": "thumbs-up-handshake",
+    "emoji1Slug": "thumbs-up",
+    "emoji2Slug": "handshake",
+    "seoTitle": "👍 vs 🤝 - Thumbs Up vs Handshake Emoji Meaning",
+    "seoDescription": "Compare the thumbs up vs handshake emoji. Learn when to use each for professional and casual contexts.",
+    "comparisonPoints": [
+      {
+        "aspect": "Meaning",
+        "emoji1Note": "Thumbs up - approval, agreement, 'all good'",
+        "emoji2Note": "Handshake - deal, agreement, new partnership"
+      },
+      {
+        "aspect": "Work Context",
+        "emoji1Note": "Work-appropriate approval, acknowledgment",
+        "emoji2Note": "Professional agreement, contract, deal-making"
+      },
+      {
+        "aspect": "Casual Context",
+        "emoji1Note": "Saying 'yes', 'good', or 'I agree'",
+        "emoji2Note": "Meeting someone new, closing a deal"
+      }
+    ]
+  },
+  {
+    "slug": "eggplant-peach",
+    "emoji1Slug": "eggplant",
+    "emoji2Slug": "peach",
+    "seoTitle": "🍆 vs 🍑 - Eggplant vs Peach Emoji Meaning",
+    "seoDescription": "Compare the eggplant vs peach emoji. Both have suggestive meanings but are used differently in flirty messaging.",
+    "comparisonPoints": [
+      {
+        "aspect": "Primary Meaning",
+        "emoji1Note": "Eggplant - often represents male anatomy, used in suggestive contexts",
+        "emoji2Note": "Peach - often represents female anatomy or glutes, used in suggestive contexts"
+      },
+      {
+        "aspect": "Usage in Dating",
+        "emoji1Note": "Can be used for bold flirty messages",
+        "emoji2Note": "Often used for subtle hints or compliments"
+      },
+      {
+        "aspect": "Risk Level",
+        "emoji1Note": "High risk - very explicit",
+        "emoji2Note": "Medium risk - can be interpreted innocently"
+      },
+      {
+        "aspect": "Combined Use",
+        "emoji1Note": "Often paired together 🍆🍑 for obvious suggestive meaning",
+        "emoji2Note": "Can stand alone for subtle hints"
+      }
+    ]
+  },
+  {
+    "slug": "fire-100",
+    "emoji1Slug": "fire",
+    "emoji2Slug": "hundred",
+    "seoTitle": "🔥 vs 💯 - Fire vs Hundred Emoji Meaning",
+    "seoDescription": "Compare the fire vs hundred emoji. Both express approval and agreement but in different ways.",
+    "comparisonPoints": [
+      {
+        "aspect": "Meaning",
+        "emoji1Note": "Fire - something is hot, cool, or excellent",
+        "emoji2Note": "Hundred - completely accurate, agree 100%, 'this'"
+      },
+      {
+        "aspect": "Combined Use",
+        "emoji1Note": "🔥💯 together means 'absolutely fire' - both cool and accurate",
+        "emoji2Note": "Each powerful alone but together become the 'fire 100' combo"
+      },
+      {
+        "aspect": "Usage",
+        "emoji1Note": "Praising something that is impressive or attractive",
+        "emoji2Note": "Affirming something is completely correct or accurate"
+      }
+    ]
+  }
+]

--- a/src/lib/combo-data.ts
+++ b/src/lib/combo-data.ts
@@ -204,6 +204,144 @@ export function getComboSummariesByEmoji(
 }
 
 /**
+ * Combo category display names mapping
+ */
+const COMBO_CATEGORY_DISPLAY_NAMES: Record<EmojiComboCategoryName, string> = {
+  humor: 'Humor',
+  flirting: 'Flirting',
+  sarcasm: 'Sarcasm',
+  celebration: 'Celebration',
+  emotion: 'Emotion',
+  reaction: 'Reaction',
+  relationship: 'Relationship',
+  work: 'Work',
+  food: 'Food',
+  travel: 'Travel',
+  other: 'Other',
+};
+
+/**
+ * Combo category descriptions mapping
+ */
+const COMBO_CATEGORY_DESCRIPTIONS: Record<EmojiComboCategoryName, string> = {
+  humor:
+    'The best emoji combos for humor and jokes. Make people laugh with these emoji combinations.',
+  flirting:
+    'Flirty emoji combinations for dating and romantic messages. Perfect for catching attention.',
+  sarcasm: 'Sarcastic emoji combos for ironic and tongue-in-cheek messages.',
+  celebration:
+    'Celebrate with these emoji combinations perfect for exciting news and achievements.',
+  emotion: 'Express emotions with these meaningful emoji combinations.',
+  reaction: 'React to messages with these expressive emoji combinations.',
+  relationship: 'Relationship-themed emoji combos for friends and family.',
+  work: 'Work-appropriate emoji combinations for professional settings.',
+  food: 'Food and drink emoji combinations for culinary conversations.',
+  travel: 'Travel and vacation emoji combinations for wanderlust.',
+  other: "Unique emoji combinations that don't fit other categories.",
+};
+
+/**
+ * Valid combo categories
+ */
+const VALID_COMBO_CATEGORIES: EmojiComboCategoryName[] = [
+  'humor',
+  'flirting',
+  'sarcasm',
+  'celebration',
+  'emotion',
+  'reaction',
+  'relationship',
+  'work',
+  'food',
+  'travel',
+  'other',
+];
+
+/**
+ * Check if a combo category is valid
+ * @param category - Category slug to check
+ * @returns True if the category is valid
+ */
+export function isValidComboCategory(category: string): category is EmojiComboCategoryName {
+  return VALID_COMBO_CATEGORIES.includes(category as EmojiComboCategoryName);
+}
+
+/**
+ * Get the display name for a combo category
+ * @param category - Category slug
+ * @returns Human-readable category name
+ */
+export function getComboCategoryDisplayName(category: string): string {
+  return (
+    COMBO_CATEGORY_DISPLAY_NAMES[category as EmojiComboCategoryName] ||
+    category.charAt(0).toUpperCase() + category.slice(1)
+  );
+}
+
+/**
+ * Get the description for a combo category
+ * @param category - Category slug
+ * @returns Category description
+ */
+export function getComboCategoryDescription(category: string): string {
+  return (
+    COMBO_CATEGORY_DESCRIPTIONS[category as EmojiComboCategoryName] ||
+    `Explore ${category} emoji combos and their meanings.`
+  );
+}
+
+/**
+ * Combo category info for listing and display
+ */
+export interface ComboCategoryInfo {
+  /** Category slug */
+  slug: EmojiComboCategoryName;
+  /** Human-readable category name */
+  displayName: string;
+  /** Category description */
+  description: string;
+  /** Number of combos in this category */
+  comboCount: number;
+}
+
+/**
+ * Get info for a specific combo category
+ * @param category - Category slug
+ * @returns Category info or null if invalid
+ */
+export function getComboCategoryInfo(category: string): ComboCategoryInfo | null {
+  if (!isValidComboCategory(category)) {
+    return null;
+  }
+
+  const combos = getCombosByCategory(category);
+
+  return {
+    slug: category,
+    displayName: getComboCategoryDisplayName(category),
+    description: getComboCategoryDescription(category),
+    comboCount: combos.length,
+  };
+}
+
+/**
+ * Get info for all combo categories
+ * @returns Array of combo category info, sorted by combo count descending
+ */
+export function getAllComboCategoryInfo(): ComboCategoryInfo[] {
+  const categories = getAllComboCategories();
+
+  return categories
+    .map((category) => ({
+      slug: category,
+      displayName: getComboCategoryDisplayName(category),
+      description: getComboCategoryDescription(category),
+      comboCount: getCombosByCategory(category).length,
+    }))
+    .sort((a, b) => b.comboCount - a.comboCount);
+}
+
+/**
  * Clear the combo cache (useful for testing)
  */
 export function clearComboCache(): void {

--- a/src/lib/comparison-data.ts
+++ b/src/lib/comparison-data.ts
@@ -1,0 +1,99 @@
+/**
+ * Emoji comparison data loader utility
+ *
+ * Provides functions to load and query curated emoji comparison data.
+ */
+
+import type { EmojiComparison, EmojiComparisonSummary } from '@/types/comparison';
+
+// Import Node.js fs for SSG/SSR context
+import fs from 'fs';
+import path from 'path';
+
+// Cache for loaded comparisons
+let comparisonCache: EmojiComparison[] | null = null;
+
+/**
+ * Get the path to the comparisons data directory
+ */
+function getComparisonsDir(): string {
+  return path.join(process.cwd(), 'src', 'data', 'comparisons');
+}
+
+/**
+ * Load all comparison data from JSON files
+ * Results are cached after first load
+ */
+function loadComparisons(): EmojiComparison[] {
+  if (comparisonCache !== null) {
+    return comparisonCache;
+  }
+
+  const comparisonsDir = getComparisonsDir();
+
+  // Check if directory exists
+  if (!fs.existsSync(comparisonsDir)) {
+    comparisonCache = [];
+    return comparisonCache;
+  }
+
+  const indexPath = path.join(comparisonsDir, 'index.json');
+
+  if (!fs.existsSync(indexPath)) {
+    comparisonCache = [];
+    return comparisonCache;
+  }
+
+  const content = fs.readFileSync(indexPath, 'utf-8');
+  comparisonCache = JSON.parse(content) as EmojiComparison[];
+
+  return comparisonCache;
+}
+
+/**
+ * Get all comparisons
+ * @returns Array of all comparison data
+ */
+export function getAllComparisons(): EmojiComparison[] {
+  return loadComparisons();
+}
+
+/**
+ * Get a comparison by its slug
+ * @param slug - URL-friendly identifier for the comparison
+ * @returns Comparison data or undefined if not found
+ */
+export function getComparisonBySlug(slug: string): EmojiComparison | undefined {
+  return loadComparisons().find((comparison) => comparison.slug === slug);
+}
+
+/**
+ * Get all comparison slugs for static path generation
+ * @returns Array of all comparison slugs
+ */
+export function getAllComparisonSlugs(): string[] {
+  return loadComparisons().map((comparison) => comparison.slug);
+}
+
+/**
+ * Get comparison summaries for list/grid display
+ * @returns Array of comparison summaries
+ */
+export function getComparisonSummaries(): EmojiComparisonSummary[] {
+  return loadComparisons().map((comparison) => ({
+    slug: comparison.slug,
+    emoji1Slug: comparison.emoji1Slug,
+    emoji2Slug: comparison.emoji2Slug,
+    emoji1Character: '',
+    emoji2Character: '',
+    emoji1Name: '',
+    emoji2Name: '',
+  }));
+}
+
+/**
+ * Clear the comparison cache (useful for testing)
+ */
+export function clearComparisonCache(): void {
+  comparisonCache = null;
+}

--- a/src/lib/emoji-data.ts
+++ b/src/lib/emoji-data.ts
@@ -309,3 +309,421 @@ export function getEmojiSummariesByCategory(category: string): EmojiSummary[] {
     tldr: emoji.tldr,
   }));
 }
+
+// ============================================
+// PLATFORM UTILITIES
+// ============================================
+
+import type { Platform } from '@/types/emoji';
+
+/**
+ * Platform display names mapping
+ */
+const PLATFORM_DISPLAY_NAMES: Record<Platform, string> = {
+  IMESSAGE: 'iMessage',
+  INSTAGRAM: 'Instagram',
+  TIKTOK: 'TikTok',
+  WHATSAPP: 'WhatsApp',
+  SLACK: 'Slack',
+  DISCORD: 'Discord',
+  TWITTER: 'Twitter/X',
+};
+
+/**
+ * Platform descriptions mapping
+ */
+const PLATFORM_DESCRIPTIONS: Record<Platform, string> = {
+  IMESSAGE:
+    'Discover how emojis are interpreted differently on Apple iMessage. Learn the platform-specific meanings and usage.',
+  INSTAGRAM:
+    'Discover how emojis are interpreted on Instagram. Learn the platform-specific meanings and usage for social media.',
+  TIKTOK:
+    'Discover how emojis are interpreted on TikTok. Learn the platform-specific meanings and usage for the viral platform.',
+  WHATSAPP:
+    'Discover how emojis are interpreted on WhatsApp. Learn the platform-specific meanings and usage.',
+  SLACK:
+    'Discover how emojis are interpreted on Slack. Learn the platform-specific meanings and usage for workplace communication.',
+  DISCORD:
+    'Discover how emojis are interpreted on Discord. Learn the platform-specific meanings and usage for servers and groups.',
+  TWITTER:
+    'Discover how emojis are interpreted on Twitter/X. Learn the platform-specific meanings and usage for social media.',
+};
+
+/**
+ * All supported platforms
+ */
+const ALL_PLATFORMS: Platform[] = [
+  'IMESSAGE',
+  'INSTAGRAM',
+  'TIKTOK',
+  'WHATSAPP',
+  'SLACK',
+  'DISCORD',
+  'TWITTER',
+];
+
+/**
+ * Get all platforms
+ * @returns Array of all platform names
+ */
+export function getAllPlatforms(): Platform[] {
+  return ALL_PLATFORMS;
+}
+
+/**
+ * Get the display name for a platform
+ * @param platform - Platform slug
+ * @returns Human-readable platform name
+ */
+export function getPlatformDisplayName(platform: string): string {
+  return PLATFORM_DISPLAY_NAMES[platform as Platform] || platform;
+}
+
+/**
+ * Get the description for a platform
+ * @param platform - Platform slug
+ * @returns Platform description
+ */
+export function getPlatformDescription(platform: string): string {
+  return (
+    PLATFORM_DESCRIPTIONS[platform as Platform] ||
+    `Discover how emojis are interpreted on ${platform}.`
+  );
+}
+
+/**
+ * Get emojis that have notable notes for a specific platform
+ * @param platform - Platform to filter by
+ * @returns Array of emojis with platform notes
+ */
+export function getEmojisWithPlatformNotes(platform: Platform): Emoji[] {
+  return loadEmojis().filter((emoji) =>
+    emoji.platformNotes.some((note) => note.platform === platform)
+  );
+}
+
+/**
+ * Get emoji summaries for a specific platform
+ * @param platform - Platform to filter by
+ * @returns Array of emoji summaries with platform notes
+ */
+export function getEmojiSummariesByPlatform(platform: Platform): EmojiSummary[] {
+  return getEmojisWithPlatformNotes(platform).map((emoji) => ({
+    slug: emoji.slug,
+    character: emoji.character,
+    name: emoji.name,
+    category: emoji.category,
+    tldr: emoji.tldr,
+  }));
+}
+
+/**
+ * Platform info for listing and display
+ */
+export interface PlatformInfo {
+  /** Platform slug */
+  slug: Platform;
+  /** Human-readable platform name */
+  displayName: string;
+  /** Platform description */
+  description: string;
+  /** Number of emojis with notes for this platform */
+  emojiCount: number;
+}
+
+/**
+ * Get info for a specific platform
+ * @param platform - Platform slug
+ * @returns Platform info
+ */
+export function getPlatformInfo(platform: Platform): PlatformInfo {
+  return {
+    slug: platform,
+    displayName: getPlatformDisplayName(platform),
+    description: getPlatformDescription(platform),
+    emojiCount: getEmojisWithPlatformNotes(platform).length,
+  };
+}
+
+/**
+ * Get info for all platforms
+ * @returns Array of platform info, sorted by emoji count descending
+ */
+export function getAllPlatformInfo(): PlatformInfo[] {
+  return getAllPlatforms()
+    .map((platform) => getPlatformInfo(platform))
+    .sort((a, b) => b.emojiCount - a.emojiCount);
+}
+
+// ============================================
+// GENERATION UTILITIES
+// ============================================
+
+import type { Generation } from '@/types/emoji';
+
+/**
+ * Generation display names mapping
+ */
+const GENERATION_DISPLAY_NAMES: Record<Generation, string> = {
+  GEN_Z: 'Gen Z',
+  MILLENNIAL: 'Millennial',
+  GEN_X: 'Gen X',
+  BOOMER: 'Boomer',
+};
+
+/**
+ * Generation descriptions mapping
+ */
+const GENERATION_DESCRIPTIONS: Record<Generation, string> = {
+  GEN_Z:
+    'Learn how Gen Z interprets emojis. From skull means dying to fire means fire, Gen Z emoji meanings are unique.',
+  MILLENNIAL:
+    'Learn how Millennials interpret emojis. This generation bridges traditional and modern emoji usage.',
+  GEN_X:
+    'Learn how Gen X interprets emojis. This generation has its own takes on emoji meaning and usage.',
+  BOOMER:
+    'Learn how Boomers interpret emojis. Understanding generational differences in emoji interpretation.',
+};
+
+/**
+ * All supported generations
+ */
+const ALL_GENERATIONS: Generation[] = ['GEN_Z', 'MILLENNIAL', 'GEN_X', 'BOOMER'];
+
+/**
+ * Get all generations
+ * @returns Array of all generation names
+ */
+export function getAllGenerations(): Generation[] {
+  return ALL_GENERATIONS;
+}
+
+/**
+ * Get the display name for a generation
+ * @param generation - Generation slug
+ * @returns Human-readable generation name
+ */
+export function getGenerationDisplayName(generation: string): string {
+  return GENERATION_DISPLAY_NAMES[generation as Generation] || generation;
+}
+
+/**
+ * Get the description for a generation
+ * @param generation - Generation slug
+ * @returns Generation description
+ */
+export function getGenerationDescription(generation: string): string {
+  return (
+    GENERATION_DESCRIPTIONS[generation as Generation] ||
+    `Learn how ${generation} interprets emojis.`
+  );
+}
+
+/**
+ * Get emojis that have notable notes for a specific generation
+ * @param generation - Generation to filter by
+ * @returns Array of emojis with generational notes
+ */
+export function getEmojisWithGenerationNotes(generation: Generation): Emoji[] {
+  return loadEmojis().filter((emoji) =>
+    emoji.generationalNotes.some((note) => note.generation === generation)
+  );
+}
+
+/**
+ * Get emoji summaries for a specific generation
+ * @param generation - Generation to filter by
+ * @returns Array of emoji summaries with generational notes
+ */
+export function getEmojiSummariesByGeneration(generation: Generation): EmojiSummary[] {
+  return getEmojisWithGenerationNotes(generation).map((emoji) => ({
+    slug: emoji.slug,
+    character: emoji.character,
+    name: emoji.name,
+    category: emoji.category,
+    tldr: emoji.tldr,
+  }));
+}
+
+/**
+ * Generation info for listing and display
+ */
+export interface GenerationInfo {
+  /** Generation slug */
+  slug: Generation;
+  /** Human-readable generation name */
+  displayName: string;
+  /** Generation description */
+  description: string;
+  /** Number of emojis with notes for this generation */
+  emojiCount: number;
+}
+
+/**
+ * Get info for a specific generation
+ * @param generation - Generation slug
+ * @returns Generation info
+ */
+export function getGenerationInfo(generation: Generation): GenerationInfo {
+  return {
+    slug: generation,
+    displayName: getGenerationDisplayName(generation),
+    description: getGenerationDescription(generation),
+    emojiCount: getEmojisWithGenerationNotes(generation).length,
+  };
+}
+
+/**
+ * Get info for all generations
+ * @returns Array of generation info, sorted by emoji count descending
+ */
+export function getAllGenerationInfo(): GenerationInfo[] {
+  return getAllGenerations()
+    .map((generation) => getGenerationInfo(generation))
+    .sort((a, b) => b.emojiCount - a.emojiCount);
+}
+
+// ============================================
+// CONTEXT UTILITIES
+// ============================================
+
+import type { ContextType } from '@/types/emoji';
+
+/**
+ * Context display names mapping
+ */
+const CONTEXT_DISPLAY_NAMES: Record<ContextType, string> = {
+  LITERAL: 'Literal',
+  SLANG: 'Slang',
+  IRONIC: 'Ironic',
+  PASSIVE_AGGRESSIVE: 'Passive-Aggressive',
+  DATING: 'Dating',
+  WORK: 'Work',
+  RED_FLAG: 'Red Flag',
+};
+
+/**
+ * Context descriptions mapping
+ */
+const CONTEXT_DESCRIPTIONS: Record<ContextType, string> = {
+  LITERAL: 'The base Unicode meaning of emojis before slang and modern interpretation.',
+  SLANG: 'Modern slang meanings for emojis that differ from their original intent.',
+  IRONIC: 'Ironic or sarcastic emoji usage where the meaning is opposite to literal.',
+  PASSIVE_AGGRESSIVE: 'Passive-aggressive emoji usage that subtly conveys negative sentiment.',
+  DATING: 'Dating and flirtatious contexts where emojis take on romantic meanings.',
+  WORK: 'Work-appropriate emoji usage that is safe for professional settings.',
+  RED_FLAG: 'Warning about emoji misuse that can signal problematic behavior.',
+};
+
+/**
+ * Context types that make sense as pages (excluding LITERAL which is the default)
+ */
+const PAGEABLE_CONTEXTS: ContextType[] = [
+  'SLANG',
+  'DATING',
+  'WORK',
+  'IRONIC',
+  'PASSIVE_AGGRESSIVE',
+  'RED_FLAG',
+];
+
+/**
+ * Get all context types that can have dedicated pages
+ * @returns Array of context type names
+ */
+export function getPageableContextTypes(): ContextType[] {
+  return PAGEABLE_CONTEXTS;
+}
+
+/**
+ * Get all context types
+ * @returns Array of all context type names
+ */
+export function getAllContextTypes(): ContextType[] {
+  return Object.keys(CONTEXT_DISPLAY_NAMES) as ContextType[];
+}
+
+/**
+ * Get the display name for a context
+ * @param context - Context slug
+ * @returns Human-readable context name
+ */
+export function getContextDisplayName(context: string): string {
+  return CONTEXT_DISPLAY_NAMES[context as ContextType] || context;
+}
+
+/**
+ * Get the description for a context
+ * @param context - Context slug
+ * @returns Context description
+ */
+export function getContextDescription(context: string): string {
+  return (
+    CONTEXT_DESCRIPTIONS[context as ContextType] ||
+    `Explore emojis with ${context} context meanings.`
+  );
+}
+
+/**
+ * Get emojis that have notable meanings for a specific context
+ * @param context - Context to filter by
+ * @returns Array of emojis with context meanings
+ */
+export function getEmojisByContext(context: ContextType): Emoji[] {
+  return loadEmojis().filter((emoji) =>
+    emoji.contextMeanings.some((meaning) => meaning.context === context)
+  );
+}
+
+/**
+ * Get emoji summaries for a specific context
+ * @param context - Context to filter by
+ * @returns Array of emoji summaries with context meanings
+ */
+export function getEmojiSummariesByContext(context: ContextType): EmojiSummary[] {
+  return getEmojisByContext(context).map((emoji) => ({
+    slug: emoji.slug,
+    character: emoji.character,
+    name: emoji.name,
+    category: emoji.category,
+    tldr: emoji.tldr,
+  }));
+}
+
+/**
+ * Context info for listing and display
+ */
+export interface ContextInfo {
+  /** Context slug */
+  slug: ContextType;
+  /** Human-readable context name */
+  displayName: string;
+  /** Context description */
+  description: string;
+  /** Number of emojis with this context */
+  emojiCount: number;
+}
+
+/**
+ * Get info for a specific context
+ * @param context - Context slug
+ * @returns Context info
+ */
+export function getContextInfo(context: ContextType): ContextInfo {
+  return {
+    slug: context,
+    displayName: getContextDisplayName(context),
+    description: getContextDescription(context),
+    emojiCount: getEmojisByContext(context).length,
+  };
+}
+
+/**
+ * Get info for all pageable contexts
+ * @returns Array of context info, sorted by emoji count descending
+ */
+export function getAllContextInfo(): ContextInfo[] {
+  return getPageableContextTypes()
+    .map((context) => getContextInfo(context))
+    .sort((a, b) => b.emojiCount - a.emojiCount);
+}

--- a/src/types/comparison.ts
+++ b/src/types/comparison.ts
@@ -1,0 +1,62 @@
+/**
+ * TypeScript types for emoji comparison data
+ */
+
+import type { EmojiSlug } from './emoji';
+
+// ============================================
+// COMPARISON TYPES
+// ============================================
+
+/**
+ * A single comparison point between two emojis
+ */
+export interface ComparisonPoint {
+  /** The aspect being compared (e.g., "Meaning", "Usage") */
+  aspect: string;
+  /** Description of how emoji1 compares */
+  emoji1Note: string;
+  /** Description of how emoji2 compares */
+  emoji2Note: string;
+}
+
+/**
+ * Emoji comparison data structure
+ * Represents a curated comparison between two emojis
+ */
+export interface EmojiComparison {
+  /** URL-friendly slug for the comparison */
+  slug: string;
+  /** Slug of the first emoji */
+  emoji1Slug: EmojiSlug;
+  /** Slug of the second emoji */
+  emoji2Slug: EmojiSlug;
+  /** SEO title for the comparison page */
+  seoTitle: string;
+  /** SEO description for the comparison page */
+  seoDescription: string;
+  /** Points of comparison between the two emojis */
+  comparisonPoints: ComparisonPoint[];
+}
+
+/**
+ * Minimal comparison summary for listing
+ */
+export interface EmojiComparisonSummary {
+  slug: string;
+  emoji1Slug: EmojiSlug;
+  emoji2Slug: string;
+  emoji1Character: string;
+  emoji2Character: string;
+  emoji1Name: string;
+  emoji2Name: string;
+}
+
+/**
+ * Result of validating comparison data
+ */
+export type EmojiComparisonValidationResult = {
+  valid: boolean;
+  errors: string[];
+  warnings: string[];
+};

--- a/tests/unit/lib/combo-data.test.ts
+++ b/tests/unit/lib/combo-data.test.ts
@@ -437,3 +437,112 @@ describe('combo types', () => {
     expect(mockCombo.examples.length).toBeGreaterThan(0);
   });
 });
+
+describe('combo category utilities', () => {
+  describe('isValidComboCategory', () => {
+    it('should return true for valid categories', async () => {
+      const { isValidComboCategory } = await import('../../../src/lib/combo-data');
+      expect(isValidComboCategory('humor')).toBe(true);
+      expect(isValidComboCategory('flirting')).toBe(true);
+      expect(isValidComboCategory('sarcasm')).toBe(true);
+      expect(isValidComboCategory('celebration')).toBe(true);
+      expect(isValidComboCategory('emotion')).toBe(true);
+      expect(isValidComboCategory('reaction')).toBe(true);
+      expect(isValidComboCategory('relationship')).toBe(true);
+      expect(isValidComboCategory('work')).toBe(true);
+      expect(isValidComboCategory('food')).toBe(true);
+      expect(isValidComboCategory('travel')).toBe(true);
+      expect(isValidComboCategory('other')).toBe(true);
+    });
+
+    it('should return false for invalid categories', async () => {
+      const { isValidComboCategory } = await import('../../../src/lib/combo-data');
+      expect(isValidComboCategory('invalid')).toBe(false);
+      expect(isValidComboCategory('')).toBe(false);
+      expect(isValidComboCategory('HUMOR')).toBe(false);
+    });
+  });
+
+  describe('getComboCategoryDisplayName', () => {
+    it('should return correct display names for valid categories', async () => {
+      const { getComboCategoryDisplayName } = await import('../../../src/lib/combo-data');
+      expect(getComboCategoryDisplayName('humor')).toBe('Humor');
+      expect(getComboCategoryDisplayName('flirting')).toBe('Flirting');
+      expect(getComboCategoryDisplayName('sarcasm')).toBe('Sarcasm');
+      expect(getComboCategoryDisplayName('celebration')).toBe('Celebration');
+      expect(getComboCategoryDisplayName('emotion')).toBe('Emotion');
+      expect(getComboCategoryDisplayName('reaction')).toBe('Reaction');
+      expect(getComboCategoryDisplayName('relationship')).toBe('Relationship');
+      expect(getComboCategoryDisplayName('work')).toBe('Work');
+      expect(getComboCategoryDisplayName('food')).toBe('Food');
+      expect(getComboCategoryDisplayName('travel')).toBe('Travel');
+      expect(getComboCategoryDisplayName('other')).toBe('Other');
+    });
+
+    it('should capitalize unknown categories', async () => {
+      const { getComboCategoryDisplayName } = await import('../../../src/lib/combo-data');
+      expect(getComboCategoryDisplayName('unknown')).toBe('Unknown');
+    });
+  });
+
+  describe('getComboCategoryDescription', () => {
+    it('should return descriptions for valid categories', async () => {
+      const { getComboCategoryDescription } = await import('../../../src/lib/combo-data');
+      const desc = getComboCategoryDescription('humor');
+      expect(typeof desc).toBe('string');
+      expect(desc.length).toBeGreaterThan(0);
+    });
+
+    it('should return fallback for unknown categories', async () => {
+      const { getComboCategoryDescription } = await import('../../../src/lib/combo-data');
+      const desc = getComboCategoryDescription('unknown');
+      expect(desc).toContain('unknown');
+    });
+  });
+
+  describe('getComboCategoryInfo', () => {
+    it('should return info for valid category', async () => {
+      const { getComboCategoryInfo } = await import('../../../src/lib/combo-data');
+      const info = getComboCategoryInfo('humor');
+      expect(info).toBeDefined();
+      expect(info?.slug).toBe('humor');
+      expect(info?.displayName).toBe('Humor');
+      expect(info?.description.length).toBeGreaterThan(0);
+      expect(info?.comboCount).toBeGreaterThan(0);
+    });
+
+    it('should return null for invalid category', async () => {
+      const { getComboCategoryInfo } = await import('../../../src/lib/combo-data');
+      const info = getComboCategoryInfo('invalid');
+      expect(info).toBeNull();
+    });
+  });
+
+  describe('getAllComboCategoryInfo', () => {
+    it('should return array of category info for all categories', async () => {
+      const { getAllComboCategoryInfo } = await import('../../../src/lib/combo-data');
+      const info = getAllComboCategoryInfo();
+      expect(Array.isArray(info)).toBe(true);
+      expect(info.length).toBeGreaterThan(0);
+    });
+
+    it('should be sorted by combo count descending', async () => {
+      const { getAllComboCategoryInfo } = await import('../../../src/lib/combo-data');
+      const info = getAllComboCategoryInfo();
+      for (let i = 1; i < info.length; i++) {
+        expect(info[i - 1].comboCount).toBeGreaterThanOrEqual(info[i].comboCount);
+      }
+    });
+
+    it('should contain all required fields', async () => {
+      const { getAllComboCategoryInfo } = await import('../../../src/lib/combo-data');
+      const info = getAllComboCategoryInfo();
+      info.forEach((cat) => {
+        expect(cat).toHaveProperty('slug');
+        expect(cat).toHaveProperty('displayName');
+        expect(cat).toHaveProperty('description');
+        expect(cat).toHaveProperty('comboCount');
+      });
+    });
+  });
+});

--- a/tests/unit/lib/emoji-data.test.ts
+++ b/tests/unit/lib/emoji-data.test.ts
@@ -413,3 +413,326 @@ describe('emoji types', () => {
     expect(validSeverities).toContain(mockSkullEmoji.warnings[0].severity);
   });
 });
+
+describe('platform utilities', () => {
+  describe('getAllPlatforms', () => {
+    it('should return all 7 platforms', async () => {
+      const { getAllPlatforms } = await import('../../../src/lib/emoji-data');
+      const platforms = getAllPlatforms();
+      expect(platforms).toContain('IMESSAGE');
+      expect(platforms).toContain('INSTAGRAM');
+      expect(platforms).toContain('TIKTOK');
+      expect(platforms).toContain('WHATSAPP');
+      expect(platforms).toContain('SLACK');
+      expect(platforms).toContain('DISCORD');
+      expect(platforms).toContain('TWITTER');
+      expect(platforms.length).toBe(7);
+    });
+  });
+
+  describe('getPlatformDisplayName', () => {
+    it('should return correct display names', async () => {
+      const { getPlatformDisplayName } = await import('../../../src/lib/emoji-data');
+      expect(getPlatformDisplayName('IMESSAGE')).toBe('iMessage');
+      expect(getPlatformDisplayName('INSTAGRAM')).toBe('Instagram');
+      expect(getPlatformDisplayName('TIKTOK')).toBe('TikTok');
+      expect(getPlatformDisplayName('WHATSAPP')).toBe('WhatsApp');
+      expect(getPlatformDisplayName('SLACK')).toBe('Slack');
+      expect(getPlatformDisplayName('DISCORD')).toBe('Discord');
+      expect(getPlatformDisplayName('TWITTER')).toBe('Twitter/X');
+    });
+
+    it('should return original string for unknown platforms', async () => {
+      const { getPlatformDisplayName } = await import('../../../src/lib/emoji-data');
+      expect(getPlatformDisplayName('unknown')).toBe('unknown');
+    });
+  });
+
+  describe('getPlatformDescription', () => {
+    it('should return descriptions for valid platforms', async () => {
+      const { getPlatformDescription } = await import('../../../src/lib/emoji-data');
+      const desc = getPlatformDescription('TIKTOK');
+      expect(typeof desc).toBe('string');
+      expect(desc.length).toBeGreaterThan(0);
+    });
+
+    it('should return fallback for unknown platforms', async () => {
+      const { getPlatformDescription } = await import('../../../src/lib/emoji-data');
+      const desc = getPlatformDescription('unknown');
+      expect(desc).toContain('unknown');
+    });
+  });
+
+  describe('getEmojisWithPlatformNotes', () => {
+    it('should return emojis that have notes for a platform', async () => {
+      const { getEmojisWithPlatformNotes } = await import('../../../src/lib/emoji-data');
+      const emojis = getEmojisWithPlatformNotes('TIKTOK');
+      expect(Array.isArray(emojis)).toBe(true);
+      emojis.forEach((emoji) => {
+        const hasTikTokNote = emoji.platformNotes.some((n) => n.platform === 'TIKTOK');
+        expect(hasTikTokNote).toBe(true);
+      });
+    });
+
+    it('should return different results for different platforms', async () => {
+      const { getEmojisWithPlatformNotes } = await import('../../../src/lib/emoji-data');
+      const tiktokEmojis = getEmojisWithPlatformNotes('TIKTOK');
+      const slackEmojis = getEmojisWithPlatformNotes('SLACK');
+      expect(tiktokEmojis).not.toEqual(slackEmojis);
+    });
+  });
+
+  describe('getEmojiSummariesByPlatform', () => {
+    it('should return emoji summaries for a platform', async () => {
+      const { getEmojiSummariesByPlatform } = await import('../../../src/lib/emoji-data');
+      const summaries = getEmojiSummariesByPlatform('TIKTOK');
+      expect(Array.isArray(summaries)).toBe(true);
+      if (summaries.length > 0) {
+        const summary = summaries[0];
+        expect(summary).toHaveProperty('slug');
+        expect(summary).toHaveProperty('character');
+        expect(summary).toHaveProperty('name');
+        expect(summary).not.toHaveProperty('platformNotes');
+      }
+    });
+  });
+
+  describe('getPlatformInfo', () => {
+    it('should return info for a valid platform', async () => {
+      const { getPlatformInfo } = await import('../../../src/lib/emoji-data');
+      const info = getPlatformInfo('TIKTOK');
+      expect(info.slug).toBe('TIKTOK');
+      expect(info.displayName).toBe('TikTok');
+      expect(info.description.length).toBeGreaterThan(0);
+      expect(info.emojiCount).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getAllPlatformInfo', () => {
+    it('should return info for all platforms', async () => {
+      const { getAllPlatformInfo } = await import('../../../src/lib/emoji-data');
+      const info = getAllPlatformInfo();
+      expect(info.length).toBe(7);
+    });
+
+    it('should be sorted by emoji count descending', async () => {
+      const { getAllPlatformInfo } = await import('../../../src/lib/emoji-data');
+      const info = getAllPlatformInfo();
+      for (let i = 1; i < info.length; i++) {
+        expect(info[i - 1].emojiCount).toBeGreaterThanOrEqual(info[i].emojiCount);
+      }
+    });
+  });
+});
+
+describe('generation utilities', () => {
+  describe('getAllGenerations', () => {
+    it('should return all 4 generations', async () => {
+      const { getAllGenerations } = await import('../../../src/lib/emoji-data');
+      const generations = getAllGenerations();
+      expect(generations).toContain('GEN_Z');
+      expect(generations).toContain('MILLENNIAL');
+      expect(generations).toContain('GEN_X');
+      expect(generations).toContain('BOOMER');
+      expect(generations.length).toBe(4);
+    });
+  });
+
+  describe('getGenerationDisplayName', () => {
+    it('should return correct display names', async () => {
+      const { getGenerationDisplayName } = await import('../../../src/lib/emoji-data');
+      expect(getGenerationDisplayName('GEN_Z')).toBe('Gen Z');
+      expect(getGenerationDisplayName('MILLENNIAL')).toBe('Millennial');
+      expect(getGenerationDisplayName('GEN_X')).toBe('Gen X');
+      expect(getGenerationDisplayName('BOOMER')).toBe('Boomer');
+    });
+
+    it('should return original string for unknown generations', async () => {
+      const { getGenerationDisplayName } = await import('../../../src/lib/emoji-data');
+      expect(getGenerationDisplayName('unknown')).toBe('unknown');
+    });
+  });
+
+  describe('getGenerationDescription', () => {
+    it('should return descriptions for valid generations', async () => {
+      const { getGenerationDescription } = await import('../../../src/lib/emoji-data');
+      const desc = getGenerationDescription('GEN_Z');
+      expect(typeof desc).toBe('string');
+      expect(desc.length).toBeGreaterThan(0);
+    });
+
+    it('should return fallback for unknown generations', async () => {
+      const { getGenerationDescription } = await import('../../../src/lib/emoji-data');
+      const desc = getGenerationDescription('unknown');
+      expect(desc).toContain('unknown');
+    });
+  });
+
+  describe('getEmojisWithGenerationNotes', () => {
+    it('should return emojis that have notes for a generation', async () => {
+      const { getEmojisWithGenerationNotes } = await import('../../../src/lib/emoji-data');
+      const emojis = getEmojisWithGenerationNotes('GEN_Z');
+      expect(Array.isArray(emojis)).toBe(true);
+      emojis.forEach((emoji) => {
+        const hasGenZNote = emoji.generationalNotes.some((n) => n.generation === 'GEN_Z');
+        expect(hasGenZNote).toBe(true);
+      });
+    });
+  });
+
+  describe('getEmojiSummariesByGeneration', () => {
+    it('should return emoji summaries for a generation', async () => {
+      const { getEmojiSummariesByGeneration } = await import('../../../src/lib/emoji-data');
+      const summaries = getEmojiSummariesByGeneration('GEN_Z');
+      expect(Array.isArray(summaries)).toBe(true);
+      if (summaries.length > 0) {
+        const summary = summaries[0];
+        expect(summary).toHaveProperty('slug');
+        expect(summary).toHaveProperty('character');
+        expect(summary).toHaveProperty('name');
+        expect(summary).not.toHaveProperty('generationalNotes');
+      }
+    });
+  });
+
+  describe('getGenerationInfo', () => {
+    it('should return info for a valid generation', async () => {
+      const { getGenerationInfo } = await import('../../../src/lib/emoji-data');
+      const info = getGenerationInfo('GEN_Z');
+      expect(info.slug).toBe('GEN_Z');
+      expect(info.displayName).toBe('Gen Z');
+      expect(info.description.length).toBeGreaterThan(0);
+      expect(info.emojiCount).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getAllGenerationInfo', () => {
+    it('should return info for all generations', async () => {
+      const { getAllGenerationInfo } = await import('../../../src/lib/emoji-data');
+      const info = getAllGenerationInfo();
+      expect(info.length).toBe(4);
+    });
+  });
+});
+
+describe('context utilities', () => {
+  describe('getAllContextTypes', () => {
+    it('should return all 7 context types', async () => {
+      const { getAllContextTypes } = await import('../../../src/lib/emoji-data');
+      const contexts = getAllContextTypes();
+      expect(contexts).toContain('LITERAL');
+      expect(contexts).toContain('SLANG');
+      expect(contexts).toContain('IRONIC');
+      expect(contexts).toContain('PASSIVE_AGGRESSIVE');
+      expect(contexts).toContain('DATING');
+      expect(contexts).toContain('WORK');
+      expect(contexts).toContain('RED_FLAG');
+      expect(contexts.length).toBe(7);
+    });
+  });
+
+  describe('getPageableContextTypes', () => {
+    it('should return 6 context types (excluding LITERAL)', async () => {
+      const { getPageableContextTypes } = await import('../../../src/lib/emoji-data');
+      const contexts = getPageableContextTypes();
+      expect(contexts).not.toContain('LITERAL');
+      expect(contexts).toContain('SLANG');
+      expect(contexts).toContain('DATING');
+      expect(contexts).toContain('WORK');
+      expect(contexts.length).toBe(6);
+    });
+  });
+
+  describe('getContextDisplayName', () => {
+    it('should return correct display names', async () => {
+      const { getContextDisplayName } = await import('../../../src/lib/emoji-data');
+      expect(getContextDisplayName('SLANG')).toBe('Slang');
+      expect(getContextDisplayName('DATING')).toBe('Dating');
+      expect(getContextDisplayName('WORK')).toBe('Work');
+      expect(getContextDisplayName('IRONIC')).toBe('Ironic');
+      expect(getContextDisplayName('PASSIVE_AGGRESSIVE')).toBe('Passive-Aggressive');
+      expect(getContextDisplayName('RED_FLAG')).toBe('Red Flag');
+    });
+
+    it('should return original string for unknown contexts', async () => {
+      const { getContextDisplayName } = await import('../../../src/lib/emoji-data');
+      expect(getContextDisplayName('unknown')).toBe('unknown');
+    });
+  });
+
+  describe('getContextDescription', () => {
+    it('should return descriptions for valid contexts', async () => {
+      const { getContextDescription } = await import('../../../src/lib/emoji-data');
+      const desc = getContextDescription('SLANG');
+      expect(typeof desc).toBe('string');
+      expect(desc.length).toBeGreaterThan(0);
+    });
+
+    it('should return fallback for unknown contexts', async () => {
+      const { getContextDescription } = await import('../../../src/lib/emoji-data');
+      const desc = getContextDescription('unknown');
+      expect(desc).toContain('unknown');
+    });
+  });
+
+  describe('getEmojisByContext', () => {
+    it('should return emojis that have meanings for a context', async () => {
+      const { getEmojisByContext } = await import('../../../src/lib/emoji-data');
+      const emojis = getEmojisByContext('SLANG');
+      expect(Array.isArray(emojis)).toBe(true);
+      emojis.forEach((emoji) => {
+        const hasSlangContext = emoji.contextMeanings.some((m) => m.context === 'SLANG');
+        expect(hasSlangContext).toBe(true);
+      });
+    });
+
+    it('should return different results for different contexts', async () => {
+      const { getEmojisByContext } = await import('../../../src/lib/emoji-data');
+      const slangEmojis = getEmojisByContext('SLANG');
+      const datingEmojis = getEmojisByContext('DATING');
+      expect(slangEmojis).not.toEqual(datingEmojis);
+    });
+  });
+
+  describe('getEmojiSummariesByContext', () => {
+    it('should return emoji summaries for a context', async () => {
+      const { getEmojiSummariesByContext } = await import('../../../src/lib/emoji-data');
+      const summaries = getEmojiSummariesByContext('SLANG');
+      expect(Array.isArray(summaries)).toBe(true);
+      if (summaries.length > 0) {
+        const summary = summaries[0];
+        expect(summary).toHaveProperty('slug');
+        expect(summary).toHaveProperty('character');
+        expect(summary).toHaveProperty('name');
+        expect(summary).not.toHaveProperty('contextMeanings');
+      }
+    });
+  });
+
+  describe('getContextInfo', () => {
+    it('should return info for a valid context', async () => {
+      const { getContextInfo } = await import('../../../src/lib/emoji-data');
+      const info = getContextInfo('SLANG');
+      expect(info.slug).toBe('SLANG');
+      expect(info.displayName).toBe('Slang');
+      expect(info.description.length).toBeGreaterThan(0);
+      expect(info.emojiCount).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getAllContextInfo', () => {
+    it('should return info for all pageable contexts', async () => {
+      const { getAllContextInfo } = await import('../../../src/lib/emoji-data');
+      const info = getAllContextInfo();
+      expect(info.length).toBe(6);
+    });
+
+    it('should be sorted by emoji count descending', async () => {
+      const { getAllContextInfo } = await import('../../../src/lib/emoji-data');
+      const info = getAllContextInfo();
+      for (let i = 1; i < info.length; i++) {
+        expect(info[i - 1].emojiCount).toBeGreaterThanOrEqual(info[i].emojiCount);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add 5 new programmatic page types to capture high-intent search queries:

- **Combo category pages** (`/combo/category/[category]`) - 11 categories (humor, flirting, sarcasm, celebration, emotion, reaction, relationship, work, food, travel, other)
- **Platform pages** (`/emoji/platform/[platform]`) - 7 platforms (iMessage, Instagram, TikTok, WhatsApp, Slack, Discord, Twitter/X)
- **Generation pages** (`/emoji/generation/[generation]`) - 4 generations (Gen Z, Millennial, Gen X, Boomer)
- **Context pages** (`/emoji/context/[context]`) - 6 contexts (slang, dating, work, ironic, passive-aggressive, red flag)
- **Comparison pages** (`/compare/[emoji1]/[emoji2]`) - 8 curated emoji comparisons (red heart vs white heart, skull vs laughing, etc.)

All pages use SSG+ISR (1-hour revalidation) with full SEO metadata including:
- Title, description, keywords
- OpenGraph and Twitter cards
- Canonical URLs
- Breadcrumbs and JSON-LD structured data

## Test plan

- [ ] Run `bun run lint` and `bun run typecheck` — both should pass
- [ ] Run `bun run build` to verify all pages generate without errors
- [ ] Manually verify metadata in browser DevTools for new pages
- [ ] Check that `generateStaticParams` returns expected counts for each route type

🤖 Generated with [Claude Code](https://claude.com/claude-code)