### PR TITLE
chore: drop deprecated @types/bcryptjs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -40,7 +40,6 @@
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
-        "@types/bcryptjs": "^3.0.0",
         "@types/bun": "^1.3.7",
         "@types/node": "^26.0.0",
         "@types/react": "^19",
@@ -625,8 +624,6 @@
     "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
-
-    "@types/bcryptjs": ["@types/bcryptjs@3.0.0", "", { "dependencies": { "bcryptjs": "*" } }, "sha512-WRZOuCuaz8UcZZE4R5HXTco2goQSI2XxjGY3hbM/xDvwmqFWd4ivooImsMx65OKM6CtNKbnZ5YL+YwAwK7c1dg=="],
 
     "@types/bun": ["@types/bun@1.3.7", "", { "dependencies": { "bun-types": "1.3.7" } }, "sha512-lmNuMda+Z9b7tmhA0tohwy8ZWFSnmQm1UDWXtH5r9F7wZCfkeO3Jx7wKQ1EOiKq43yHts7ky6r8SDJQWRNupkA=="],
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
-    "@types/bcryptjs": "^3.0.0",
     "@types/bun": "^1.3.7",
     "@types/node": "^26.0.0",
     "@types/react": "^19",


### PR DESCRIPTION
Removes the deprecated `@types/bcryptjs` stub. The DefinitelyTyped package now redirects to `bcryptjs` itself, which ships its own TypeScript definitions as of v3 (see `bcryptjs/index.d.ts` and `bcryptjs/umd/index.d.ts`).

**Changes**
- `package.json`: drop `@types/bcryptjs` from `devDependencies`
- `bun.lock`: refresh after `bun install`

**Verification**
- `bun run typecheck` — clean
- `bun run lint` — clean
- `bun run test` — 3490 pass, 0 fail (coverage thresholds still met: 99.33% funcs / 99.53% lines)
- Pre-commit `tsc --noEmit` and `bun test` hooks both green

Resolves the Deprecations / Replacements warning surfaced by the dependency datasource for `@types/bcryptjs`.