### PR TITLE
feat: add ads.txt for Google AdSense authorization

### DIFF
--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-4731086750813339, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## Summary
- Add `public/ads.txt` authorizing Google AdSense (pub-4731086750813339) as a DIRECT seller
- Served at `https://knowyouremoji.com/ads.txt` via Next.js public directory

## Test plan
- [ ] Verify file is reachable at `/ads.txt` after deploy
- [ ] Confirm content matches AdSense's expected line exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)