### PR TITLE
feat: add Google AdSense meta tag

### DIFF
--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -108,6 +108,9 @@ export function createSiteMetadata(): Metadata {
     alternates: {
       canonical: siteUrl,
     },
+    other: {
+      'google-adsense-account': 'ca-pub-4731086750813339',
+    },
   };
 }
 

--- a/tests/unit/lib/metadata.test.ts
+++ b/tests/unit/lib/metadata.test.ts
@@ -327,6 +327,15 @@ describe('Site Metadata Configuration', () => {
       const alternates = metadata.alternates as { canonical?: string };
       expect(alternates?.canonical).toBe('https://knowyouremoji.com');
     });
+
+    test('has google-adsense-account meta tag', async () => {
+      const { createSiteMetadata } = await import('../../../src/lib/metadata');
+      const metadata = createSiteMetadata();
+
+      const other = metadata.other as Record<string, string>;
+      expect(other).toBeDefined();
+      expect(other['google-adsense-account']).toBe('ca-pub-4731086750813339');
+    });
   });
 
   describe('Helper functions', () => {


### PR DESCRIPTION
## Summary
- Adds the `google-adsense-account` meta tag (`ca-pub-4731086750813339`) to site metadata via Next.js `other` field in `src/lib/metadata.ts`, so it renders in `<head>` on every page for AdSense ownership verification.
- Adds a unit test covering the new tag.

## Test plan
- [x] `bun test tests/unit/lib/metadata.test.ts` — 32 pass, 100% coverage on `src/lib/metadata.ts`
- [x] `bun run lint` clean
- [ ] Verify `<meta name="google-adsense-account" content="ca-pub-4731086750813339">` is present in rendered HTML on the deployed preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)