### PR TITLE
feat: extend long-form content model to combos + publish deep content for popular pages (#340)

### DIFF
--- a/docs/emoji-content-guide.md
+++ b/docs/emoji-content-guide.md
@@ -1,0 +1,98 @@
+# Emoji Content Guide
+
+How to author emoji JSON pages, including the optional long-form fields
+introduced in CONTENT-P1-001.
+
+The JSON loader still requires every page to ship the original "thin" fields
+(`unicode`, `slug`, `character`, `name`, `shortName`, `category`,
+`unicodeVersion`, `baseMeaning`, `tldr`, `contextMeanings`, `platformNotes`,
+`generationalNotes`, `warnings`, `relatedCombos`, `seoTitle`, `seoDescription`).
+Everything below this section is optional, but adopting it unlocks the deep
+content tier and the richer article layout on `/emoji/[slug]`.
+
+## Field reference (additions)
+
+Add these inside any emoji JSON file. All top-level keys are optional and
+backward-compatible.
+
+| Key                    | Type                                  | Notes                                                                                                                                                                                                                        |
+| ---------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `contentTier`          | `"thin"` \| `"standard"` \| `"deep"`  | Marks the page for publishing QA. Leave off (or use `"thin"`) for legacy pages. Use `"standard"` for an enriched page that is not yet ready for the strict deep checks. Use `"deep"` only when every threshold below is met. |
+| `contentUpdatedAt`     | ISO date string (e.g. `"2026-01-15"`) | When the content was last meaningfully refreshed.                                                                                                                                                                            |
+| `longForm`             | object                                | Article-style body content. See sub-fields below.                                                                                                                                                                            |
+| `conversationExamples` | array                                 | Richer, full-message examples grouped by social setting.                                                                                                                                                                     |
+
+### `longForm`
+
+| Key              | Type                            | Notes                                                                                                                       |
+| ---------------- | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `overview`       | string                          | 2–4 paragraphs that go beyond the one-line `tldr`. Must read like an article lede, not a paraphrase of the existing fields. |
+| `howPeopleUseIt` | string                          | How the emoji shows up in real chat: counts, pairings, captions, the vibe.                                                  |
+| `whenNotToUse`   | string                          | The contexts where the emoji is a bad fit — formal, professional, sensitive, or simply misunderstood.                       |
+| `howToReply`     | string                          | Practical guidance for someone who just received the emoji and is not sure how to respond.                                  |
+| `faqs`           | array of `{ question, answer }` | "People Also Ask" style entries. Answer each one self-contained.                                                            |
+
+### `conversationExamples[]`
+
+| Key              | Type                                                                           | Notes                                                                                      |
+| ---------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| `setting`        | `"dating"` \| `"friends"` \| `"work"` \| `"family"` \| `"social"` \| `"other"` | Where the exchange happens. Pick the closest match — do not duplicate one setting.         |
+| `message`        | string                                                                         | The full message being interpreted (include the emoji).                                    |
+| `interpretation` | string                                                                         | What that message (and emoji) actually means in this setting, plus a hint at how to reply. |
+
+## Deep-tier thresholds
+
+Setting `contentTier: "deep"` opts the page into the strict publishing checks
+in `scripts/validate-emojis.ts` (`bun run validate:emojis`). To pass:
+
+- `longForm.overview` must contain **at least 120 words**.
+- `conversationExamples` must contain **at least 3 entries**.
+- `longForm.faqs` must contain **at least 3 entries**.
+- Every `platformNotes[].note` must be **at least 40 characters** AND must not
+  match one of the boilerplate patterns in
+  `scripts/validate-emojis.ts` (`DEEP_BOILERPLATE_PATTERNS`).
+
+If you cannot meet a threshold yet, keep `contentTier` at `"standard"` (or
+omit it) so the validation pipeline does not block the page.
+
+## Anti-boilerplate rules
+
+The most common failure mode for platform and generational notes is generic
+copy that could apply to any emoji ("very common in comments", "used in many
+contexts"). The validation script rejects notes that match these patterns at
+the deep tier.
+
+For each `platformNotes[].note`, write something that names the platform:
+
+- What does the emoji look like in that platform's UI?
+- Who is using it (creators, commenters, lurkers)?
+- What does it signal in that specific context?
+
+If your note could be copy-pasted into another emoji page, rewrite it.
+
+## Reference example
+
+See `tests/utils/fixtures/emojis.fixtures.ts` → `SKULL_DEEP_EMOJI` for a
+passing deep-tier example. It is intentionally verbose so writers can copy
+the structure, then rewrite the body for the emoji they are working on.
+
+## Workflow
+
+1. Pick the emoji slug. Open `src/data/emojis/<slug>.json`.
+2. Read the existing `tldr`, `contextMeanings`, and `platformNotes`. The new
+   content should complement, not duplicate, them.
+3. Draft `longForm` paragraphs first. Hit the 120-word overview target.
+4. Add at least 3 `conversationExamples` that show distinct settings.
+5. Add at least 3 `faqs` readers are likely to type into a search engine.
+6. Run `bun run validate:emojis` to catch threshold and boilerplate failures.
+7. Set `contentTier: "deep"` and `contentUpdatedAt: <today>` once the page is
+   ready for QA.
+
+## When not to use deep tier
+
+- The page is new and only has a few examples. Mark it `"standard"` or omit
+  the field.
+- The emoji has no slang or generational nuance (e.g. a flag). Skip
+  `longForm` entirely; the existing thin layout is more honest.
+- You cannot write a 120-word overview without repeating the `tldr`. Keep the
+  page thin and ask a writer to revisit.

--- a/scripts/validate-emojis.ts
+++ b/scripts/validate-emojis.ts
@@ -15,11 +15,16 @@ import type {
   GenerationalNote,
   EmojiWarning,
   EmojiValidationResult,
+  EmojiLongForm,
+  EmojiFaq,
+  ConversationExample,
+  ContentTier,
   ContextType,
   RiskLevel,
   Platform,
   Generation,
   WarningSeverity,
+  ConversationSetting,
 } from '../src/types/emoji';
 
 // Valid enum values for validation
@@ -48,6 +53,39 @@ const VALID_PLATFORMS: Platform[] = [
 const VALID_GENERATIONS: Generation[] = ['GEN_Z', 'MILLENNIAL', 'GEN_X', 'BOOMER'];
 
 const VALID_SEVERITIES: WarningSeverity[] = ['LOW', 'MEDIUM', 'HIGH'];
+
+const VALID_CONTENT_TIERS: ContentTier[] = ['thin', 'standard', 'deep'];
+
+const VALID_CONVERSATION_SETTINGS: ConversationSetting[] = [
+  'dating',
+  'friends',
+  'work',
+  'family',
+  'social',
+  'other',
+];
+
+// Minimum word count for the `longForm.overview` field on deep-tier pages
+export const DEEP_OVERVIEW_MIN_WORDS = 120;
+
+// Minimum number of richer conversation examples for deep-tier pages
+export const DEEP_CONVERSATION_EXAMPLES_MIN = 3;
+
+// Minimum number of FAQ entries for deep-tier pages (when longForm is present)
+export const DEEP_FAQS_MIN = 3;
+
+// Minimum character length per platform note for deep-tier pages
+export const DEEP_PLATFORM_NOTE_MIN_CHARS = 40;
+
+// Boilerplate substrings that will fail deep-tier platform note validation.
+// Keep intentionally short so we don't over-fit; writers can always add detail.
+export const DEEP_BOILERPLATE_PATTERNS: string[] = [
+  'commonly used',
+  'very common',
+  'general purpose',
+  'used for various',
+  'used in many contexts',
+];
 
 // Required emoji fields
 const REQUIRED_EMOJI_FIELDS: (keyof Emoji)[] = [
@@ -204,6 +242,223 @@ export function validateWarning(warning: EmojiWarning, index: number): Validatio
 }
 
 /**
+ * Count the whitespace-delimited words in a string.
+ */
+export function countWords(text: string): number {
+  if (typeof text !== 'string') return 0;
+  const trimmed = text.trim();
+  if (trimmed === '') return 0;
+  return trimmed.split(/\s+/).length;
+}
+
+/**
+ * Validate a single FAQ entry
+ */
+export function validateFaq(faq: EmojiFaq, index: number): ValidationError[] {
+  const errors: ValidationError[] = [];
+  const prefix = `longForm.faqs[${index}]`;
+
+  if (!faq.question || typeof faq.question !== 'string') {
+    errors.push({
+      file: '',
+      field: prefix,
+      message: 'Missing or invalid question field',
+    });
+  }
+
+  if (!faq.answer || typeof faq.answer !== 'string') {
+    errors.push({
+      file: '',
+      field: prefix,
+      message: 'Missing or invalid answer field',
+    });
+  }
+
+  return errors;
+}
+
+/**
+ * Validate the optional longForm block
+ */
+export function validateLongForm(longForm: EmojiLongForm): ValidationError[] {
+  const errors: ValidationError[] = [];
+  const stringFields: (keyof EmojiLongForm)[] = [
+    'overview',
+    'howPeopleUseIt',
+    'whenNotToUse',
+    'howToReply',
+  ];
+
+  for (const field of stringFields) {
+    const value = longForm[field];
+    if (value !== undefined && (typeof value !== 'string' || value.trim() === '')) {
+      errors.push({
+        file: '',
+        field: `longForm.${field}`,
+        message: `longForm.${field} must be a non-empty string when provided`,
+      });
+    }
+  }
+
+  if (longForm.faqs !== undefined) {
+    if (!Array.isArray(longForm.faqs)) {
+      errors.push({
+        file: '',
+        field: 'longForm.faqs',
+        message: 'longForm.faqs must be an array',
+      });
+    } else {
+      longForm.faqs.forEach((faq, index) => {
+        const faqErrors = validateFaq(faq, index);
+        errors.push(...faqErrors);
+      });
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Validate a single conversation example
+ */
+export function validateConversationExample(
+  example: ConversationExample,
+  index: number
+): ValidationError[] {
+  const errors: ValidationError[] = [];
+  const prefix = `conversationExamples[${index}]`;
+
+  if (!example.setting || !VALID_CONVERSATION_SETTINGS.includes(example.setting)) {
+    errors.push({
+      file: '',
+      field: prefix,
+      message: `Invalid setting: ${example.setting}. Must be one of: ${VALID_CONVERSATION_SETTINGS.join(', ')}`,
+    });
+  }
+
+  if (!example.message || typeof example.message !== 'string') {
+    errors.push({
+      file: '',
+      field: prefix,
+      message: 'Missing or invalid message field',
+    });
+  }
+
+  if (!example.interpretation || typeof example.interpretation !== 'string') {
+    errors.push({
+      file: '',
+      field: prefix,
+      message: 'Missing or invalid interpretation field',
+    });
+  }
+
+  return errors;
+}
+
+/**
+ * Validate a contentTier value
+ */
+function validateContentTier(tier: unknown): ValidationError[] {
+  const errors: ValidationError[] = [];
+  if (tier !== undefined && !VALID_CONTENT_TIERS.includes(tier as ContentTier)) {
+    errors.push({
+      file: '',
+      field: 'contentTier',
+      message: `Invalid contentTier: ${String(tier)}. Must be one of: ${VALID_CONTENT_TIERS.join(', ')}`,
+    });
+  }
+  return errors;
+}
+
+/**
+ * Validate a contentUpdatedAt ISO date string
+ */
+function validateContentUpdatedAt(value: unknown): ValidationError[] {
+  const errors: ValidationError[] = [];
+  if (value === undefined) return errors;
+  if (typeof value !== 'string') {
+    errors.push({
+      file: '',
+      field: 'contentUpdatedAt',
+      message: 'contentUpdatedAt must be an ISO date string',
+    });
+    return errors;
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    errors.push({
+      file: '',
+      field: 'contentUpdatedAt',
+      message: `contentUpdatedAt must be a valid ISO date string (got "${value}")`,
+    });
+  }
+  return errors;
+}
+
+/**
+ * Enforce thresholds required when an emoji opts into contentTier: 'deep'.
+ *
+ * Throws errors (not warnings) so the publishing QA pipeline can gate on them.
+ */
+export function validateDeepTier(emoji: Emoji): ValidationError[] {
+  const errors: ValidationError[] = [];
+  const file = emoji.slug || 'unknown';
+
+  const longForm = emoji.longForm ?? {};
+  const overview = longForm.overview ?? '';
+  const overviewWords = countWords(overview);
+
+  if (overviewWords < DEEP_OVERVIEW_MIN_WORDS) {
+    errors.push({
+      file,
+      field: 'longForm.overview',
+      message: `deep-tier requires longForm.overview of at least ${DEEP_OVERVIEW_MIN_WORDS} words (got ${overviewWords})`,
+    });
+  }
+
+  const examples = Array.isArray(emoji.conversationExamples) ? emoji.conversationExamples : [];
+  if (examples.length < DEEP_CONVERSATION_EXAMPLES_MIN) {
+    errors.push({
+      file,
+      field: 'conversationExamples',
+      message: `deep-tier requires at least ${DEEP_CONVERSATION_EXAMPLES_MIN} conversationExamples (got ${examples.length})`,
+    });
+  }
+
+  const faqs = Array.isArray(longForm.faqs) ? longForm.faqs : [];
+  if (faqs.length < DEEP_FAQS_MIN) {
+    errors.push({
+      file,
+      field: 'longForm.faqs',
+      message: `deep-tier requires at least ${DEEP_FAQS_MIN} longForm.faqs entries (got ${faqs.length})`,
+    });
+  }
+
+  // Per-platform notes: must be ≥ min chars and not match boilerplate patterns.
+  emoji.platformNotes.forEach((note, index) => {
+    const trimmed = (note.note ?? '').trim();
+    if (trimmed.length < DEEP_PLATFORM_NOTE_MIN_CHARS) {
+      errors.push({
+        file,
+        field: `platformNotes[${index}].note`,
+        message: `deep-tier requires platformNotes[${index}].note to be at least ${DEEP_PLATFORM_NOTE_MIN_CHARS} characters (got ${trimmed.length})`,
+      });
+    }
+    const lowered = trimmed.toLowerCase();
+    const matchedPattern = DEEP_BOILERPLATE_PATTERNS.find((pattern) => lowered.includes(pattern));
+    if (matchedPattern) {
+      errors.push({
+        file,
+        field: `platformNotes[${index}].note`,
+        message: `deep-tier platformNotes[${index}].note matches boilerplate pattern "${matchedPattern}"; write an emoji-specific note instead`,
+      });
+    }
+  });
+
+  return errors;
+}
+
+/**
  * Validate a single emoji object
  */
 export function validateEmoji(emoji: Emoji): ValidationError[] {
@@ -321,6 +576,62 @@ export function validateEmoji(emoji: Emoji): ValidationError[] {
       field: 'relatedCombos',
       message: 'relatedCombos must be an array',
     });
+  }
+
+  // Optional contentTier (CONTENT-P1-001)
+  const tierErrors = validateContentTier(emoji.contentTier);
+  tierErrors.forEach((e) => {
+    e.file = emoji.slug || 'unknown';
+    errors.push(e);
+  });
+
+  // Optional contentUpdatedAt (CONTENT-P1-001)
+  const updatedAtErrors = validateContentUpdatedAt(emoji.contentUpdatedAt);
+  updatedAtErrors.forEach((e) => {
+    e.file = emoji.slug || 'unknown';
+    errors.push(e);
+  });
+
+  // Optional longForm (CONTENT-P1-001)
+  if (emoji.longForm !== undefined) {
+    if (typeof emoji.longForm !== 'object' || emoji.longForm === null) {
+      errors.push({
+        file: emoji.slug || 'unknown',
+        field: 'longForm',
+        message: 'longForm must be an object',
+      });
+    } else {
+      const longFormErrors = validateLongForm(emoji.longForm);
+      longFormErrors.forEach((e) => {
+        e.file = emoji.slug || 'unknown';
+        errors.push(e);
+      });
+    }
+  }
+
+  // Optional conversationExamples (CONTENT-P1-001)
+  if (emoji.conversationExamples !== undefined) {
+    if (!Array.isArray(emoji.conversationExamples)) {
+      errors.push({
+        file: emoji.slug || 'unknown',
+        field: 'conversationExamples',
+        message: 'conversationExamples must be an array',
+      });
+    } else {
+      emoji.conversationExamples.forEach((example, index) => {
+        const exampleErrors = validateConversationExample(example, index);
+        exampleErrors.forEach((e) => {
+          e.file = emoji.slug || 'unknown';
+          errors.push(e);
+        });
+      });
+    }
+  }
+
+  // If opted into deep tier, enforce the strict thresholds.
+  if (emoji.contentTier === 'deep') {
+    const deepErrors = validateDeepTier(emoji);
+    errors.push(...deepErrors);
   }
 
   return errors;

--- a/src/app/combo/[slug]/page.tsx
+++ b/src/app/combo/[slug]/page.tsx
@@ -12,6 +12,8 @@ import { ComboJsonLd } from '@/components/seo/combo-json-ld';
 import { BreadcrumbJsonLd } from '@/components/seo/breadcrumb-json-ld';
 import { Breadcrumbs } from '@/components/layout/breadcrumbs';
 import { RelatedCombosSection } from '@/components/combo/related-combos-section';
+import { ComboLongFormSection } from '@/components/combo/combo-long-form-section';
+import { ComboConversationExamplesSection } from '@/components/combo/combo-conversation-examples-section';
 import type { Metadata } from 'next';
 
 interface ComboPageProps {
@@ -213,6 +215,14 @@ export default async function ComboPage({ params }: ComboPageProps) {
             </CardContent>
           </Card>
         </section>
+
+        {/* Long-Form Content (CONTENT-P1-001) */}
+        {combo.longForm && <ComboLongFormSection longForm={combo.longForm} />}
+
+        {/* Conversation Examples (CONTENT-P1-001) */}
+        {combo.conversationExamples && combo.conversationExamples.length > 0 && (
+          <ComboConversationExamplesSection examples={combo.conversationExamples} />
+        )}
 
         {/* Examples Section */}
         {combo.examples.length > 0 && (

--- a/src/app/emoji/[slug]/page.tsx
+++ b/src/app/emoji/[slug]/page.tsx
@@ -15,6 +15,8 @@ import { RelatedEmojisSection } from '@/components/emoji/related-emojis-section'
 import { EmojiCombosSection } from '@/components/emoji/emoji-combos-section';
 import { CategoryLink } from '@/components/emoji/category-link';
 import { PlatformIcon } from '@/components/emoji/platform-icon';
+import { EmojiLongFormSection } from '@/components/emoji/emoji-long-form-section';
+import { EmojiConversationExamplesSection } from '@/components/emoji/emoji-conversation-examples-section';
 import { ShareSection } from '@/components/share/share-section';
 import { CopySectionButton } from '@/components/ui/copy-section-button';
 import { ShareMeaningButton } from '@/components/share/share-meaning-button';
@@ -282,6 +284,9 @@ export default async function EmojiPage({ params }: EmojiPageProps) {
           </Card>
         </section>
 
+        {/* Long-form article sections (CONTENT-P1-001) — only render when present */}
+        {emoji.longForm && <EmojiLongFormSection longForm={emoji.longForm} />}
+
         {/* Context Meanings Section */}
         {emoji.contextMeanings.length > 0 && (
           <section className="mb-8">
@@ -372,6 +377,11 @@ export default async function EmojiPage({ params }: EmojiPageProps) {
               ))}
             </div>
           </section>
+        )}
+
+        {/* Conversation Examples (CONTENT-P1-001) */}
+        {emoji.conversationExamples && emoji.conversationExamples.length > 0 && (
+          <EmojiConversationExamplesSection examples={emoji.conversationExamples} />
         )}
 
         {/* Warnings Section */}

--- a/src/components/combo/combo-conversation-examples-section.tsx
+++ b/src/components/combo/combo-conversation-examples-section.tsx
@@ -1,0 +1,70 @@
+import { cn } from '@/lib/utils';
+import type { ComboConversationExample, ComboConversationSetting } from '@/types/combo';
+
+/**
+ * Props for the ComboConversationExamplesSection component
+ */
+export interface ComboConversationExamplesSectionProps {
+  /** Richer conversation examples from the combo data */
+  examples: ComboConversationExample[];
+  /** Optional extra classes */
+  className?: string;
+}
+
+/**
+ * Display label for each conversation setting.
+ */
+const SETTING_LABEL: Record<ComboConversationSetting, string> = {
+  dating: 'Dating',
+  friends: 'Friends',
+  work: 'Work',
+  family: 'Family',
+  social: 'Social',
+  other: 'Other',
+};
+
+/**
+ * ComboConversationExamplesSection renders the optional `conversationExamples`
+ * array as a card grid, with one card per setting so readers can scan
+ * vibe quickly.
+ */
+export function ComboConversationExamplesSection({
+  examples,
+  className,
+}: ComboConversationExamplesSectionProps) {
+  if (!Array.isArray(examples) || examples.length === 0) return null;
+
+  return (
+    <section
+      aria-labelledby="combo-conversation-examples-heading"
+      className={cn('my-8', className)}
+      data-testid="combo-conversation-examples-section"
+    >
+      <h2
+        id="combo-conversation-examples-heading"
+        className="text-xl font-semibold mb-4 text-gray-900 dark:text-gray-100"
+      >
+        Real Conversation Examples
+      </h2>
+      <div className="grid gap-4 md:grid-cols-2">
+        {examples.map((example, idx) => (
+          <article
+            key={idx}
+            className="rounded-2xl border bg-white/80 dark:bg-gray-800/60 border-gray-200 dark:border-gray-700/50 p-5 shadow-sm transition-all duration-300"
+            data-testid="combo-conversation-example"
+          >
+            <div className="text-xs font-medium uppercase tracking-wide text-blue-600 dark:text-blue-400 mb-2">
+              {SETTING_LABEL[example.setting] ?? example.setting}
+            </div>
+            <blockquote className="border-l-4 border-gray-200 dark:border-gray-700 pl-3 italic text-gray-900 dark:text-gray-100 mb-3">
+              &ldquo;{example.message}&rdquo;
+            </blockquote>
+            <p className="text-sm text-gray-700 dark:text-gray-300 leading-relaxed">
+              {example.interpretation}
+            </p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/combo/combo-long-form-section.tsx
+++ b/src/components/combo/combo-long-form-section.tsx
@@ -1,0 +1,25 @@
+import { LongFormSection, type LongFormContent } from '@/components/ui/long-form-section';
+import type { ComboLongForm } from '@/types/combo';
+
+/**
+ * Props for the ComboLongFormSection component.
+ */
+export interface ComboLongFormSectionProps {
+  /** Long-form content block from the combo data */
+  longForm: ComboLongForm;
+  /** Optional extra classes */
+  className?: string;
+}
+
+/**
+ * Thin wrapper that adapts the shared LongFormSection to the combo type.
+ */
+export function ComboLongFormSection({ longForm, className }: ComboLongFormSectionProps) {
+  return (
+    <LongFormSection
+      longForm={longForm as LongFormContent}
+      className={className}
+      testId="combo-long-form-section"
+    />
+  );
+}

--- a/src/components/emoji/emoji-conversation-examples-section.tsx
+++ b/src/components/emoji/emoji-conversation-examples-section.tsx
@@ -1,0 +1,70 @@
+import { cn } from '@/lib/utils';
+import type { ConversationExample, ConversationSetting } from '@/types/emoji';
+
+/**
+ * Props for the EmojiConversationExamplesSection component
+ */
+export interface EmojiConversationExamplesSectionProps {
+  /** Richer conversation examples from the emoji data */
+  examples: ConversationExample[];
+  /** Optional extra classes */
+  className?: string;
+}
+
+/**
+ * Display label for each conversation setting.
+ */
+const SETTING_LABEL: Record<ConversationSetting, string> = {
+  dating: 'Dating',
+  friends: 'Friends',
+  work: 'Work',
+  family: 'Family',
+  social: 'Social',
+  other: 'Other',
+};
+
+/**
+ * EmojiConversationExamplesSection renders the optional `conversationExamples`
+ * array as a card grid, with one card per setting so readers can scan
+ * vibe quickly.
+ */
+export function EmojiConversationExamplesSection({
+  examples,
+  className,
+}: EmojiConversationExamplesSectionProps) {
+  if (!Array.isArray(examples) || examples.length === 0) return null;
+
+  return (
+    <section
+      aria-labelledby="conversation-examples-heading"
+      className={cn('my-8', className)}
+      data-testid="emoji-conversation-examples-section"
+    >
+      <h2
+        id="conversation-examples-heading"
+        className="text-xl font-semibold mb-4 text-gray-900 dark:text-gray-100"
+      >
+        Real Conversation Examples
+      </h2>
+      <div className="grid gap-4 md:grid-cols-2">
+        {examples.map((example, idx) => (
+          <article
+            key={idx}
+            className="rounded-2xl border bg-white/80 dark:bg-gray-800/60 border-gray-200 dark:border-gray-700/50 p-5 shadow-sm transition-all duration-300"
+            data-testid="conversation-example"
+          >
+            <div className="text-xs font-medium uppercase tracking-wide text-blue-600 dark:text-blue-400 mb-2">
+              {SETTING_LABEL[example.setting] ?? example.setting}
+            </div>
+            <blockquote className="border-l-4 border-gray-200 dark:border-gray-700 pl-3 italic text-gray-900 dark:text-gray-100 mb-3">
+              &ldquo;{example.message}&rdquo;
+            </blockquote>
+            <p className="text-sm text-gray-700 dark:text-gray-300 leading-relaxed">
+              {example.interpretation}
+            </p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/emoji/emoji-long-form-section.tsx
+++ b/src/components/emoji/emoji-long-form-section.tsx
@@ -1,0 +1,116 @@
+import { cn } from '@/lib/utils';
+import type { EmojiLongForm } from '@/types/emoji';
+
+/**
+ * Props for the EmojiLongFormSection component
+ */
+export interface EmojiLongFormSectionProps {
+  /** Long-form content block from the emoji data */
+  longForm: EmojiLongForm;
+  /** Optional extra classes */
+  className?: string;
+}
+
+/**
+ * Split a multi-paragraph string into trimmed, non-empty paragraphs.
+ * Writers use blank lines (`\n\n`) as paragraph breaks.
+ */
+function splitParagraphs(text: string | undefined): string[] {
+  if (!text) return [];
+  return text
+    .split(/\n{2,}/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+}
+
+/**
+ * Render a labeled article section (heading + paragraphs).
+ */
+function ArticleBlock({
+  id,
+  heading,
+  paragraphs,
+}: {
+  id: string;
+  heading: string;
+  paragraphs: string[];
+}) {
+  if (paragraphs.length === 0) return null;
+  return (
+    <section aria-labelledby={`${id}-heading`} className="space-y-3">
+      <h2 id={`${id}-heading`} className="text-xl font-semibold text-gray-900 dark:text-gray-100">
+        {heading}
+      </h2>
+      <div className="space-y-3 text-gray-700 dark:text-gray-300 leading-relaxed">
+        {paragraphs.map((p, idx) => (
+          <p key={idx}>{p}</p>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+/**
+ * Render the FAQ block as a definition list — clear Q/A pairs without an
+ * accordion so they remain indexable and printable.
+ */
+function FaqBlock({ faqs }: { faqs: NonNullable<EmojiLongForm['faqs']> }) {
+  if (!Array.isArray(faqs) || faqs.length === 0) return null;
+  return (
+    <section aria-labelledby="faq-heading" className="space-y-4">
+      <h2 id="faq-heading" className="text-xl font-semibold text-gray-900 dark:text-gray-100">
+        Frequently Asked Questions
+      </h2>
+      <div className="space-y-4">
+        {faqs.map((faq, idx) => (
+          <div
+            key={idx}
+            className="border-l-4 border-blue-200 dark:border-blue-800 bg-blue-50/40 dark:bg-blue-950/30 rounded-r-lg p-4"
+          >
+            <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-2">{faq.question}</h3>
+            <p className="text-gray-700 dark:text-gray-300 leading-relaxed">{faq.answer}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+/**
+ * EmojiLongFormSection renders the optional article-style `longForm` block
+ * for an emoji page. Each sub-section is only rendered when its content is
+ * present so thin pages remain visually unchanged.
+ */
+export function EmojiLongFormSection({ longForm, className }: EmojiLongFormSectionProps) {
+  const overview = splitParagraphs(longForm.overview);
+  const howPeopleUseIt = splitParagraphs(longForm.howPeopleUseIt);
+  const whenNotToUse = splitParagraphs(longForm.whenNotToUse);
+  const howToReply = splitParagraphs(longForm.howToReply);
+  const faqs = Array.isArray(longForm.faqs) ? longForm.faqs : [];
+
+  const hasAnyContent =
+    overview.length > 0 ||
+    howPeopleUseIt.length > 0 ||
+    whenNotToUse.length > 0 ||
+    howToReply.length > 0 ||
+    faqs.length > 0;
+
+  if (!hasAnyContent) return null;
+
+  return (
+    <div
+      className={cn('my-10 space-y-8 prose prose-gray dark:prose-invert max-w-none', className)}
+      data-testid="emoji-long-form-section"
+    >
+      <ArticleBlock id="overview" heading="Overview" paragraphs={overview} />
+      <ArticleBlock
+        id="how-people-use-it"
+        heading="How People Use It"
+        paragraphs={howPeopleUseIt}
+      />
+      <ArticleBlock id="when-not-to-use" heading="When Not to Use It" paragraphs={whenNotToUse} />
+      <ArticleBlock id="how-to-reply" heading="How to Reply" paragraphs={howToReply} />
+      <FaqBlock faqs={faqs} />
+    </div>
+  );
+}

--- a/src/components/emoji/emoji-long-form-section.tsx
+++ b/src/components/emoji/emoji-long-form-section.tsx
@@ -1,8 +1,13 @@
-import { cn } from '@/lib/utils';
+import {
+  LongFormSection,
+  type LongFormContent,
+  type LongFormSectionProps,
+} from '@/components/ui/long-form-section';
 import type { EmojiLongForm } from '@/types/emoji';
 
 /**
- * Props for the EmojiLongFormSection component
+ * Props for the EmojiLongFormSection component.
+ * Aliased so consumers don't need to import from `@/types/emoji`.
  */
 export interface EmojiLongFormSectionProps {
   /** Long-form content block from the emoji data */
@@ -12,105 +17,19 @@ export interface EmojiLongFormSectionProps {
 }
 
 /**
- * Split a multi-paragraph string into trimmed, non-empty paragraphs.
- * Writers use blank lines (`\n\n`) as paragraph breaks.
- */
-function splitParagraphs(text: string | undefined): string[] {
-  if (!text) return [];
-  return text
-    .split(/\n{2,}/)
-    .map((p) => p.trim())
-    .filter((p) => p.length > 0);
-}
-
-/**
- * Render a labeled article section (heading + paragraphs).
- */
-function ArticleBlock({
-  id,
-  heading,
-  paragraphs,
-}: {
-  id: string;
-  heading: string;
-  paragraphs: string[];
-}) {
-  if (paragraphs.length === 0) return null;
-  return (
-    <section aria-labelledby={`${id}-heading`} className="space-y-3">
-      <h2 id={`${id}-heading`} className="text-xl font-semibold text-gray-900 dark:text-gray-100">
-        {heading}
-      </h2>
-      <div className="space-y-3 text-gray-700 dark:text-gray-300 leading-relaxed">
-        {paragraphs.map((p, idx) => (
-          <p key={idx}>{p}</p>
-        ))}
-      </div>
-    </section>
-  );
-}
-
-/**
- * Render the FAQ block as a definition list — clear Q/A pairs without an
- * accordion so they remain indexable and printable.
- */
-function FaqBlock({ faqs }: { faqs: NonNullable<EmojiLongForm['faqs']> }) {
-  if (!Array.isArray(faqs) || faqs.length === 0) return null;
-  return (
-    <section aria-labelledby="faq-heading" className="space-y-4">
-      <h2 id="faq-heading" className="text-xl font-semibold text-gray-900 dark:text-gray-100">
-        Frequently Asked Questions
-      </h2>
-      <div className="space-y-4">
-        {faqs.map((faq, idx) => (
-          <div
-            key={idx}
-            className="border-l-4 border-blue-200 dark:border-blue-800 bg-blue-50/40 dark:bg-blue-950/30 rounded-r-lg p-4"
-          >
-            <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-2">{faq.question}</h3>
-            <p className="text-gray-700 dark:text-gray-300 leading-relaxed">{faq.answer}</p>
-          </div>
-        ))}
-      </div>
-    </section>
-  );
-}
-
-/**
- * EmojiLongFormSection renders the optional article-style `longForm` block
- * for an emoji page. Each sub-section is only rendered when its content is
- * present so thin pages remain visually unchanged.
+ * Thin wrapper that adapts the shared LongFormSection to the emoji type and
+ * keeps the existing `data-testid="emoji-long-form-section"` contract for
+ * the page and snapshot tests.
  */
 export function EmojiLongFormSection({ longForm, className }: EmojiLongFormSectionProps) {
-  const overview = splitParagraphs(longForm.overview);
-  const howPeopleUseIt = splitParagraphs(longForm.howPeopleUseIt);
-  const whenNotToUse = splitParagraphs(longForm.whenNotToUse);
-  const howToReply = splitParagraphs(longForm.howToReply);
-  const faqs = Array.isArray(longForm.faqs) ? longForm.faqs : [];
-
-  const hasAnyContent =
-    overview.length > 0 ||
-    howPeopleUseIt.length > 0 ||
-    whenNotToUse.length > 0 ||
-    howToReply.length > 0 ||
-    faqs.length > 0;
-
-  if (!hasAnyContent) return null;
-
   return (
-    <div
-      className={cn('my-10 space-y-8 prose prose-gray dark:prose-invert max-w-none', className)}
-      data-testid="emoji-long-form-section"
-    >
-      <ArticleBlock id="overview" heading="Overview" paragraphs={overview} />
-      <ArticleBlock
-        id="how-people-use-it"
-        heading="How People Use It"
-        paragraphs={howPeopleUseIt}
-      />
-      <ArticleBlock id="when-not-to-use" heading="When Not to Use It" paragraphs={whenNotToUse} />
-      <ArticleBlock id="how-to-reply" heading="How to Reply" paragraphs={howToReply} />
-      <FaqBlock faqs={faqs} />
-    </div>
+    <LongFormSection
+      longForm={longForm as LongFormContent}
+      className={className}
+      testId="emoji-long-form-section"
+    />
   );
 }
+
+// Re-export shared types so existing callers keep working without churn.
+export type { LongFormSectionProps };

--- a/src/components/emoji/index.ts
+++ b/src/components/emoji/index.ts
@@ -22,6 +22,13 @@ export {
   type EmojiWarningExtended,
 } from './emoji-warnings';
 
+// Long-form content sections (CONTENT-P1-001)
+export { EmojiLongFormSection, type EmojiLongFormSectionProps } from './emoji-long-form-section';
+export {
+  EmojiConversationExamplesSection,
+  type EmojiConversationExamplesSectionProps,
+} from './emoji-conversation-examples-section';
+
 // Section components
 export {
   ContextMeaningsSection,

--- a/src/components/seo/combo-json-ld.tsx
+++ b/src/components/seo/combo-json-ld.tsx
@@ -3,6 +3,8 @@
  *
  * Generates Schema.org Article markup for rich snippets in search results.
  * Uses DefinedTerm to describe the emoji combo entity within the article.
+ * When the combo ships FAQs (CONTENT-P1-001), an additional FAQPage entity
+ * is emitted so search engines can pick up "People Also Ask" style answers.
  */
 
 import type { EmojiCombo } from '@/types/combo';
@@ -24,7 +26,33 @@ function capitalizeFirst(str: string): string {
 }
 
 /**
+ * Build an optional FAQPage entity when the combo has FAQs to expose.
+ * Returns `undefined` when there are no FAQs so the Article payload stays
+ * clean for thin pages.
+ */
+function buildFaqEntity(combo: EmojiCombo) {
+  const faqs = combo.longForm?.faqs;
+  if (!Array.isArray(faqs) || faqs.length === 0) return undefined;
+
+  return {
+    '@type': 'FAQPage',
+    mainEntity: faqs.map((faq) => ({
+      '@type': 'Question',
+      name: faq.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: faq.answer,
+      },
+    })),
+  };
+}
+
+/**
  * Generate JSON-LD structured data for a combo page
+ *
+ * Emits a single @graph with Article + (optional) FAQPage entries so
+ * search engines can pick up both the article metadata and any
+ * "People Also Ask" answers (CONTENT-P1-001).
  */
 function generateComboJsonLd(combo: EmojiCombo, appUrl: string, appName: string) {
   const pageUrl = `${appUrl}/combo/${combo.slug}`;
@@ -41,8 +69,7 @@ function generateComboJsonLd(combo: EmojiCombo, appUrl: string, appName: string)
     ...(combo.tags || []),
   ];
 
-  return {
-    '@context': 'https://schema.org',
+  const article = {
     '@type': 'Article',
     headline: `${combo.combo} ${combo.name} Combo Meaning`,
     description: combo.meaning,
@@ -67,6 +94,19 @@ function generateComboJsonLd(combo: EmojiCombo, appUrl: string, appName: string)
         name: 'Emoji Combinations',
       },
     },
+  };
+
+  const faqEntity = buildFaqEntity(combo);
+  if (faqEntity) {
+    return {
+      '@context': 'https://schema.org',
+      '@graph': [article, faqEntity],
+    };
+  }
+
+  return {
+    '@context': 'https://schema.org',
+    ...article,
   };
 }
 

--- a/src/components/seo/emoji-json-ld.tsx
+++ b/src/components/seo/emoji-json-ld.tsx
@@ -3,6 +3,8 @@
  *
  * Generates Schema.org Article markup for rich snippets in search results.
  * Uses DefinedTerm to describe the emoji entity within the article.
+ * When the emoji ships FAQs (CONTENT-P1-001), an additional FAQPage entity
+ * is emitted so search engines can pick up "People Also Ask" style answers.
  */
 
 import type { Emoji } from '@/types/emoji';
@@ -24,7 +26,33 @@ function capitalizeFirst(str: string): string {
 }
 
 /**
+ * Build an optional FAQPage entity when the emoji has FAQs to expose.
+ * Returns `undefined` when there are no FAQs so the Article payload stays
+ * clean for thin pages.
+ */
+function buildFaqEntity(emoji: Emoji) {
+  const faqs = emoji.longForm?.faqs;
+  if (!Array.isArray(faqs) || faqs.length === 0) return undefined;
+
+  return {
+    '@type': 'FAQPage',
+    mainEntity: faqs.map((faq) => ({
+      '@type': 'Question',
+      name: faq.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: faq.answer,
+      },
+    })),
+  };
+}
+
+/**
  * Generate JSON-LD structured data for an emoji page
+ *
+ * Emits a single @graph with Article + (optional) FAQPage entries so
+ * search engines can pick up both the article metadata and any
+ * "People Also Ask" answers (CONTENT-P1-001).
  */
 function generateEmojiJsonLd(emoji: Emoji, appUrl: string, appName: string) {
   const pageUrl = `${appUrl}/emoji/${emoji.slug}`;
@@ -41,8 +69,7 @@ function generateEmojiJsonLd(emoji: Emoji, appUrl: string, appName: string) {
     'emoji guide',
   ];
 
-  return {
-    '@context': 'https://schema.org',
+  const article = {
     '@type': 'Article',
     headline: `${emoji.character} ${emoji.name} Emoji Meaning`,
     description: emoji.tldr,
@@ -67,6 +94,19 @@ function generateEmojiJsonLd(emoji: Emoji, appUrl: string, appName: string) {
         name: 'Unicode Emoji',
       },
     },
+  };
+
+  const faqEntity = buildFaqEntity(emoji);
+  if (faqEntity) {
+    return {
+      '@context': 'https://schema.org',
+      '@graph': [article, faqEntity],
+    };
+  }
+
+  return {
+    '@context': 'https://schema.org',
+    ...article,
   };
 }
 

--- a/src/components/ui/long-form-section.tsx
+++ b/src/components/ui/long-form-section.tsx
@@ -1,0 +1,134 @@
+import { cn } from '@/lib/utils';
+
+/**
+ * The shared shape of the long-form block. Mirrors `EmojiLongForm` and
+ * `ComboLongForm` from the emoji/combo type modules so a single renderer
+ * can be used by both emoji and combo pages.
+ */
+export interface LongFormContent {
+  overview?: string;
+  howPeopleUseIt?: string;
+  whenNotToUse?: string;
+  howToReply?: string;
+  faqs?: Array<{ question: string; answer: string }>;
+}
+
+/**
+ * Props for the LongFormSection component
+ */
+export interface LongFormSectionProps {
+  /** Long-form content block (from emoji or combo data) */
+  longForm: LongFormContent;
+  /** Optional extra classes */
+  className?: string;
+  /** Optional testid override (defaults to `long-form-section`) */
+  testId?: string;
+}
+
+/**
+ * Split a multi-paragraph string into trimmed, non-empty paragraphs.
+ * Writers use blank lines (`\n\n`) as paragraph breaks.
+ */
+function splitParagraphs(text: string | undefined): string[] {
+  if (!text) return [];
+  return text
+    .split(/\n{2,}/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+}
+
+/**
+ * Render a labeled article section (heading + paragraphs).
+ */
+function ArticleBlock({
+  id,
+  heading,
+  paragraphs,
+}: {
+  id: string;
+  heading: string;
+  paragraphs: string[];
+}) {
+  if (paragraphs.length === 0) return null;
+  return (
+    <section aria-labelledby={`${id}-heading`} className="space-y-3">
+      <h2 id={`${id}-heading`} className="text-xl font-semibold text-gray-900 dark:text-gray-100">
+        {heading}
+      </h2>
+      <div className="space-y-3 text-gray-700 dark:text-gray-300 leading-relaxed">
+        {paragraphs.map((p, idx) => (
+          <p key={idx}>{p}</p>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+/**
+ * Render the FAQ block as a definition list — clear Q/A pairs without an
+ * accordion so they remain indexable and printable.
+ */
+function FaqBlock({ faqs }: { faqs: NonNullable<LongFormContent['faqs']> }) {
+  if (!Array.isArray(faqs) || faqs.length === 0) return null;
+  return (
+    <section aria-labelledby="faq-heading" className="space-y-4">
+      <h2 id="faq-heading" className="text-xl font-semibold text-gray-900 dark:text-gray-100">
+        Frequently Asked Questions
+      </h2>
+      <div className="space-y-4">
+        {faqs.map((faq, idx) => (
+          <div
+            key={idx}
+            className="border-l-4 border-blue-200 dark:border-blue-800 bg-blue-50/40 dark:bg-blue-950/30 rounded-r-lg p-4"
+          >
+            <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-2">{faq.question}</h3>
+            <p className="text-gray-700 dark:text-gray-300 leading-relaxed">{faq.answer}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+/**
+ * LongFormSection renders the optional article-style long-form block for
+ * either an emoji or a combo page. Each sub-section is only rendered when
+ * its content is present so thin pages remain visually unchanged.
+ */
+export function LongFormSection({
+  longForm,
+  className,
+  testId = 'long-form-section',
+}: LongFormSectionProps) {
+  const overview = splitParagraphs(longForm.overview);
+  const howPeopleUseIt = splitParagraphs(longForm.howPeopleUseIt);
+  const whenNotToUse = splitParagraphs(longForm.whenNotToUse);
+  const howToReply = splitParagraphs(longForm.howToReply);
+  const faqs = Array.isArray(longForm.faqs) ? longForm.faqs : [];
+
+  const hasAnyContent =
+    overview.length > 0 ||
+    howPeopleUseIt.length > 0 ||
+    whenNotToUse.length > 0 ||
+    howToReply.length > 0 ||
+    faqs.length > 0;
+
+  if (!hasAnyContent) return null;
+
+  return (
+    <div
+      className={cn('my-10 space-y-8 prose prose-gray dark:prose-invert max-w-none', className)}
+      data-testid={testId}
+    >
+      <ArticleBlock id="overview" heading="Overview" paragraphs={overview} />
+      <ArticleBlock
+        id="how-people-use-it"
+        heading="How People Use It"
+        paragraphs={howPeopleUseIt}
+      />
+      <ArticleBlock id="when-not-to-use" heading="When Not to Use It" paragraphs={whenNotToUse} />
+      <ArticleBlock id="how-to-reply" heading="How to Reply" paragraphs={howToReply} />
+      <FaqBlock faqs={faqs} />
+    </div>
+  );
+}

--- a/src/data/combos/100-fire.json
+++ b/src/data/combos/100-fire.json
@@ -11,5 +11,58 @@
   "seoDescription": "What does 💯🔥 mean? The 100 and fire emoji combo explained. Used to show something is absolutely perfect.",
   "relatedCombos": ["fire-100", "flexed-biceps-fire"],
   "tags": ["perfect", "impressive", "approval", "compliment", "slang"],
-  "popularity": 85
+  "popularity": 85,
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "💯🔥 is the maximum-possible approval reaction, the emoji combo that says 'this is perfect, full stop, no notes.' Stacking the 💯 (already a one-word 'real talk, this delivered') with 🔥 (already a one-word 'this is hot') produces a redundant high-five of approval that lands as the loudest validation on the keyboard. On TikTok, Twitter, and Instagram 💯🔥 shows up under clips, beats, and posts that the sender wants to mark as genuinely exceptional — and unlike its reverse-order sibling fire-100, the 100-first version reads slightly more emphatic because the 'real' signal lands before the 'hot.'\n\nThe combo also doubles as a way to react when neither emoji alone feels strong enough. A single 💯 reads as cool validation; a single 🔥 reads as hot. Putting them together amplifies both, and the redundancy is the point — the sender wants you to know the content earned the maximum possible reaction. Writers should treat 💯🔥 as the ceiling for casual approval and reserve it for moments that really do deserve it.",
+    "howPeopleUseIt": "💯🔥 arrives as the punchline on a compliment, the comment under a creator's video, or as the closer on a take the sender wants to crown. On TikTok creators paste 💯🔥 in their own captions as the visual tag for peak moments. On Twitter quote-tweets it functions as the 'this take won' reaction. And in stan Twitter, sports Twitter, and music commentary 💯🔥 is the standard unit of strong validation.\n\nThe combo pairs naturally with a bicep 💪 for 'this is strong' emphasis and with crown 👑 for 'this is elite.' It is rarely used in formal professional contexts because the slang energy is too performative, and a customer-support thread that replies with 💯🔥 will read as unhinged.",
+    "whenNotToUse": "Skip 💯🔥 in any context where the recipient may not read the slang — in older-family threads, in cold professional channels, or in formal client comms. A 💯🔥 in a customer complaint reply sounds as if you are enjoying the drama. Avoid it in workplace channels where the hyperbole will undercut the seriousness of the message.\n\nAlso avoid 💯🔥 when you want to deliver measured, specific feedback. A mentor who replies 'your work needs improvement 💯🔥' sounds as if they are mocking the attempt. Reach for words or a more neutral reaction when the moment warrants nuance rather than maximum approval.",
+    "howToReply": "Mirror 💯🔥 with another 💯🔥 or with 👑 if you want to keep the validation going, or upgrade with a sentence that explains what specifically landed. If you receive 💯🔥 on your own content, reply with 'thanks 💯🔥' or a sentence that acknowledges the strong reaction.\n\nIf 💯🔥 arrives as a strong take on something you shared, treat it as a high-water mark — content that collected a 💯🔥 reads as having broken the recipient. And if you want to send 💯🔥 as a friend or peer, anchor the combo with a sentence that names what specifically earned the reaction so it does not feel like generic hype.",
+    "faqs": [
+      {
+        "question": "What does 💯🔥 mean in texting?",
+        "answer": "💯🔥 means 'this is absolutely perfect.' The combo stacks 100 (real) with fire (hot) into the strongest possible approval reaction and reads as maximum validation."
+      },
+      {
+        "question": "Is 💯🔥 a compliment?",
+        "answer": "Yes, 💯🔥 reads as a strong compliment or approval signal. It marks the content as exceptional and is the casual ceiling for positive reaction."
+      },
+      {
+        "question": "What does 💯🔥 mean from a girl?",
+        "answer": "From a girl or anyone else, 💯🔥 means the sender thinks the content is perfect. There is no gendered meaning; the combo is about the strength of the reaction, not who is sending it."
+      },
+      {
+        "question": "What does 💯🔥 mean on TikTok?",
+        "answer": "On TikTok a single 💯🔥 in the comments means the viewer thinks the content is perfect. Creators often count the combo as a soft metric of how strong a video landed."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "that freestyle was insane 💯🔥",
+      "interpretation": "Strong approval on a friend's content. Mirror with 💯🔥 or 🔥 to match the hype."
+    },
+    {
+      "setting": "social",
+      "message": "this is the take we needed 💯🔥",
+      "interpretation": "Group chat agreement with a viral post. Mirror with 💯🔥 or 👑 to amplify."
+    },
+    {
+      "setting": "work",
+      "message": "the launch numbers 💯🔥",
+      "interpretation": "Team win in a tight channel. Mirror with 💯🔥 or 'great work' to acknowledge the team."
+    },
+    {
+      "setting": "dating",
+      "message": "that fit pic 🔥💯",
+      "interpretation": "Romantic or flirty compliment on a partner's photo. Mirror with a heart or a sentence that engages with the look."
+    },
+    {
+      "setting": "family",
+      "message": "you really got that promotion 💯🔥",
+      "interpretation": "Family pride in a milestone. Mirror with a sentence that celebrates the win."
+    }
+  ]
 }

--- a/src/data/combos/clap-back.json
+++ b/src/data/combos/clap-back.json
@@ -11,5 +11,58 @@
   "seoDescription": "What does 👏👏👏 mean? Multiple clapping emojis explained. Used for emphasis and clapbacks.",
   "relatedCombos": ["fire-100"],
   "tags": ["emphasis", "clapback", "important", "statement", "punctuation"],
-  "popularity": 82
+  "popularity": 82,
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "👏👏👏 is the multi-clap combo that turns a single 👏 reaction into a typed-out 'slow clap' or per-word emphasis. The pattern emerged as Black Twitter popularized the 'each-clap-one-word' style (THIS 👏 IS 👏 IMPORTANT 👏) and became a recognizable shorthand for both supportive emphasis and pointed clapbacks. The same three claps can read as enthusiastic applause for a friend or as a slow, sarcastic clap aimed at someone being ridiculous, and the difference is almost entirely in the surrounding text.\n\nThe combo is one of the few emoji patterns that genuinely changes tone by punctuation and context. A trio of claps under a graduation photo reads as celebration; the same trio under a politician's gaffe reads as mockery. Writers should default to the per-word style for emphasis and the slow-clap style for sarcasm, and always pair the combo with text so the tone is unambiguous.",
+    "howPeopleUseIt": "👏👏👏 arrives in three patterns: as a per-word emphasis (THIS 👏 POINT 👏 MATTERS), as a slow sarcastic clap aimed at a bad take, and as enthusiastic applause under a win announcement. The per-word style is the most common on Twitter and TikTok, where users break sentences into claps for emphasis the way a speaker would tap the podium. The slow-clap style is the clapback — used when someone says something so absurd the only appropriate response is ironic applause.\n\nIn group chats 👏👏👏 functions as a punctuation mark. A friend lands a good joke and you reply 👏👏👏 to mark the moment. A friend drops a hot take and you reply 👏👏👏 to cosign it. The combo pairs naturally with 🔥💯 for the maximum hype and with 💀 for 'this is so absurd the only response is applause.' It is rarely used in professional channels because the energy is too performative, but inside friendly teams the combo reads as warm support.",
+    "whenNotToUse": "Skip 👏👏👏 in any context where sarcasm could be misread as sincere, or where sincere emphasis could be misread as sarcasm. The combo is ambiguous on its own, and using it without clear text can leave the recipient unsure whether you are celebrating or mocking them. Avoid it in customer-facing complaint threads — the slow-clap read will land as gloating regardless of intent.\n\nAlso avoid using 👏👏👏 as the only response to a serious disclosure. A person shares something painful and you reply with the clap combo, the per-word style reads as performative and the slow-clap style reads as mockery. Reach for a heart or a plain sentence instead, and save the claps for moments that warrant the energy.",
+    "howToReply": "Mirror 👏👏👏 with another 👏👏👏 if you want to keep the emphasis, or upgrade to 🔥💯 for maximum hype. If you want to acknowledge a clapback without escalating, you can reply with 😂 or 'okay fair' to take the L gracefully. The combo is a conversation-closer, so most replies either match it or pivot to the next beat.\n\nIf you receive 👏👏👏 and you are not sure whether it is sincere or sarcastic, glance at the surrounding text — per-word emphasis is almost always sincere, while slow claps arrive with phrases like 'congratulations' or 'wow' that tip the tone. When in doubt, you can ask 'sincerely or sarcastically?' and most people will clarify.",
+    "faqs": [
+      {
+        "question": "What does 👏👏👏 mean?",
+        "answer": "👏👏👏 means emphatic applause — either as per-word emphasis on a point (THIS 👏 IS 👏 IMPORTANT) or as a slow sarcastic clap aimed at a bad take. The surrounding text usually clarifies the tone."
+      },
+      {
+        "question": "Is 👏👏👏 rude?",
+        "answer": "👏👏👏 can read as rude when used as a slow sarcastic clap at someone's expense. As per-word emphasis on a real point it is supportive, and as applause under a win it is celebratory."
+      },
+      {
+        "question": "What does 👏👏👏 mean from a girl?",
+        "answer": "From a girl or anyone else, 👏👏👏 has the same meaning it has from anyone else: emphasis or applause. There is no gendered meaning; the tone is driven by the surrounding text."
+      },
+      {
+        "question": "What does 👏👏👏 mean on Twitter?",
+        "answer": "On Twitter 👏👏👏 is the standard clapback pattern. It can be per-word emphasis on a take, slow sarcasm at a bad take, or enthusiastic applause under a viral moment."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "she really said that in front of the whole team 👏👏👏",
+      "interpretation": "Group chat applause for a bold statement. Mirror with another 👏👏👏 or a sentence about the moment."
+    },
+    {
+      "setting": "social",
+      "message": "CEO: 'we're like a family here' 👏👏👏",
+      "interpretation": "Quote-tweet sarcasm. Slow clap aimed at a tone-deaf statement; usually paired with a sentence to land the joke."
+    },
+    {
+      "setting": "work",
+      "message": "FINALLY 👏👏👏 shipped",
+      "interpretation": "Team celebration of a launch. Safe in a tight team channel; tone down for cross-org comms."
+    },
+    {
+      "setting": "dating",
+      "message": "you remembered the restaurant 👏👏👏",
+      "interpretation": "Playful emphasis on a sweet gesture. Mirror with a softer reaction or a follow-up sentence."
+    },
+    {
+      "setting": "family",
+      "message": "Dad finally learned how to use the printer 👏👏👏",
+      "interpretation": "Family group applause for a small win. Mirror with another 👏👏👏 or a supportive sentence."
+    }
+  ]
 }

--- a/src/data/combos/clown-face.json
+++ b/src/data/combos/clown-face.json
@@ -15,5 +15,58 @@
   "seoDescription": "What does 🤡 mean when used alone? The clown emoji explained. Often used for self-deprecating humor about bad decisions.",
   "relatedCombos": ["skull-laughing"],
   "tags": ["self-deprecating", "foolish", "humor", "roast", "relatable"],
-  "popularity": 90
+  "popularity": 90,
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "🤡 is the universal sign that the sender knows they did something dumb — the clown emoji that has become Gen Z's default self-roast reaction. Posted after a regrettable text, a bad decision, or a plan that fell apart, the 🤡 lets the sender admit the foolishness without having to type out a paragraph of self-pity. On Twitter and TikTok the emoji shows up under confession-style tweets and self-deprecating memes; in group chats it lands as the wry closer on a 'I knew better but did it anyway' story.\n\nThe 🤡 also doubles as a soft redirect toward someone else's bad call — 'you really thought that would work? 🤡' — though the self-directed reading is the most common. It has very little ironic distance; the clown always means the clown, which is why it stays a relatable humor emoji rather than a dismissive insult. Writers should reach for 🤡 when the moment genuinely warrants admitting a mistake, because overusing it begins to undercut the self-aware beat the emoji is built around.",
+    "howPeopleUseIt": "🤡 arrives as the closer on a self-deprecating tweet, the reaction to one's own bad take, or the punchline on a 'I cannot believe I did that' story. On Twitter it shows up under confession threads and 'me at 3am' memes as the visual tag for dumb decisions. On TikTok creators paste 🤡 onto voiceover clips about regrettable choices as the signature self-roast.\n\nIn group chats 🤡 works as the acknowledging emoji after sending a message that lands badly. Friend says something silly and you reply with 🤡 as the 'I see what I did there' tag. The emoji pairs naturally with skull (💀🤡) for max foolishness, with 😭 for crying-laugh emphasis, and alone when the moment only needs the clown beat.",
+    "whenNotToUse": "Skip 🤡 when calling out someone else for a bad decision — the self-directed reading is so strong that throwing 🤡 at another person reads as bullying rather than humor. If the joke is about a friend's mistake, use a softer reaction or write the tease out as text rather than dropping a clown emoji on their comment.\n\nAlso avoid 🤡 in serious discussions where you actually need to deliver criticism. A manager who replies to a missed deadline with 🤡 sounds as if they are mocking the employee rather than addressing the work. Reach for words or a neutral emoji when the message needs to land as a real correction.",
+    "howToReply": "Mirror 🤡 with another 🤡 or with 😭 if you want to keep the self-roast energy going, or upgrade to 💀 if the moment is more 'I'm dead' than 'I'm a fool.' If someone sends 🤡 to you about a mistake you made, a matching 🤡 or 'fair point' acknowledges the joke without escalating.\n\nIf 🤡 arrives on your own post as a self-roast, mirror with a sentence that confirms the regret so the bit lands cleanly. And if you want to send 🤡 as a soft tease on someone else's bad call, pair it with a sentence that anchors the humor so the clown does not feel pointed.",
+    "faqs": [
+      {
+        "question": "What does 🤡 mean in texting?",
+        "answer": "🤡 means the sender acknowledges being foolish or making a bad call. It is the universal self-roast reaction for regrettable decisions, bad takes, or plans that fell apart."
+      },
+      {
+        "question": "Is 🤡 an insult?",
+        "answer": "🤡 is usually self-directed, not insulting. Posted by the sender about their own behavior it reads as self-aware humor. Posted at someone else it can read as dismissive or mocking, so context matters."
+      },
+      {
+        "question": "What does 🤡 mean from a girl?",
+        "answer": "From a girl or anyone else, 🤡 means the sender is calling themselves out for a foolish moment. There is no gendered meaning; the emoji is about the self-roast, not who is sending it."
+      },
+      {
+        "question": "What does 🤡 mean on Twitter?",
+        "answer": "On Twitter 🤡 shows up under self-deprecating tweets, bad-take apologies, and confession-style posts. It marks the moment the sender admits the decision was clown-level."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "i actually texted him back 🤡",
+      "interpretation": "Friend admitting a regrettable contact. Mirror with 🤡 or 😭 to keep the self-roast energy going."
+    },
+    {
+      "setting": "social",
+      "message": "me thinking i could fix it myself 🤡",
+      "interpretation": "Self-deprecating tweet about a failed plan. Mirror with 🤡 or 💀 to acknowledge the clown beat."
+    },
+    {
+      "setting": "dating",
+      "message": "wait she actually replied yes 🤡",
+      "interpretation": "Self-roast disbelief at good news. Mirror with a softer reaction or a sentence that matches the surprise."
+    },
+    {
+      "setting": "family",
+      "message": "mom caught me in the lie 🤡",
+      "interpretation": "Family group laughter at getting caught. Mirror with 🤡 or 'deserved honestly' to engage."
+    },
+    {
+      "setting": "work",
+      "message": "i really thought the deploy would hold 🤡",
+      "interpretation": "Risky in a wide team channel; safe in a tight collaborator DM. If used in a team channel, anchor with a sentence that adds context."
+    }
+  ]
 }

--- a/src/data/combos/double-hearts.json
+++ b/src/data/combos/double-hearts.json
@@ -11,5 +11,58 @@
   "seoDescription": "What does ❤️❤️ mean? Double heart emoji explained. Used to express extra love and affection.",
   "relatedCombos": ["heart-eyes", "two-hearts-sparkles"],
   "tags": ["love", "affection", "hearts", "emphasis", "caring"],
-  "popularity": 82
+  "popularity": 82,
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "❤️❤️ is the simple love-emphasis reaction — two red hearts stacked as the visual shorthand for 'extra love, on purpose.' Where a single ❤️ already reads as sincere affection, the doubled version pushes it past polite into 'I really mean it.' On Instagram captions, TikTok edits, and dating-app conversations ❤️❤️ shows up wherever the sender wants to mark a moment as loving rather than just warm. The combo also functions as a stacked reaction under posts that already collect ❤️, creating the visual effect of overflowing with affection.\n\nThe combo reads more intense than a single ❤️ but lighter than 💕, which carries the cute couple-post energy. ❤️❤️ stays sincere on both romantic and platonic readings, which makes it one of the most versatile love combos on the emoji keyboard. Reserve it for moments that genuinely warrant the extra emphasis, because stacking hearts on every message begins to undercut the sincerity the combo is built around.",
+    "howPeopleUseIt": "❤️❤️ arrives as the closer on a romantic message, the caption on a couple's post, or as the punchline reaction on a sincere appreciation. On Instagram captions ❤️❤️ shows up under anniversary posts, milestone announcements, and family moments as the warm-and-sincere signature. On Twitter the combo lands as the red-heart double-tap on a public post the sender wants to mark as loved.\n\nIn dating-app conversations ❤️❤️ works as the 'I really mean it' reaction — 'good morning ❤️❤️' or 'thinking about you ❤️❤️' — that pushes the message past the casual stage. The combo pairs naturally with 💕 for layered affection and with 🥰 for warmth. It is rare to see ❤️❤️ in work channels; the warmth is too personal for most professional reading.",
+    "whenNotToUse": "Skip ❤️❤️ in cold work channels or customer-facing comms where the romantic reading would feel mismatched. A ❤️❤️ in a customer complaint reply sounds unprofessional and tone deaf. Avoid it in first-contact dating messages where the rapport has not been established — the combo is sincere, so leading with it can feel heavy.\n\nAlso avoid ❤️❤️ in serious discussions about a relationship breaking down. The combo celebrates love, so using it during a fight or a hard conversation will land as cruel or dismissive. Match the emoji to the emotional register of the moment.",
+    "howToReply": "Mirror ❤️❤️ with another ❤️❤️ if you want to keep the warmth going, or upgrade to 🥰 for extra softness. If you receive ❤️❤️ from a romantic partner, a short 'love you too ❤️❤️' or a heart emoji closes the loop warmly.\n\nIf ❤️❤️ arrives on a parent or friend's post, mirror with a single ❤️ or 'thanks ❤️' so the warmth stays without doubling it. And if you want to send ❤️❤️ as a friend, anchor the combo with a sentence that lands the affection so the hearts do not feel like a romantic escalation.",
+    "faqs": [
+      {
+        "question": "What does ❤️❤️ mean in texting?",
+        "answer": "❤️❤️ means 'extra love, on purpose.' The combo doubles the heart to push past casual affection into 'I really mean it,' and reads as sincere across romantic and platonic relationships."
+      },
+      {
+        "question": "Is ❤️❤️ flirty?",
+        "answer": "❤️❤️ can read as flirty in a dating context, especially paired with romantic content. In family and friendship contexts it stays in the sincere affection zone."
+      },
+      {
+        "question": "What does ❤️❤️ mean from a girl?",
+        "answer": "From a girl or anyone else, ❤️❤️ means the sender is sending extra love or emphasis. There is no gendered meaning; the combo is about the warmth, not who is sending it."
+      },
+      {
+        "question": "What does ❤️❤️ mean from a guy?",
+        "answer": "From a guy, ❤️❤️ has the same meaning it has from anyone else: sincere love or strong affection. The combo is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "dating",
+      "message": "love you so much ❤️❤️",
+      "interpretation": "Romantic partner's warm message. Mirror with ❤️❤️ or 'love you too' to keep the warmth going."
+    },
+    {
+      "setting": "family",
+      "message": "love you both ❤️❤️",
+      "interpretation": "Family warmth to parents or siblings. Mirror with ❤️ or 'love you too' to close the loop."
+    },
+    {
+      "setting": "friends",
+      "message": "best friends forever ❤️❤️",
+      "interpretation": "Platonic friendship post. Mirror with ❤️❤️ or 'love you too' to celebrate the friendship."
+    },
+    {
+      "setting": "social",
+      "message": "your dog is so cute ❤️❤️",
+      "interpretation": "Friendly comment on a creator's content. Mirror with a heart or 'thanks' to engage."
+    },
+    {
+      "setting": "work",
+      "message": "thanks for the handoff ❤️❤️",
+      "interpretation": "Risky in a wide team channel; safe in a tight collaborator DM. If used in a team channel, anchor with a sentence that adds context."
+    }
+  ]
 }

--- a/src/data/combos/eggplant-peach.json
+++ b/src/data/combos/eggplant-peach.json
@@ -11,5 +11,58 @@
   "seoDescription": "What does 🍆🍑 mean? The eggplant and peach emoji combo explained. A suggestive pairing used in flirty contexts.",
   "relatedCombos": ["smirk-devil"],
   "tags": ["suggestive", "flirty", "intimate", "dating", "adult"],
-  "popularity": 92
+  "popularity": 92,
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "🍆🍑 is the most universally suggestive combination on the emoji keyboard — the pairing of eggplant and peach that almost every internet user recognizes as a stand-in for sexual content. Both emojis have lost most of their literal meaning in modern texting because each one carries a slang reading so widely known that the visual metaphor has drifted far from its Unicode definition. Stacked together they form a tidy shorthand that lets the sender imply without stating.\n\nThe combo reads more aggressively than either emoji alone. A solitary 🍆 has plausible deniability — it can be about dinner. 🍑 still gets read as food in many contexts. But pairing the two collapses the ambiguity: anyone who has ever spent five minutes on TikTok or Twitter knows what the sender is implying. Because of that, 🍆🍑 is the rare combo that travels well across age groups and platforms, even when older users do not use the keyboard the same way.",
+    "howPeopleUseIt": "🍆🍑 arrives as the punchline on a flirty message, the comment on a spicy photo, or as a reaction to something the sender wants to mark as adult. On TikTok and Twitter the combo shows up under thirst traps and celebrity thirst edits; on Instagram it lands as the bolder compliment on fitness or fashion content. In dating-app conversations it functions as the explicit closer, the emoji equivalent of typing 'come over.'\n\nIn group chats 🍆🍑 doubles as the universal 'we are all adults here' reaction when a conversation turns risqué. It also pairs naturally with 😈 for max heat, with 🥵 for emphasis, and with 👀🍑 for the teaser version. The combo is rarely used in workplace channels or family threads; the suggestion is too overt for safe professional reading.",
+    "whenNotToUse": "Skip 🍆🍑 in any context where the recipient has not opted into the flirtatious reading — in work channels, in support replies, in family group chats, or in customer comms. A 🍆🍑 in a customer-facing complaint thread will sound predatory and is a fast way to lose trust. Avoid it in first-contact dating messages where the rapport has not been established; the combo is too forward when you do not yet know if the other person is on the same page.\n\nAlso avoid 🍆🍑 when you do not want to be perceived as overtly sexual. The suggestion is so widely recognized that using the combo by accident in a food thread will derail the conversation. If your reference is genuinely about eggplant parmesan, 🍆 alone is enough — and even then prefer a word.",
+    "howToReply": "Mirror 🍆🍑 with another 🍆🍑 or with 🔥 or 😈 if you want to keep the heat going, or upgrade to 🥵 for emphasis. If you receive the combo and the flirtation is welcome, a heart, a 🔥, or a suggestive sentence closes the loop in matching energy.\n\nIf 🍆🍑 lands and the energy is not welcome, a 😐 or 🙄 sends a clear 'we are done here' signal without a paragraph. And if you want to tease someone about overuse of the combo, a 🍆/🍑 side-by-side reference or 'real original' lands the joke without escalating.",
+    "faqs": [
+      {
+        "question": "What does 🍆🍑 mean in texting?",
+        "answer": "🍆🍑 means the sender is being sexually suggestive or flirtatious. Both emoji carry slang readings, and pairing them together removes any plausible deniability about the intent."
+      },
+      {
+        "question": "Is 🍆🍑 flirty?",
+        "answer": "Yes. 🍆🍑 is one of the most flirty emoji combos on the keyboard. It reads as suggestive regardless of the surrounding message and is treated as the explicit shorthand for sexual content."
+      },
+      {
+        "question": "What does 🍆🍑 mean from a girl?",
+        "answer": "From a girl or anyone else, 🍆🍑 means the sender is signaling sexual interest or teasing. There is no gendered meaning; the combo is about the heat, not who is sending it."
+      },
+      {
+        "question": "What does 🍆🍑 mean from a guy?",
+        "answer": "From a guy, 🍆🍑 has the same meaning it has from anyone else: suggestive or sexually teasing content. The combo is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "dating",
+      "message": "later tonight? 🍆🍑",
+      "interpretation": "Explicit invite in a flirty dating conversation. Mirror with 🍆🍑 or a suggestive sentence if the energy is mutual; close the loop politely if it is not."
+    },
+    {
+      "setting": "social",
+      "message": "she really said that on main 🍆🍑",
+      "interpretation": "Group chat reaction to an unexpectedly bold public post. Mirror with 🍆🍑 or 😈 to match the heat."
+    },
+    {
+      "setting": "friends",
+      "message": "bro that DM was wild 🍆🍑",
+      "interpretation": "Friend flagging an explicit message they received. Mirror with 🍆🍑 or 🔥 to engage with the joke."
+    },
+    {
+      "setting": "family",
+      "message": "dad just discovered the eggplant 🍆🍑",
+      "interpretation": "Family group laughter at an older relative learning the slang. Mirror with 😬 or a sentence that lands the joke gently."
+    },
+    {
+      "setting": "work",
+      "message": "this design review went sideways 🍆🍑",
+      "interpretation": "Risky in a workplace context; the slang reading will land first. Replace with a safer reaction like 😬 or 🙃 in shared channels."
+    }
+  ]
 }

--- a/src/data/combos/eyes-tea.json
+++ b/src/data/combos/eyes-tea.json
@@ -15,5 +15,58 @@
   "seoDescription": "What does 👀🍵 mean? The eyes and tea emoji combo explained. Used when observing drama without getting involved.",
   "relatedCombos": ["eyes-lips-eyes", "thinking-eyes"],
   "tags": ["tea", "gossip", "drama", "observing", "unbothered"],
-  "popularity": 83
+  "popularity": 83,
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "👀🍵 is the universal 'I am watching, but staying out of it' reaction — eyes stacked with tea as the visual shorthand for an observer sipping tea while drama unfolds. The combo lands as amused non-involvement: the sender sees the chaos, sees it getting good, and is content to watch without contributing. On Twitter, TikTok, and Instagram 👀🍵 shows up in comment sections, quote-tweets, and group chats wherever a story is escalating and the sender wants to mark themselves as a spectator rather than a participant.\n\nThe combo also doubles as a soft request for context — '👀🍵 explain?' reads as 'I am watching and would like the story.' The dual reading — passive observer or engaged-bystander — makes 👀🍵 one of the most versatile meta-reaction combos on the keyboard. Reserve it for moments that genuinely warrant the amused-observer beat, because overusing it begins to feel performatively unbothered.",
+    "howPeopleUseIt": "👀🍵 arrives as a quote-tweet reaction to public drama, the comment on a spiraling thread, or as the in-group signal that the sender is paying attention without weighing in. On Twitter quote-tweets 👀🍵 marks a take as worth following without the sender having to add their own commentary. On TikTok the combo shows up in comment sections under messy public feuds as the 'I am here for this' reaction.\n\nIn group chats 👀🍵 works as the engaged-observer emoji when a friend begins telling a story the sender knows is juicy. The combo pairs naturally with popcorn 🍿 for the literal 'grab a snack' beat and with monkey-see 🙈 for the playful 'do not blame me' angle. Stand-alone 👀🍵 reads as sipping tea; in a thread it lands as part of the moment.",
+    "whenNotToUse": "Skip 👀🍵 in any context where the recipient may want actual support — when a friend shares bad news, in serious personal conversations, or in support threads. A 👀🍵 under a friend's breakup post reads as gossiping about their pain rather than standing with them. Avoid it in workplace channels where the meta-observer angle may undercut a serious conversation.\n\nAlso avoid 👀🍵 when you actually have useful input to add. A 👀🍵 reply on a thread where you have context that would help reads as lazy. Reach for a sentence that contributes rather than a combo that observes.",
+    "howToReply": "Mirror 👀🍵 with another 👀🍵 if you want to keep the observer energy going, or upgrade with 🍿 for the snack angle. If you receive 👀🍵 as a sign someone is waiting for context, deliver the story with a sentence that lands the drama so the bit keeps moving.\n\nIf 👀🍵 arrives on a thread you posted, treat it as a sign that people are watching and decide whether to keep adding the receipts. And if you want to send 👀🍵 as a flirty observer signal, anchor it with a sentence that lands the tone so the meta-observer energy does not feel pointed.",
+    "faqs": [
+      {
+        "question": "What does 👀🍵 mean in texting?",
+        "answer": "👀🍵 means 'I am watching and staying out of it.' The combo marks the sender as an amused observer of drama — they see the chaos and are content to sip tea without getting involved."
+      },
+      {
+        "question": "Is 👀🍵 gossiping?",
+        "answer": "👀🍵 sits on the edge of gossiping — it acknowledges the drama without contributing to it. The 'I am just watching' framing lets the sender be part of the moment without spreading the story."
+      },
+      {
+        "question": "What does 👀🍵 mean from a girl?",
+        "answer": "From a girl or anyone else, 👀🍵 means the sender is observing and staying unbothered. There is no gendered meaning; the combo is about the spectator angle, not who is sending it."
+      },
+      {
+        "question": "What does 👀🍵 mean on Twitter?",
+        "answer": "On Twitter 👀🍵 in a quote-tweet means the sender is watching the drama unfold. It is the casual 'this is getting good, I want to see where it goes' reaction."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "ok so they actually showed up 👀🍵",
+      "interpretation": "Friend flagging a juicy moment. Mirror with 👀🍵 or 🍿 to keep the observer energy going."
+    },
+    {
+      "setting": "social",
+      "message": "quote-tweeting the company statement 👀🍵",
+      "interpretation": "Public amused-observer reaction. Mirror with 👀🍵 or a sentence that adds to the bit."
+    },
+    {
+      "setting": "work",
+      "message": "the all-hands just got real 👀🍵",
+      "interpretation": "Risky in a wide team channel; safer in a tight collaborator DM. If used in a team channel, anchor with a sentence that adds context."
+    },
+    {
+      "setting": "dating",
+      "message": "so her reply was… 👀🍵",
+      "interpretation": "Friend waiting for the dramatic update. Mirror with 👀🍵 or 'go on' to keep the story flowing."
+    },
+    {
+      "setting": "family",
+      "message": "grandma saw the whole thing 👀🍵",
+      "interpretation": "Family group laughter at a story. Mirror with 👀🍵 or a sentence that engages with the moment."
+    }
+  ]
 }

--- a/src/data/combos/fire-100.json
+++ b/src/data/combos/fire-100.json
@@ -11,5 +11,58 @@
   "seoDescription": "What does 🔥💯 mean? The fire and 100 emoji combo explained. Used to show something is absolutely perfect and impressive.",
   "relatedCombos": ["skull-laughing"],
   "tags": ["approval", "perfect", "impressive", "compliment", "slang"],
-  "popularity": 85
+  "popularity": 85,
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "🔥💯 is the maximum hype combo on social media — fire for 'this is hot' and the 100 for 'this is flawless,' stacked together as a single double-emphasis reaction. On TikTok, Instagram, and Twitter the combo reads as 'this is excellent and I am one hundred percent sure of it,' which is why it shows up under album drops, fit pics, dunk highlights, hot takes, and restaurant reviews where the sender wants to remove any doubt. The combo also functions as the cleanest possible compliment emoji because both halves are positive and the redundancy makes it impossible to misread.\n\nThe combo has aged well because neither emoji has gone through a major slang stigma shift. 🔥💯 in 2026 reads almost the same as it did in 2019, which is rare for emoji culture. The only meaningful risk is that some Boomer or Gen X recipients may still read the 100 as a literal score rather than slang, so the combo tilts younger in its default audience. Writers should reserve 🔥💯 for content that genuinely deserves maximum hype, because the combo has become so common that using it casually can read as performative rather than sincere.",
+    "howPeopleUseIt": "🔥💯 arrives as a stand-alone comment, stacked under a screenshot, or pasted onto a creator's video as a self-applied hype sticker. TikTok comments spam it under dance clips and music releases; Instagram uses it on fit pics and food shots; Twitter stacks it on hot takes as a one-word cosign. The combo also works as a self-applied label — creators paste 🔥💯 onto their own posts the way they might write 'no cap' on a story.\n\nIn group chats 🔥💯 closes a debate with 'facts, end of story' energy. A friend shares a wild take and you reply 🔥💯 to mark the conversation as resolved. The combo pairs naturally with 💯 alone, with 🔥 alone, and with 🔥💯 stacked twice (🔥💯🔥💯) for the truly unhinged moments. It is also the standard reaction to a win — a friend announces a job offer, a relationship milestone, or a personal record, and the chat lights up with 🔥💯.",
+    "whenNotToUse": "Skip 🔥💯 in any context where literal fire, burns, or disaster relief is the topic, because the slang reading will sound flippant. Avoid it in serious professional emails about risk, safety incidents, or insurance. And do not stack 🔥💯 on criticism you are trying to soften — 'the deck was mid 🔥💯' sounds dismissive rather than friendly.\n\nAlso avoid 🔥💯 in cross-cultural business communication, where the slang has not spread evenly. A pitch deck or RFP that closes with 🔥💯 will read as unprofessional to international clients. And in customer-facing complaint threads, the combo comes across as gloating — reach for 'thanks for flagging this' instead.",
+    "howToReply": "Mirror 🔥💯 with another 🔥💯 if you want to keep the energy, or upgrade to a longer sentence like 'this is genuinely the best thing I've seen all week' to land as more sincere. A single 🔥 or 💯 alone also works as a softer agreement if you want to register support without the maximum hype energy.\n\nIf you receive 🔥💯 on your own post, treat it as a win and resist the urge to explain or downplay it. A short 'appreciate it 🔥💯' or a thank-you message closes the loop without sounding try-hard. If you suspect someone sent 🔥💯 sarcastically, glance at the surrounding message — sarcastic 🔥💯 usually arrives with 'sure' or 'okay' that tips the tone.",
+    "faqs": [
+      {
+        "question": "What does 🔥💯 mean?",
+        "answer": "🔥💯 means something is excellent and flawless — the maximum possible hype reaction. The fire adds 'this is hot' and the 100 adds 'this is one hundred percent perfect.'"
+      },
+      {
+        "question": "Is 🔥💯 flirty?",
+        "answer": "🔥💯 is not inherently flirty. It is a hype and approval reaction. On a dating-app opener or a selfie comment it can read as flirtatious, but in a group chat it is just agreement."
+      },
+      {
+        "question": "What does 🔥💯 mean from a girl?",
+        "answer": "From a girl, 🔥💯 means the same thing it means from anyone else: maximum approval. There is no gendered meaning; the combo is about content quality, not who is sending it."
+      },
+      {
+        "question": "What does 🔥💯 mean on TikTok?",
+        "answer": "On TikTok 🔥💯 means the viewer thinks the content is flawless. Creators paste it on their own videos as a self-applied hype sticker before posting."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "she dropped the album at midnight 🔥💯",
+      "interpretation": "Shared hype about a music release. Mirror with another 🔥💯 or a follow-up sentence about a favorite track."
+    },
+    {
+      "setting": "dating",
+      "message": "first date outfit is on 🔥💯",
+      "interpretation": "Self-applied hype before a date. Reply with a compliment or a confidence boost rather than mirroring the combo."
+    },
+    {
+      "setting": "work",
+      "message": "shipped the feature on time 🔥💯",
+      "interpretation": "Team hype about a launch. Safe in a tight team channel; tone down for cross-company comms."
+    },
+    {
+      "setting": "social",
+      "message": "this restaurant was actually insane 🔥💯",
+      "interpretation": "Real-time food review. A flame back or a sentence about the dish keeps the thread moving."
+    },
+    {
+      "setting": "family",
+      "message": "Dad cooked the turkey to perfection 🔥💯",
+      "interpretation": "Likely literal — family bragging about a holiday cook. Reply with a celebratory message rather than just a hype combo."
+    }
+  ]
 }

--- a/src/data/combos/fire-heart.json
+++ b/src/data/combos/fire-heart.json
@@ -11,5 +11,58 @@
   "seoDescription": "What does 🔥❤️ mean? The fire and heart emoji combo explained. Used to express passionate, intense love.",
   "relatedCombos": ["sparkles-heart-sparkles", "two-hearts-sparkles"],
   "tags": ["love", "passion", "romance", "attraction", "intense"],
-  "popularity": 85
+  "popularity": 85,
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "🔥❤️ is the emoji combo that says 'this love is hot' — fire amplifying the heart into something hotter than a single ❤️ can deliver. Where the red heart alone reads as sincere romance, the 🔥 in front reads as passionate attraction, the difference between 'I love you' and 'I am on fire about you.' On Instagram captions, TikTok edits, and dating-app conversations 🔥❤️ shows up wherever the sender wants to mark a relationship or a moment as burning with intensity rather than quietly holding warmth.\n\nThe combo also doubles as the standard thirst reaction to someone who looks good — a flirty selfie or a fitness post collects 🔥❤️ as the shorthand for 'you are attractive and I am feeling it.' The dual reading — romantic love or lustful heat — makes 🔥❤️ one of the most versatile positive-relationship combos on the keyboard. Reserve it for moments that genuinely warrant the heat, because the combo is loud and direct.",
+    "howPeopleUseIt": "🔥❤️ arrives as the closer on a romantic message, the caption on a couple's anniversary post, or as the punchline reaction to an attractive photo. On Instagram captions the combo functions as the warm-and-hot romantic signature, often posted on engagement photos or first-date recaps. On Twitter and TikTok it lands as the flirtatious reaction to a public post that the sender wants to mark as hot.\n\nIn dating-app conversations 🔥❤️ works as the strong closer — 'you are 🔥❤️' or 'thinking about you 🔥❤️' — that pushes the relationship past the casual stage. The combo pairs naturally with 😍 for layered affection and with 😘 for the kiss-and-heat full stack. It is rare to see 🔥❤️ in workplace channels; the heat is too performative for professional reading.",
+    "whenNotToUse": "Skip 🔥❤️ in cold work channels or customer-facing comms where the romantic reading would feel mismatched. A 🔥❤️ in a customer complaint reply sounds tone deaf. Avoid it in first-contact dating messages where the rapport has not been established — the combo is loud, so leading with it can feel forward.\n\nAlso avoid 🔥❤️ in serious discussions about a relationship breaking down. The combo celebrates heat, so using it about a partner during a fight or a hard conversation will land as cruel or dismissive. Match the emoji to the emotional register of the moment.",
+    "howToReply": "Mirror 🔥❤️ with another 🔥❤️ if you want to keep the heat going, or upgrade to 😍 for a softer affection signal or 🥰 for warmth. If you receive 🔥❤️ from a romantic partner, a short 'feeling it too 🔥❤️' or a heart emoji closes the loop warmly.\n\nIf 🔥❤️ arrives on a thirst reaction, mirror with a flirty reply or a 🔥 to match the heat. And if you want to send 🔥❤️ as a friend, anchor the combo with a sentence that lands the platonic reading so the romantic heat does not feel like an escalation.",
+    "faqs": [
+      {
+        "question": "What does 🔥❤️ mean in texting?",
+        "answer": "🔥❤️ means passionate or intense love. The fire amplifies the heart into something hotter than casual affection, so the combo reads as deep attraction or burning romance."
+      },
+      {
+        "question": "Is 🔥❤️ flirty?",
+        "answer": "Yes, 🔥❤️ reads as flirty or strongly romantic. Inside a relationship it is the default heat emoji; in other contexts it can feel forward if the warmth is not mutual."
+      },
+      {
+        "question": "What does 🔥❤️ mean from a girl?",
+        "answer": "From a girl or anyone else, 🔥❤️ means the sender feels intense attraction or deep love. There is no gendered meaning; the combo is about the heat, not who is sending it."
+      },
+      {
+        "question": "What does 🔥❤️ mean from a guy?",
+        "answer": "From a guy, 🔥❤️ has the same meaning it has from anyone else: passionate love or strong attraction. The combo is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "dating",
+      "message": "you look amazing tonight 🔥❤️",
+      "interpretation": "Romantic partner's flirty compliment. Mirror with 🔥❤️ or a follow-up sweet line to match the heat."
+    },
+    {
+      "setting": "social",
+      "message": "six months with you 🔥❤️",
+      "interpretation": "Romantic anniversary post on social media. Mirror with 🔥❤️ or 'congratulations' to celebrate the milestone."
+    },
+    {
+      "setting": "friends",
+      "message": "that fit pic was insane 🔥❤️",
+      "interpretation": "Friend complimenting a public look. Mirror with 🔥 or a heart to engage with the heat."
+    },
+    {
+      "setting": "family",
+      "message": "love you both so much 🔥❤️",
+      "interpretation": "Family warmth to parents or siblings. Mirror with ❤️ or 'love you too' to close the loop."
+    },
+    {
+      "setting": "work",
+      "message": "thanks for the handoff 🔥❤️",
+      "interpretation": "Risky in a wide team channel; safe in a tight collaborator DM. If used in a team channel, anchor with a sentence that adds context."
+    }
+  ]
 }

--- a/src/data/combos/heart-eyes-fire.json
+++ b/src/data/combos/heart-eyes-fire.json
@@ -11,5 +11,58 @@
   "seoDescription": "What does 😍🔥 mean? The heart eyes and fire combo explained. Used as an enthusiastic compliment.",
   "relatedCombos": ["fire-heart", "fire-100"],
   "tags": ["attraction", "compliment", "gorgeous", "stunning", "hot"],
-  "popularity": 84
+  "popularity": 84,
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "😍🔥 is the emoji combo for 'you are absolutely stunning' — heart-eyes stacked with fire as the loud, enthusiastic compliment reaction. Where a single 😍 reads as 'I like this,' the 🔥 in tow upgrades the moment to 'I am on fire about it.' On Instagram, TikTok, and dating-app conversations 😍🔥 shows up as the punchline reaction to a jaw-dropping photo, a fit pic, or a freshly styled look — the combo that means the sender is genuinely impressed, not just being polite.\n\nThe combo also doubles as a strong reaction to anything visually stunning: a sunset, a meal, an outfit drop. The 😍 does the 'I am smitten' work and the 🔥 pushes it past polite into 'this is exceptional.' It is one of the most reliable compliments on the emoji keyboard because the dual reading — attraction or aesthetics — keeps it versatile. Use 😍🔥 when you genuinely want to crown the moment, not as a default reaction.",
+    "howPeopleUseIt": "😍🔥 arrives as the comment under a creator's post, the reaction to a partner's fit pic, or as the punchline on a friend's big news. On Instagram captions 😍🔥 shows up under outfit-of-the-day posts, travel shots, and engagement announcements as the visual tag for 'this is exceptional.' On TikTok creators paste 😍🔥 in their own captions as the moment a look or reveal comes together.\n\nIn dating-app conversations 😍🔥 functions as the strong flirty compliment — 'you are 😍🔥 tonight' — that marks the recipient as visually impressive. The combo pairs naturally with ❤️ for layered affection, with 💯 for validation, and with 👑 for the elite-version emphasis. It is rare to see 😍🔥 in work channels; the heat is too flirty for most professional reading.",
+    "whenNotToUse": "Skip 😍🔥 in any context where the flirty or aesthetic reading would feel mismatched — in a customer complaint thread, in a serious work channel, or in formal professional emails. A 😍🔥 in a customer-facing reply sounds unprofessional and tone deaf. Avoid it in cold work channels where the recipient may not share the same humor.\n\nAlso avoid 😍🔥 when you want to deliver measured feedback about someone's appearance. A friend who asks 'is this too much?' does not want a 😍🔥 reaction if you actually have honest input — the combo is so enthusiastic that offering it without sincerity will read as performative.",
+    "howToReply": "Mirror 😍🔥 with another 😍🔥 or with ❤️ if you want to keep the affection going, or upgrade with a sentence that names what specifically looked good. If you receive 😍🔥 on your own content, reply with 'thanks 😍🔥' or a follow-up that acknowledges the strong reaction.\n\nIf 😍🔥 arrives as a flirty reaction, mirror with a softer 😍 or a heart emoji to keep the warmth without doubling the heat. And if you want to send 😍🔥 to a friend, anchor the combo with a sentence that lands the compliment so the fire does not feel like a romantic escalation.",
+    "faqs": [
+      {
+        "question": "What does 😍🔥 mean in texting?",
+        "answer": "😍🔥 means the sender thinks the recipient or content is absolutely stunning. The combo stacks 'I am smitten' with 'this is on fire' to mark the moment as exceptional."
+      },
+      {
+        "question": "Is 😍🔥 flirty?",
+        "answer": "Yes, 😍🔥 reads as flirty in most contexts. Inside a relationship it is the strong-attraction signal; on social media it lands as a strong aesthetic compliment."
+      },
+      {
+        "question": "What does 😍🔥 mean from a girl?",
+        "answer": "From a girl or anyone else, 😍🔥 means the sender is genuinely impressed. There is no gendered meaning; the combo is about the strength of the reaction, not who is sending it."
+      },
+      {
+        "question": "What does 😍🔥 mean from a guy?",
+        "answer": "From a guy, 😍🔥 has the same meaning it has from anyone else: 'this is stunning or attractive.' The combo is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "dating",
+      "message": "you look incredible tonight 😍🔥",
+      "interpretation": "Romantic partner's strong attraction reaction. Mirror with 😍🔥 or a follow-up sweet line."
+    },
+    {
+      "setting": "social",
+      "message": "she really won the night 😍🔥",
+      "interpretation": "Group chat appreciation of a friend's look. Mirror with 😍🔥 or 🔥 to match the energy."
+    },
+    {
+      "setting": "friends",
+      "message": "this fit came together 😍🔥",
+      "interpretation": "Friend bragging about a successful look. Mirror with 😍🔥 or a heart to engage."
+    },
+    {
+      "setting": "family",
+      "message": "the new haircut mom 😍🔥",
+      "interpretation": "Family appreciation of a relative's look. Mirror with a sentence that celebrates the change."
+    },
+    {
+      "setting": "work",
+      "message": "that deck you put together 😍🔥",
+      "interpretation": "Risky in a wide team channel; safe in a tight collaborator DM. If used in a team channel, anchor with a sentence that adds context."
+    }
+  ]
 }

--- a/src/data/combos/heart-eyes.json
+++ b/src/data/combos/heart-eyes.json
@@ -11,5 +11,58 @@
   "seoDescription": "What does 😍❤️ mean? The heart eyes and heart combo explained. Used to express being totally smitten.",
   "relatedCombos": ["heart-eyes-fire", "fire-heart"],
   "tags": ["love", "smitten", "attraction", "adoration", "heart"],
-  "popularity": 84
+  "popularity": 84,
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "😍❤️ is the maximum affection combo — the heart-eyes face says 'I am smitten' and the red heart doubles down with 'and I love it.' On Instagram, TikTok, and iMessage the combo lands as enthusiastic adoration, the kind of reaction people send to a friend's engagement photo, a new puppy, a sunset, a meal, or anything that genuinely melted them. The combination is louder than either emoji alone: 😍 reads as warm appreciation, ❤️ reads as deep affection, and 😍❤️ reads as 'this has my whole heart.'\n\nThe combo leans romantic when sent by a partner or a date and leans platonic in most other contexts. The key variable is who is sending it and what they are reacting to. 😍❤️ under a celebrity's photo is fandom; 😍❤️ under a friend's vacation photo is appreciation; 😍❤️ under a partner's selfie is romance. Writers should default to the combo when the moment really is full-throated adoration, and reach for a single heart or a single 😍 when the read should be lighter.",
+    "howPeopleUseIt": "😍❤️ arrives as a stand-alone reaction, sandwiched in a sentence as a beat ('your dog 😍❤️'), or stacked under a photo someone shared. The combo is the go-to reaction to anything that prompts genuine awe: a new baby announcement, a friend's wedding photo, a sunset, a meal that came out perfect. It also works as a flirty signal in early dating conversations, where 😍 alone can read as measured and a ❤️ alone can read as too much, but 😍❤️ sits in the warm middle.\n\nIn family group chats 😍❤️ shows up on grandkid photos and milestone announcements. In stan Twitter it shows up under celebrity posts as fandom cosign. In group chats with friends it arrives when someone shares a personal win — a promotion, a new house, a new relationship. The combo is rarely sarcastic because both emojis are unambiguously positive, which makes it a safe bet when you want to land as sincere.",
+    "whenNotToUse": "Skip 😍❤️ in cold work channels where the relationship does not justify the warmth — a 😍❤️ from a brand account under a complaint reply reads as tone deaf. Avoid it in customer-facing comms where the sentiment can be misread as romantic. And do not default to 😍❤️ when a softer reaction (😊, 🙌, 👏) would do the same job without the romantic weight.\n\nAlso avoid 😍❤️ when the content is not actually lovable. A 😍❤️ on a coworker's low-effort presentation reads as sarcastic, and a 😍❤️ on a friend's bad haircut will land as mockery no matter how friendly you intended it. The combo is loud and sincere, so use it when you mean it.",
+    "howToReply": "Mirror 😍❤️ with another 😍❤️ if you want to keep the warmth, or upgrade to a longer sentence like 'I am genuinely so happy for you' to land as more sincere. A single ❤️ or a single 😍 also works as a softer agreement if you want to register support without the maximum affection energy.\n\nIf you receive 😍❤️ on your own post, treat it as a clean win and reply with 'thank you 😍❤️' or a sentence about what you shared. If the combo landed from a contact where the read feels romantic and that is not what you wanted, you can pull back with a softer reaction emoji like 😊 so the message registers as friendly rather than flirtatious.",
+    "faqs": [
+      {
+        "question": "What does 😍❤️ mean?",
+        "answer": "😍❤️ means the sender is smitten and full of affection. The heart-eyes face adds 'I adore this' and the red heart doubles down with 'and I love it.'"
+      },
+      {
+        "question": "Is 😍❤️ flirty?",
+        "answer": "😍❤️ can read as flirty when it lands from a contact you are not already close with. Inside an established romantic relationship it is the default adoration signal."
+      },
+      {
+        "question": "What does 😍❤️ mean from a girl?",
+        "answer": "From a girl, 😍❤️ means she is genuinely impressed or smitten. There is no universal 'flirty' meaning; the read depends on who is sending it and what they are reacting to."
+      },
+      {
+        "question": "What does 😍❤️ mean on Instagram?",
+        "answer": "On Instagram 😍❤️ is the maximum admiration reaction. It lands stronger than a heart-shaped like and implies the sender had a real emotional reaction to the post."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "look at this puppy 😍❤️",
+      "interpretation": "Friend sharing a cute animal. Mirror with 😍❤️ or 'omg' to keep the warmth."
+    },
+    {
+      "setting": "dating",
+      "message": "you look amazing tonight 😍❤️",
+      "interpretation": "Romantic compliment from a date. Mirror with another 😍❤️ or a follow-up sweet line."
+    },
+    {
+      "setting": "family",
+      "message": "first grandbaby photo 😍❤️",
+      "interpretation": "Family group love for a new baby. Mirror with 😍❤️ or 'love you both' to keep the warmth."
+    },
+    {
+      "setting": "social",
+      "message": "this sunset is unreal 😍❤️",
+      "interpretation": "Group chat appreciation of a shared view. Mirror with 😍❤️ or a sentence about the scene."
+    },
+    {
+      "setting": "work",
+      "message": "client loved the proposal 😍❤️",
+      "interpretation": "Friendly team celebration. Mirror with a softer reaction in a wide team channel; save 😍❤️ for tight collaborators."
+    }
+  ]
 }

--- a/src/data/combos/kiss-heart.json
+++ b/src/data/combos/kiss-heart.json
@@ -11,5 +11,58 @@
   "seoDescription": "What does 😘❤️ mean? The kiss and heart combo explained. Used to send love and affection.",
   "relatedCombos": ["heart-eyes", "fire-heart"],
   "tags": ["kiss", "love", "affection", "romantic", "sweet"],
-  "popularity": 83
+  "popularity": 83,
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "😘❤️ is the loving-kiss combo, the face-blowing-a-kiss stacked with a heart for the universal 'love you, sending kisses' reaction. The pairing is the standard romantic warmer, used when the sender wants to add both the kiss and the heart beats at once. On Twitter and TikTok 😘❤️ shows up under partner-posts, anniversary shares, and any moment the sender wants to underline that the love is at full capacity. The combo is interesting because it spans the literal kiss-and-love reading and the softer affection-tag, making it both more emphatic than 😘 alone and more kiss-y than ❤️ alone.\n\nThe combo also doubles as the universal 'goodnight love' reaction. A partner messages 'goodnight' and the appropriate reply is 😘❤️ — the visual tag for the loving-kiss beat. The doubled emoji lands more emphatic than either single emoji, which is why the combo works best when the love is genuinely strong.",
+    "howPeopleUseIt": "😘❤️ arrives as the closer on a partner's goodnight message, the reaction to a romantic post, or the punchline on a 'love you' share. On Twitter it functions as the standard reaction to a public romance moment. On Instagram captions the combo lands as the signature reaction on a couple's post. On TikTok creators paste 😘❤️ on romance edits as the visual tag for the moment the love lands.\n\nIn group chats 😘❤️ works as the shared 'sending love' reaction when a friend shares a romantic moment. The combo also pairs naturally with 🥰 for the warm admiration, with 🫶 for the heart-hands sibling, and with a sentence that names what is being loved so the kiss-heart does not feel generic.",
+    "whenNotToUse": "Skip 😘❤️ in contexts where the romantic reading will land wrong — in cold professional channels, in customer complaint replies, or in formal client emails. A 😘❤️ in a customer complaint thread will sound tone deaf. Avoid it in conversations where the recipient does not want the romantic undertone.\n\nAlso avoid 😘❤️ when the actual context calls for a different moment. The combo is more coded than a heart alone, so 😘❤️ on a coworker's birthday card may read as performative. Reach for a heart or a sentence of care when the message warrants simple appreciation.",
+    "howToReply": "Mirror 😘❤️ with another 😘❤️ or 🫶 if you want to keep the loving-kiss going, or upgrade to 🥰 for the warm admiration. If you receive 😘❤️ on a romantic post, reply with a sentence that engages with the moment.\n\nIf 😘❤️ arrives as a goodnight kiss, mirror with a sentence that engages with the moment. And if you want to send 😘❤️ as a soft friendly reaction, anchor the combo with a sentence that names the love so the kiss-heart does not feel performative.",
+    "faqs": [
+      {
+        "question": "What does 😘❤️ mean in texting?",
+        "answer": "😘❤️ means 'love you' or 'sending kisses.' The kiss-heart combo is the universal romantic warmer and reads as either genuine romance or affectionate friendly closer."
+      },
+      {
+        "question": "What does 😘❤️ mean from a girl?",
+        "answer": "From a girl or anyone else, 😘❤️ means the sender is sending love and kisses. There is no gendered meaning; the combo is about the affection, not who is sending it."
+      },
+      {
+        "question": "Is 😘❤️ flirty?",
+        "answer": "😘❤️ can read as flirty in a dating context, especially paired with romantic content. In other contexts it stays in the affectionate-friendly zone."
+      },
+      {
+        "question": "What does 😘❤️ mean from a guy?",
+        "answer": "From a guy, 😘❤️ has the same meaning it has from anyone else: loving affection or romantic warm. The combo is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "dating",
+      "message": "goodnight 😘❤️",
+      "interpretation": "Partner's loving goodnight. Mirror with 😘❤️ or a heart to close the loop."
+    },
+    {
+      "setting": "friends",
+      "message": "love you bestie 😘❤️",
+      "interpretation": "Friend's warm affection. Mirror with 😘❤️ or a heart to close the loop."
+    },
+    {
+      "setting": "social",
+      "message": "anniversary post 😘❤️",
+      "interpretation": "Public romance share. Mirror with 😘❤️ or a heart to engage with the moment."
+    },
+    {
+      "setting": "family",
+      "message": "love you mom 😘❤️",
+      "interpretation": "Family warmth. Mirror with 😘❤️ or a heart to close the loop."
+    },
+    {
+      "setting": "work",
+      "message": "thanks for the handoff 😘❤️",
+      "interpretation": "Risky in a wide team channel; safe in a tight collaborator DM. If used in a team channel, anchor with a sentence that adds context."
+    }
+  ]
 }

--- a/src/data/combos/laughing-crying-repeat.json
+++ b/src/data/combos/laughing-crying-repeat.json
@@ -11,5 +11,58 @@
   "seoDescription": "What does 😂😂😂 mean? Multiple laughing emojis explained. Used when something is extremely funny.",
   "relatedCombos": ["skull-laughing", "sob-laughing"],
   "tags": ["laughing", "hilarious", "funny", "lol", "hysterical"],
-  "popularity": 88
+  "popularity": 88,
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "😂😂😂 is the maximum-laughter reaction, the three-stacked tears-of-joy faces that signal 'I cannot stop laughing.' The repetition is the entire point — one 😂 can feel polite, two 😂 is clearly laughing, three 😂 is the visual 'I am broken' beat. On Twitter, TikTok, and Instagram 😂😂😂 shows up under content that genuinely broke the viewer, and it has become so common that the laughter emoji itself has drifted toward overexposure. The triple-stack is the reaction for moments that warrant the overflow.\n\nThe combo also doubles as the safer alternative to the more aggressive humor combos like 💀😂 (skull-laughing). The 😂😂😂 lands as pure humor without the morbidity undercurrent, which makes it the right choice for wholesome viral content, family-friendly moments, and reactions the sender wants to keep clean. Reserve 😂😂😂 for things that genuinely warranted the maximum laughter, because stacking the emoji on every message begins to undercut the special overflow language the combo is built around.",
+    "howPeopleUseIt": "😂😂😂 arrives as the comment on a viral clip, the closer on a friend's joke, or the punchline on a thread that broke the reader. On Twitter it functions as the 'this is gold' reaction that everyone pastes on the same content at once. On TikTok the combo shows up in comments under genuinely funny clips as the visual tag for the moment the joke landed. On iMessage 😂😂😂 works as the standard friend-group reaction to a shared joke that needs the overflow emphasis.\n\nThe combo also pairs naturally with 😭 (😭😂 for the sobbing-laughing alternative) and with 💀 for the skull-laughing stronger version. Stand-alone 😂😂😂 reads as uncontrollably funny; in a longer stack it leans performative.",
+    "whenNotToUse": "Skip 😂😂😂 in contexts where the content is not actually funny — in condolences, in serious professional channels, or in customer complaint replies. A 😂😂😂 on a friend's breakup post reads as dismissive. Avoid it in any thread where the recipient needs empathy rather than laughter.\n\nAlso avoid 😂😂😂 when you want to actually offer a thoughtful reaction. The combo is so loud that it overwhelms the actual message. Reach for a sentence or a softer reaction when the moment needs nuance.",
+    "howToReply": "Mirror 😂😂😂 with another 😂😂😂 or with 💀 if you want to keep the laughter going, or upgrade to 😭😂 for the crying-laughing variant. If you receive 😂😂😂 on your own content, reply with 'thanks 😂' or a sentence that acknowledges the reaction.\n\nIf 😂😂😂 arrives on a friend's joke, mirror with a sentence that adds to the bit. And if you want to send 😂😂😂 as a comment on something viral, anchor it with a sentence that names what was so funny so the stack does not feel performative.",
+    "faqs": [
+      {
+        "question": "What does 😂😂😂 mean in texting?",
+        "answer": "😂😂😂 means 'I cannot stop laughing.' The triple-stack of tears-of-joy faces signals the maximum humor reaction and reads as overflow laughter rather than polite appreciation."
+      },
+      {
+        "question": "Is 😂😂😂 flirty?",
+        "answer": "😂😂😂 is not flirty. It marks overwhelming laughter, with no romantic undercurrent. Using it on a romantic post will read as supportive rather than flirtatious."
+      },
+      {
+        "question": "What does 😂😂😂 mean from a girl?",
+        "answer": "From a girl or anyone else, 😂😂😂 means the sender is laughing uncontrollably. There is no gendered meaning; the combo is about the laughter, not who is sending it."
+      },
+      {
+        "question": "What does 😂😂😂 mean on TikTok?",
+        "answer": "On TikTok a triple 😂😂😂 in the comments means the viewer thought the content was hilarious. The stack signals overflow laughter — the video broke the viewer."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "that video of the dog 😂😂😂",
+      "interpretation": "Friend sharing a viral clip. Mirror with 😂😂😂 or a sentence that adds to the laughter."
+    },
+    {
+      "setting": "social",
+      "message": "the way she ended him 😂😂😂",
+      "interpretation": "Public reaction to a clapback. Mirror with 😂😂😂 or 🔥 to amplify the moment."
+    },
+    {
+      "setting": "work",
+      "message": "the deploy broke immediately 😂😂😂",
+      "interpretation": "Team disaster in a tight channel. Mirror with 😂😂😂 or a sentence that engages with the situation."
+    },
+    {
+      "setting": "dating",
+      "message": "you really said that 😂😂😂",
+      "interpretation": "Partner's playful disbelief. Mirror with 😂😂😂 or a sentence that engages with the joke."
+    },
+    {
+      "setting": "family",
+      "message": "dad at the family dinner 😂😂😂",
+      "interpretation": "Family group laughter at a relative's antics. Mirror with 😂😂😂 or a sentence that engages with the moment."
+    }
+  ]
 }

--- a/src/data/combos/nail-polish-sparkles.json
+++ b/src/data/combos/nail-polish-sparkles.json
@@ -15,5 +15,58 @@
   "seoDescription": "What does 💅✨ mean? The nail polish and sparkles combo explained. Used to express unbothered, sassy confidence.",
   "relatedCombos": ["sparkles-heart-sparkles"],
   "tags": ["unbothered", "sassy", "confident", "queen", "fabulous"],
-  "popularity": 86
+  "popularity": 86,
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "💅✨ is the unbothered queen combo, the nail polish + sparkles pairing that signals sassy confidence and self-assured indifference. The phrase 'I don't know her' paired with 💅✨ became the Gen Z / millennial shorthand for the 'too fabulous to be involved' takeaway, and the combo has stayed popular because the energy is so specific: cold, confident, unbothered. On Twitter, Instagram, and TikTok the combo shows up under drama commentary, self-care content, and any moment the sender wants to mark as confidently above the noise. The 💅 does the 'I am doing my nails, I cannot be bothered' work and the ✨ adds the sparkle on top.\n\nThe combo also doubles as the standard aesthetic reaction to a 'living my best life' share. On Instagram captions 💅✨ shows up on self-care posts, glow-up reveals, and the visual tag for the 'I am thriving while you are not' tone. The dual reading — unbothered or aesthetic — keeps the combo versatile without diluting the sass. Use 💅✨ when the moment genuinely warrants the queen energy, because the combo is loud and overusing it begins to undercut the genuine confidence the emoji is built to deliver.",
+    "howPeopleUseIt": "💅✨ arrives as the comment on a drama post, the caption on a self-care share, or the punchline on a moment where the sender is choosing to be unbothered. On Twitter it functions as the 'I am too fabulous for this' reaction to a public mess. On Instagram captions the combo lands as the signature flourish on a glow-up post or a self-care reveal. On TikTok creators paste 💅✨ on GRWM and confidence edits as the visual tag for the moment the look comes together.\n\nThe combo also pairs naturally with 👑 for the queen-emphasis, with 😎 for the cool sibling, and with a sentence that names what is being unbothered about. Stand-alone 💅✨ reads as confidently unbothered; in a stack it leans performative.",
+    "whenNotToUse": "Skip 💅✨ in contexts where the sassy confidence would feel mismatched — in friendly conversations where warmth is needed, in serious professional channels, or in customer complaint replies. A 💅✨ in a customer complaint thread will read as tone deaf. Avoid it in moments where the recipient actually needs empathy or support.\n\nAlso avoid 💅✨ when the sass is not actually warranted. A 💅✨ on a friend's small win reads as dismissive. Reserve the combo for moments where the unbothered energy genuinely matches the situation.",
+    "howToReply": "Mirror 💅✨ with another 💅✨ or 👑 if you want to keep the queen energy going, or upgrade to 😎 for the cool-styled version. If you receive 💅✨ on a glow-up post, reply with a soft heart or a sentence that acknowledges the shift.\n\nIf 💅✨ arrives as a drama reaction, mirror with a sentence that engages with the actual observation. And if you want to send 💅✨ as a self-affirmation, anchor the combo with a sentence that names what specifically is being celebrated so the sass does not feel performative.",
+    "faqs": [
+      {
+        "question": "What does 💅✨ mean in texting?",
+        "answer": "💅✨ means 'I am too fabulous to be bothered' or 'unbothered queen energy.' The nail polish + sparkles combo signals confident indifference and self-assured sass."
+      },
+      {
+        "question": "Is 💅✨ flirty?",
+        "answer": "💅✨ is not flirty. It marks confident indifference or aesthetic pride, with no romantic undercurrent. Using it on a romantic post will read as supportive rather than flirtatious."
+      },
+      {
+        "question": "What does 💅✨ mean from a girl?",
+        "answer": "From a girl or anyone else, 💅✨ means the sender is feeling unbothered or sassy. There is no gendered meaning; the combo is about the confidence, not who is sending it."
+      },
+      {
+        "question": "What does 💅✨ mean on Instagram?",
+        "answer": "On Instagram captions 💅✨ shows up on self-care posts and glow-up reveals as the visual tag for the 'I am thriving' energy. The combo is the standard aesthetic reaction to a confident share."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "drama? don't know her 💅✨",
+      "interpretation": "Friend unbothered reaction. Mirror with 💅✨ or a sentence that engages with the nonchalance."
+    },
+    {
+      "setting": "social",
+      "message": "glow-up check 💅✨",
+      "interpretation": "Public self-care celebration. Mirror with 💅✨ or a heart to acknowledge the glow-up."
+    },
+    {
+      "setting": "work",
+      "message": "the meeting could not hold me 💅✨",
+      "interpretation": "Risky in a wide team channel; safe in a tight collaborator DM. If used in a team channel, anchor with a sentence that adds context."
+    },
+    {
+      "setting": "dating",
+      "message": "they tried it 💅✨",
+      "interpretation": "Partner's unbothered reaction. Mirror with 💅✨ or a sentence that engages with the situation."
+    },
+    {
+      "setting": "family",
+      "message": "self-care day 💅✨",
+      "interpretation": "Family sharing a self-care moment. Mirror with a heart or a sentence that engages with the day."
+    }
+  ]
 }

--- a/src/data/combos/party-celebrate.json
+++ b/src/data/combos/party-celebrate.json
@@ -11,5 +11,58 @@
   "seoDescription": "What does 🎉🥳 mean? The party popper and party face combo explained. Used for full celebration mode.",
   "relatedCombos": ["party-fire", "rocket-sparkles"],
   "tags": ["celebration", "party", "achievement", "excited", "happy"],
-  "popularity": 83
+  "popularity": 83,
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "🎉🥳 is the full-celebration combo, the party popper stacked with party face to mark 'full party mode activated.' The pairing is the universal maximum-cheer reaction, used when the achievement deserves both a popper and a party face. On Twitter and TikTok 🎉🥳 shows up under birthday posts, milestone announcements, and any moment the sender wants to underline that the celebration is at full capacity. The combo is interesting because it spans the literal celebration and the face-emoji reaction, making it both more emphatic than 🎉 alone and more cheerful than 🥳 alone.\n\nThe combo also doubles as the universal 'happy birthday' reaction. A friend announces their birthday and the appropriate reply is 🎉🥳 — the visual tag for the full-party beat. The doubled emoji lands more emphatic than either single emoji, which is why the combo works best when the celebration is genuinely major.",
+    "howPeopleUseIt": "🎉🥳 arrives as the closer on a friend's birthday share, the reaction to a major milestone announcement, or the punchline on a 'full party mode' moment. On Twitter it functions as the standard reaction to a public celebration. On Instagram captions the combo lands as the signature reaction on a birthday or milestone post. On TikTok creators paste 🎉🥳 on reveal videos as the visual tag for the moment the celebration lands.\n\nIn group chats 🎉🥳 works as the shared 'full party' reaction when a friend shares good news. The combo also pairs naturally with 🎊 for the confetti sibling stack, with 🥂 for the toast emphasis, and with a sentence that names what is being celebrated so the party combo does not feel generic.",
+    "whenNotToUse": "Skip 🎉🥳 in contexts where the celebration will land wrong — in condolence threads, in serious professional feedback, or in conversations where the recipient has actually lost something. A 🎉🥳 in a condolence thread will sound tone deaf. Avoid it on a friend's vulnerable post; the full-party beat will land wrong.\n\nAlso avoid 🎉🥳 when the moment is not actually celebratory. A 🎉🥳 on a coworker's small typo fix reads as performative. Reserve the combo for moments where the celebration genuinely warrants the full party.",
+    "howToReply": "Mirror 🎉🥳 with another 🎉🥳 or 🎊 if you want to keep the full-party going, or upgrade to a heart for the warmer affection. If you receive 🎉🥳 on a personal win, reply with 'thanks 🎉🥳' or a sentence that acknowledges the moment.\n\nIf 🎉🥳 arrives as a birthday reaction, mirror with a sentence that engages with the day. And if you want to send 🎉🥳 as a soft friendly reaction, anchor the combo with a sentence that names what is being celebrated so the full-party beat does not feel performative.",
+    "faqs": [
+      {
+        "question": "What does 🎉🥳 mean in texting?",
+        "answer": "🎉🥳 means 'full celebration' or 'full party mode.' The party-celebrate combo signals a major celebration, achievement, or birthday, more emphatic than 🎉 alone."
+      },
+      {
+        "question": "What does 🎉🥳 mean from a girl?",
+        "answer": "From a girl or anyone else, 🎉🥳 means the sender is celebrating at full capacity. There is no gendered meaning; the combo is about the moment, not who is sending it."
+      },
+      {
+        "question": "Is 🎉🥳 flirty?",
+        "answer": "🎉🥳 is not flirty. It marks celebration or excitement, with no romantic undercurrent. Using it on a romantic post will read as supportive rather than flirtatious."
+      },
+      {
+        "question": "What does 🎉🥳 mean from a guy?",
+        "answer": "From a guy, 🎉🥳 has the same meaning it has from anyone else: full celebration. The combo is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "got the job 🎉🥳",
+      "interpretation": "Friend sharing a win. Mirror with 🎉🥳 or a sentence that engages with the news."
+    },
+    {
+      "setting": "social",
+      "message": "happy birthday to me 🎉🥳",
+      "interpretation": "Public birthday share. Mirror with 🎉🥳 or a sentence that engages with the day."
+    },
+    {
+      "setting": "dating",
+      "message": "made it official 🎉🥳",
+      "interpretation": "Partner's milestone share. Mirror with a heart or a sentence that engages with the moment."
+    },
+    {
+      "setting": "family",
+      "message": "grandma turned 90 🎉🥳",
+      "interpretation": "Family milestone share. Mirror with 🎉🥳 or a sentence that engages with the day."
+    },
+    {
+      "setting": "work",
+      "message": "ship it 🎉🥳",
+      "interpretation": "Risky in a wide team channel; safe in a tight collaborator DM. If used in a team channel, anchor with a sentence that adds context."
+    }
+  ]
 }

--- a/src/data/combos/party-fire.json
+++ b/src/data/combos/party-fire.json
@@ -9,7 +9,60 @@
   "category": "celebration",
   "seoTitle": "🎉🔥 Party Fire Combo Meaning",
   "seoDescription": "What does 🎉🔥 mean? The party popper and fire emoji combo explained. Used to celebrate impressive achievements.",
-  "relatedCombos": ["fire-100", "rocket-sparkles"],
+  "relatedCombos": ["fire-100", "rocket-sparkles", "party-celebrate"],
   "tags": ["celebration", "impressive", "achievement", "lit", "exciting"],
-  "popularity": 83
+  "popularity": 83,
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "🎉🔥 is the lit-celebration combo, the party popper stacked with fire to mark 'the win is not just real, it is fire.' The pairing is the universal celebration-with-hype reaction, used when the achievement deserves both a cheer and a hot take. On Twitter and TikTok 🎉🔥 shows up under launch announcements, promotion posts, and any moment the sender wants to underline that the win is impressive. The combo is interesting because it spans the literal celebration and the hype-add, making it both more emphatic than 🎉 alone and more celebratory than 🔥 alone.\n\nThe combo also doubles as the universal 'we are doing it' reaction. A friend shares a milestone and the appropriate reply is 🎉🔥 — the visual tag for the celebration-plus-hype beat. The doubled emoji lands more emphatic than either single emoji, which is why the combo works best when the win is genuinely impressive.",
+    "howPeopleUseIt": "🎉🔥 arrives as the closer on a friend's milestone share, the reaction to a launch announcement, or the punchline on a 'we are officially lit' moment. On Twitter it functions as the standard reaction to a public achievement. On Instagram captions the combo lands as the signature reaction on a win post. On TikTok creators paste 🎉🔥 on reveal videos as the visual tag for the moment the win lands.\n\nIn group chats 🎉🔥 works as the shared 'congrats plus hype' reaction when a friend shares good news. The combo also pairs naturally with 🚀 for the launch-sibling stack, with 💯 for the percentage emphasis, and with a sentence that names what is being celebrated so the lit combo does not feel generic.",
+    "whenNotToUse": "Skip 🎉🔥 in contexts where the celebration-plus-hype will land wrong — in condolence threads, in serious professional feedback, or in conversations where the recipient has actually lost something. A 🎉🔥 in a condolence thread will sound tone deaf. Avoid it on a friend's vulnerable post; the lit beat will land wrong.\n\nAlso avoid 🎉🔥 when the moment is not actually celebratory. A 🎉🔥 on a coworker's small typo fix reads as performative. Reserve the combo for moments where the win genuinely warrants both celebration and hype.",
+    "howToReply": "Mirror 🎉🔥 with another 🎉🔥 or 🚀 if you want to keep the lit energy going, or upgrade to a heart for the warmer affection. If you receive 🎉🔥 on a personal win, reply with 'thanks 🎉🔥' or a sentence that acknowledges the moment.\n\nIf 🎉🔥 arrives as a hype-add reaction, mirror with a sentence that engages with the win. And if you want to send 🎉🔥 as a soft friendly reaction, anchor the combo with a sentence that names what is being celebrated so the lit beat does not feel performative.",
+    "faqs": [
+      {
+        "question": "What does 🎉🔥 mean in texting?",
+        "answer": "🎉🔥 means 'celebration plus hype' or 'the win is lit.' The party-fire combo signals an impressive achievement that is worth both cheering and hyping up."
+      },
+      {
+        "question": "What does 🎉🔥 mean from a girl?",
+        "answer": "From a girl or anyone else, 🎉🔥 means the sender is celebrating with hype. There is no gendered meaning; the combo is about the moment, not who is sending it."
+      },
+      {
+        "question": "Is 🎉🔥 flirty?",
+        "answer": "🎉🔥 is not flirty. It marks celebration with hype, with no romantic undercurrent. Using it on a romantic post will read as supportive rather than flirtatious."
+      },
+      {
+        "question": "What does 🎉🔥 mean from a guy?",
+        "answer": "From a guy, 🎉🔥 has the same meaning it has from anyone else: lit celebration. The combo is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "got the job 🎉🔥",
+      "interpretation": "Friend sharing a win. Mirror with 🎉🔥 or a sentence that engages with the news."
+    },
+    {
+      "setting": "work",
+      "message": "ship it 🎉🔥",
+      "interpretation": "Team launch reaction in a tight channel. Mirror with 🎉🔥 or a sentence that acknowledges the launch."
+    },
+    {
+      "setting": "social",
+      "message": "album of the year 🎉🔥",
+      "interpretation": "Public milestone share. Mirror with 🎉🔥 or a sentence that celebrates the win."
+    },
+    {
+      "setting": "family",
+      "message": "grandma turned 90 🎉🔥",
+      "interpretation": "Family milestone share. Mirror with 🎉🔥 or a sentence that engages with the day."
+    },
+    {
+      "setting": "dating",
+      "message": "made it to your block 🎉🔥",
+      "interpretation": "Partner's arrival share. Mirror with a heart or a sentence that acknowledges the moment."
+    }
+  ]
 }

--- a/src/data/combos/peach-eggplant.json
+++ b/src/data/combos/peach-eggplant.json
@@ -11,5 +11,58 @@
   "seoDescription": "What does 🍑🍆 mean? The peach and eggplant emoji combo explained. A suggestive pairing used in flirty contexts.",
   "relatedCombos": ["eggplant-peach", "smirk-devil"],
   "tags": ["suggestive", "flirty", "intimate", "dating", "adult"],
-  "popularity": 90
+  "popularity": 90,
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "🍑🍆 is the reverse-order cousin of the eggplant-peach pair — the same two emoji, but peach in front of eggplant — and the meaning is identical. The dual-peach-eggplant pattern is so universally understood as a flirtatious shorthand that the order rarely matters. On Twitter, Instagram, and TikTok the combo shows up wherever the eggplant-peach combination does, with the same spicy vibe, the same inside-joke energy, and the same understanding that the sender is signaling something adult. The combo is interchangeable across the two orders; both land on the same suggestive beat.\n\nThe reason 🍑🍆 works is that the meaning lives in the pair, not the sequence. Most users will not even notice whether the peach is first or the eggplant is first — they will read the visual shorthand and immediately understand the implication. Order is a stylistic choice, not a semantic one. Writers should reach for 🍑🍆 whenever the moment calls for the explicit suggestive shorthand and the specific order is a personal preference.",
+    "howPeopleUseIt": "🍑🍆 arrives as the punchline on a flirty message, the comment on a spicy photo, or as the reaction to something the sender wants to mark as adult. On TikTok and Twitter the combo shows up under thirst traps and sexually suggestive content; on Instagram it lands as the bolder compliment on risqué fashion content. In dating-app conversations it functions as the explicit closer, the emoji equivalent of typing 'come over.'\n\nIn group chats 🍑🍆 doubles as the universal 'we are all adults here' reaction when a conversation turns risqué. The combo also pairs naturally with 😈 for max heat, with 🥵 for emphasis, and with the matching eggplant-peach for symmetry. The combo is rarely used in workplace channels or family threads; the suggestion is too overt for safe professional reading.",
+    "whenNotToUse": "Skip 🍑🍆 in any context where the recipient has not opted into the flirtatious reading — in work channels, in support replies, in family group chats, or in customer comms. A 🍑🍆 in a customer-facing complaint thread will sound predatory and is a fast way to lose trust. Avoid it in first-contact dating messages where the rapport has not been established; the combo is too forward when you do not yet know if the other person is on the same page.\n\nAlso avoid 🍑🍆 when you do not want to be perceived as overtly sexual. The suggestion is so widely recognized that using the combo in a food thread will derail the conversation. If your reference is genuinely about peaches and eggplant parmesan, use the emoji alone with a clarifying sentence.",
+    "howToReply": "Mirror 🍑🍆 with another 🍑🍆 or with 🔥 or 😈 if you want to keep the heat going, or upgrade to 🥵 for emphasis. If you receive the combo and the flirtation is welcome, a heart, a 🔥, or a suggestive sentence closes the loop in matching energy.\n\nIf 🍑🍆 lands and the energy is not welcome, a 😐 or 🙄 sends a clear 'we are done here' signal without a paragraph. And if you want to tease someone about overuse of the combo, a 'real original' lands the joke without escalating.",
+    "faqs": [
+      {
+        "question": "What does 🍑🍆 mean in texting?",
+        "answer": "🍑🍆 means the sender is being sexually suggestive or flirtatious. The reverse-order pairing of peach and eggplant carries the same implication as the more common eggplant-peach."
+      },
+      {
+        "question": "Is 🍑🍆 flirty?",
+        "answer": "Yes. 🍑🍆 is one of the most flirty emoji combos on the keyboard and reads as overtly suggestive regardless of the surrounding message."
+      },
+      {
+        "question": "What does 🍑🍆 mean from a girl?",
+        "answer": "From a girl or anyone else, 🍑🍆 means the sender is signaling sexual interest or teasing. There is no gendered meaning; the combo is about the heat, not who is sending it."
+      },
+      {
+        "question": "What does 🍑🍆 mean from a guy?",
+        "answer": "From a guy, 🍑🍆 has the same meaning it has from anyone else: suggestive or sexually teasing content. The combo is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "dating",
+      "message": "you coming over? 🍑🍆",
+      "interpretation": "Explicit invite in a flirty dating conversation. Mirror with 🍑🍆 or a suggestive sentence if the energy is mutual; close the loop politely if it is not."
+    },
+    {
+      "setting": "social",
+      "message": "that fit pic was 🍑🍆",
+      "interpretation": "Public reaction to a spicy photo. Mirror with 🍑🍆 or 🔥 to match the energy."
+    },
+    {
+      "setting": "friends",
+      "message": "did you see her DM 🍑🍆",
+      "interpretation": "Friend flagging an explicit message. Mirror with 🍑🍆 or 😈 to engage with the joke."
+    },
+    {
+      "setting": "family",
+      "message": "dad just discovered the combo 🍑🍆",
+      "interpretation": "Family group laughter at an older relative learning the slang. Mirror with 😬 or a sentence that lands the joke gently."
+    },
+    {
+      "setting": "work",
+      "message": "the demo went sideways 🍑🍆",
+      "interpretation": "Risky in a workplace context; the slang reading will land first. Replace with a safer reaction like 😬 or 🙃 in shared channels."
+    }
+  ]
 }

--- a/src/data/combos/pleading-sparkles.json
+++ b/src/data/combos/pleading-sparkles.json
@@ -11,5 +11,58 @@
   "seoDescription": "What does 🥺✨ mean? The pleading face and sparkles combo explained. Used to make requests extra cute and persuasive.",
   "relatedCombos": ["sparkles-heart-sparkles"],
   "tags": ["pleading", "cute", "persuasive", "soft", "request"],
-  "popularity": 82
+  "popularity": 82,
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "🥺✨ is the soft-pleading combo, the pleading face stacked with sparkles to make the request feel extra cute and persuasive. The pairing is the universal 'pretty please' reaction, used when the sender wants to soften a request with maximum sweetness. On Twitter and TikTok 🥺✨ shows up under friend-asks, public-petition posts, and any moment the sender wants to underline that the plea is at full cute capacity. The combo is interesting because it spans the literal pleading and the sparkle-emphasis, making it both more emphatic than 🥺 alone and more persuasive than ✨ alone.\n\nThe combo also doubles as the universal 'pretty please' reaction. A friend asks for a favor and the appropriate reply is 🥺✨ — the visual tag for the soft-persuasion beat. The doubled emoji lands more emphatic than either single emoji, which is why the combo works best when the request is genuinely soft and the answer is genuinely up for negotiation.",
+    "howPeopleUseIt": "🥺✨ arrives as the closer on a friend's favor-ask, the reaction to a public-petition post, or the punchline on a 'pretty please' moment. On Twitter it functions as the standard reaction to a public cute-ask. On Instagram captions the combo lands as the signature reaction on a pet photo or a soft request. On TikTok creators paste 🥺✨ on plea clips as the visual tag for the moment the ask lands.\n\nIn group chats 🥺✨ works as the shared 'please say yes' reaction when a friend makes a request. The combo also pairs naturally with 🙏 for the prayer-emphasis, with a sentence that names what is being requested, and with ❤️ for the warmth-emphasis when the request is heartfelt.",
+    "whenNotToUse": "Skip 🥺✨ in contexts where the cute-pleading will land wrong — in serious professional channels, in customer complaint replies, or in formal client emails. A 🥺✨ in a customer complaint thread will sound tone deaf. Avoid it in conversations where the recipient does not want the persuasion undertone.\n\nAlso avoid 🥺✨ when the situation actually calls for a different moment. The combo is more coded than a polite ask, so 🥺✨ on a coworker's first-draft request may read as performative. Reach for words or a sentence when the message warrants direct communication.",
+    "howToReply": "Mirror 🥺✨ with another 🥺✨ or 🙏 if you want to keep the pretty-please going, or upgrade to ❤️ for the warmth. If you receive 🥺✨ on a friend's favor-ask, reply with a sentence that engages with the actual ask.\n\nIf 🥺✨ arrives as a soft request, mirror with a sentence that acknowledges the plea. And if you want to send 🥺✨ as a soft friendly reaction, anchor the combo with a sentence that names what is being asked so the pretty-please does not feel performative.",
+    "faqs": [
+      {
+        "question": "What does 🥺✨ mean in texting?",
+        "answer": "🥺✨ means 'pretty please' or 'soft pleading.' The pleading-sparkles combo signals a cute persuasive request, more emphatic than 🥺 alone."
+      },
+      {
+        "question": "What does 🥺✨ mean from a girl?",
+        "answer": "From a girl or anyone else, 🥺✨ means the sender is making a soft persuasive request. There is no gendered meaning; the combo is about the ask, not who is sending it."
+      },
+      {
+        "question": "Is 🥺✨ flirty?",
+        "answer": "🥺✨ can read as flirty in a dating context, especially paired with a cute request. In other contexts it stays in the soft-pleading zone."
+      },
+      {
+        "question": "What does 🥺✨ mean from a guy?",
+        "answer": "From a guy, 🥺✨ has the same meaning it has from anyone else: soft pleading or pretty please. The combo is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "can i have a bite 🥺✨",
+      "interpretation": "Friend making a cute request. Mirror with 🥺✨ or a sentence that engages with the ask."
+    },
+    {
+      "setting": "social",
+      "message": "please bring it back 🥺✨",
+      "interpretation": "Public petition post. Mirror with 🥺✨ or a sentence that engages with the request."
+    },
+    {
+      "setting": "dating",
+      "message": "one more episode 🥺✨",
+      "interpretation": "Partner's cute request. Mirror with 🥺✨ or a sentence that engages with the ask."
+    },
+    {
+      "setting": "family",
+      "message": "can we get the puppy 🥺✨",
+      "interpretation": "Family petition. Mirror with a heart or a sentence that engages with the request."
+    },
+    {
+      "setting": "work",
+      "message": "can we ship today 🥺✨",
+      "interpretation": "Risky in a wide team channel; safe in a tight collaborator DM. If used in a team channel, anchor with a sentence that adds context."
+    }
+  ]
 }

--- a/src/data/combos/red-flag-running.json
+++ b/src/data/combos/red-flag-running.json
@@ -13,7 +13,60 @@
   "category": "relationship",
   "seoTitle": "🚩🏃 Red Flag Running Combo Meaning",
   "seoDescription": "What does 🚩🏃 mean? The red flag and running emoji combo explained. Used to indicate fleeing from warning signs.",
-  "relatedCombos": [],
+  "relatedCombos": ["red-flags-dating"],
   "tags": ["warning", "red flag", "escape", "dating", "advice"],
-  "popularity": 84
+  "popularity": 84,
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "🚩🏃 is the warning-and-flee combo, the red flag stacked with a running figure to underline the 'this is bad, run' beat. The pairing is rare in practice — most senders reach for 🚩 alone — but the doubled emoji hits harder when the sender wants to specifically call for escape. On Twitter and TikTok 🚩🏃 shows up under dating-roast videos, public-warning posts, and friend-group callouts. The combo is interesting because it spans the literal 'I am running' reading and the softer 'you should run' advice tag.\n\nThe combo also doubles as the universal 'flee immediately' reaction. A friend shares a dating-profile red flag and the appropriate reply is 🚩🏃 — the visual tag for the warning-and-flee beat. The doubled emoji lands more emphatic than 🚩 alone, which is why the combo works best when the sender wants to specifically mark the situation as worth running from.",
+    "howPeopleUseIt": "🚩🏃 arrives as the closer on a dating-red-flag story, the reaction to a public warning, or the punchline on a friend's questionable life choice. On Twitter it functions as the standard reaction to a public flag-stack. On Instagram captions the combo lands as the signature reaction on a relationship meme. On TikTok creators paste 🚩🏃 under storytime videos as the visual tag for the moment the red flag lands.\n\nIn group chats 🚩🏃 works as the shared 'run away' reaction when a friend shares a date or a job offer with warning signs. The combo also pairs naturally with 🚩 for the warning-emphasis, with a sentence that names the specific flag, and with 🏃 for the flee-only sibling when the flag is implied.",
+    "whenNotToUse": "Skip 🚩🏃 in contexts where the warning will land wrong — when the recipient is actually going through a hard time, in serious professional feedback, or in conversations where the joke will read as bullying. A 🚩🏃 on a coworker's small typo will land wrong. Avoid it on a friend's vulnerable post; the flee beat will read as dismissive.\n\nAlso avoid 🚩🏃 when the situation actually calls for a different moment. The combo is more emphatic than a flag alone, so 🚩🏃 on a friend's minor quirk reads as performative. Reach for 🚩 alone or a sentence of care when the message warrants nuance.",
+    "howToReply": "Mirror 🚩🏃 with another 🚩🏃 or 🚩 if you want to keep the warning going, or upgrade to 🚩🚩🚩 for the multi-flag stack. If you receive 🚩🏃 on a friend's date, reply with a sentence that engages with the specific concern.\n\nIf 🚩🏃 arrives on your own post, mirror with a sentence that confirms the regret so the bit lands cleanly. And if you want to send 🚩🏃 as a soft friendly reaction, anchor the combo with a sentence that names what is so warning-worthy so the flee beat does not feel performative.",
+    "faqs": [
+      {
+        "question": "What does 🚩🏃 mean in texting?",
+        "answer": "🚩🏃 means 'this is a warning, run away.' The red-flag-running combo signals a dating or situation warning with explicit flee energy, more emphatic than 🚩 alone."
+      },
+      {
+        "question": "What does 🚩🏃 mean from a girl?",
+        "answer": "From a girl or anyone else, 🚩🏃 means the sender is flagging a warning sign with explicit flee advice. There is no gendered meaning; the combo is about the warning, not who is sending it."
+      },
+      {
+        "question": "Is 🚩🏃 flirty?",
+        "answer": "🚩🏃 is not flirty. It marks a warning with flee advice, with no romantic undercurrent. Using it on a romantic post will read as a warning rather than flirtation."
+      },
+      {
+        "question": "What does 🚩🏃 mean from a guy?",
+        "answer": "From a guy, 🚩🏃 has the same meaning it has from anyone else: warning with flee advice. The combo is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "dating",
+      "message": "his dating profile 🚩🏃",
+      "interpretation": "Friend reacting to a questionable profile. Mirror with 🚩🏃 or a sentence that adds to the roast."
+    },
+    {
+      "setting": "friends",
+      "message": "she said 'I'm not like other girls' 🚩🏃",
+      "interpretation": "Friend flagging a dating red flag. Mirror with 🚩🏃 or a sentence that engages with the warning."
+    },
+    {
+      "setting": "social",
+      "message": "the interview had three 🚩🏃",
+      "interpretation": "Public reaction to a bad interview. Mirror with 🚩🏃 or a sentence that engages with the warning."
+    },
+    {
+      "setting": "family",
+      "message": "her new boyfriend 🚩🏃",
+      "interpretation": "Family sharing concern. Mirror with a sentence that engages with the specific concern."
+    },
+    {
+      "setting": "work",
+      "message": "the job posting has 🚩🏃",
+      "interpretation": "Risky in a wide team channel; safe in a tight collaborator DM. If used in a team channel, anchor with a sentence that adds context."
+    }
+  ]
 }

--- a/src/data/combos/red-flags-dating.json
+++ b/src/data/combos/red-flags-dating.json
@@ -11,5 +11,58 @@
   "seoDescription": "What does 🚩🚩🚩 mean? Multiple red flags explained. Used when there are numerous warning signs.",
   "relatedCombos": ["red-flag-running"],
   "tags": ["warning", "red flags", "dating", "danger", "avoid"],
-  "popularity": 87
+  "popularity": 87,
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "🚩🚩🚩 is the universal warning combo, the three-stacked red flags that signal 'this is full of warning signs, run.' The repetition is the message — a single 🚩 is a flag, two 🚩🚩 is a pattern, three 🚩🚩🚩 is the clear-and-present-danger beat. On Twitter, TikTok, and Instagram the combo shows up on dating-profile roasts, bad-interview commentary, and any situation where the speaker is cataloging the warning signs. The 'red flag' phrase has become so central to Gen Z dating language that the emoji has stretched past its roots into the universal 'this is a problem' shorthand.\n\nThe combo also doubles as a way to react when a single flag is not enough. A friend's new partner texts 'we need to talk' and the appropriate reply is 🚩🚩🚩 — the visual tag for 'I see something and I am concerned.' The standard 'run don't walk' closer confirms the seriousness. Use 🚩🚩🚩 when the moment genuinely warrants the warning barrage, because the combo is so loud that overuse dilutes the genuine alarm.",
+    "howPeopleUseIt": "🚩🚩🚩 arrives as the comment on a dating profile screenshot, the reaction to a bad interview story, or the punchline on a friend's questionable life choice. On Twitter it functions as the standard reaction to a public statement that contains too many warning signs to count. On TikTok creators paste 🚩🚩🚩 on dating-roast videos as the visual tag for the warning. In group chats the combo works as the shared 'this is a problem' reaction when a friend shares a story that needs cataloging.\n\nThe combo also pairs naturally with a sentence that names the specific flag ('he said \"I don't believe in labels\" 🚩🚩🚩') and with the matching single-flag companion. Stand-alone 🚩🚩🚩 reads as warning; in a longer stack it leans dramatic.",
+    "whenNotToUse": "Skip 🚩🚩🚩 in contexts where the warning will land wrong — when the recipient is actually going through a hard time, in serious professional feedback, or in conversations whose stakes do not warrant the alarm. A 🚩🚩🚩 on a coworker's first-draft deck will read as hostile. Avoid it on a friend's vulnerable post; the warning will land wrong.\n\nAlso avoid 🚩🚩🚩 when the situation is genuinely concerning and the recipient needs actual support. A friend in a bad relationship needs empathy and a conversation, not a flag-storm emoji. Use the combo for the casual-warning cases where the joke lands safely.",
+    "howToReply": "Mirror 🚩🚩🚩 with another 🚩🚩🚩 if you want to keep the warning energy going, or upgrade to a sentence that adds a specific concern. If you receive 🚩🚩🚩 on a story you shared, treat it as a signal that the recipient saw something you may not have noticed and consider whether to engage with the warning.\n\nIf 🚩🚩🚩 arrives on a friend's questionable choice, mirror with a sentence that names the specific flag you noticed. And if you want to send 🚩🚩🚩 as a meta-reaction to a public failure, anchor the combo with a sentence that names what was so warning-worthy so the triple-flag does not feel performative.",
+    "faqs": [
+      {
+        "question": "What does 🚩🚩🚩 mean in texting?",
+        "answer": "🚩🚩🚩 means 'this is full of warning signs.' The triple-stack of red flags signals maximum concern and reads as 'there are too many issues to count.'"
+      },
+      {
+        "question": "Is 🚩🚩🚩 rude?",
+        "answer": "🚩🚩🚩 can read as judgmental, especially in personal or vulnerable contexts. Use it carefully when the recipient may not be in on the joke, since the warning signal can land wrong."
+      },
+      {
+        "question": "What does 🚩🚩🚩 mean from a girl?",
+        "answer": "From a girl or anyone else, 🚩🚩🚩 means the sender sees warning signs. There is no gendered meaning; the combo is about the concern, not who is sending it."
+      },
+      {
+        "question": "What does 🚩🚩🚩 mean on TikTok?",
+        "answer": "On TikTok 🚩🚩🚩 in the comments means the viewer thinks the content is full of warning signs. The stack signals catalog-level concern."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "dating",
+      "message": "their dating profile 🚩🚩🚩",
+      "interpretation": "Friend reacting to a questionable profile. Mirror with 🚩🚩🚩 or a sentence that adds to the roast."
+    },
+    {
+      "setting": "social",
+      "message": "the interview was 🚩🚩🚩",
+      "interpretation": "Public reaction to a bad interview. Mirror with 🚩🚩🚩 or a sentence that engages with the moment."
+    },
+    {
+      "setting": "friends",
+      "message": "he said he is 'not like other guys' 🚩🚩🚩",
+      "interpretation": "Friend flagging a dating warning. Mirror with 🚩🚩🚩 or a sentence that engages with the red flag."
+    },
+    {
+      "setting": "work",
+      "message": "the job posting has 🚩🚩🚩",
+      "interpretation": "Risky in a wide team channel. Anchor with a sentence that names the specific concern."
+    },
+    {
+      "setting": "family",
+      "message": "her new boyfriend 🚩🚩🚩",
+      "interpretation": "Family sharing concern. Mirror with a sentence that engages with the specific concern."
+    }
+  ]
 }

--- a/src/data/combos/rofl-laughing.json
+++ b/src/data/combos/rofl-laughing.json
@@ -11,5 +11,58 @@
   "seoDescription": "What does 🤣😂 mean? The ROFL and laughing emoji combo explained. Used for maximum laughter.",
   "relatedCombos": ["skull-laughing", "sob-laughing"],
   "tags": ["rofl", "laughing", "hilarious", "funny", "lmao"],
-  "popularity": 85
+  "popularity": 85,
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "🤣😂 is the maximum-laughter combo, the face-with-tears-of-joy stacked with the crying-laughing face for ROFL energy. The pairing is rare in practice — most senders reach for 🤣 alone — but the doubled emoji hits harder when the sender wants to underline the laughter. On Twitter and TikTok 🤣😂 shows up under reaction posts, voiceover joke clips, and friend-group storytimes. The combo is interesting because it spans the literal 'this destroyed me' reading and the softer 'this was funny' tag.\n\nThe combo also doubles as the universal 'I cannot breathe' reaction. A friend sends a clip and the appropriate reply is 🤣😂 — the visual tag for the laugh beat. The doubled emoji lands more emphatic than 🤣 alone, which is why the combo works best when the laughter is genuinely strong.",
+    "howPeopleUseIt": "🤣😂 arrives as the closer on a friend's storytime, the reaction to a viral clip, or the punchline on a self-deprecating tweet. On Twitter it functions as the standard reaction to a public joke. On Instagram captions the combo lands as the signature reaction on a funny story. On TikTok creators paste 🤣😂 under voiceover joke clips as the visual tag for the moment the punchline lands.\n\nIn group chats 🤣😂 works as the shared 'I am deceased' reaction when a friend shares a joke. The combo also pairs naturally with 💀 for the skull-laugh sibling, with 😭 for the louder cry, and with a sentence that names what is so funny so the laugh combo does not feel generic.",
+    "whenNotToUse": "Skip 🤣😂 in contexts where the laughter will land wrong — in serious professional channels, in condolence threads, or in conversations where the recipient is actually sharing a hard moment. A 🤣😂 in a condolence thread will sound tone deaf. Avoid it on a friend's vulnerable post; the doubled laugh will land wrong.\n\nAlso avoid 🤣😂 when the actual moment calls for a different reaction. The combo is more emphatic than a heart, so 🤣😂 on a friend's small win may read as performative. Reach for a heart or a sentence of care when the message warrants simple appreciation.",
+    "howToReply": "Mirror 🤣😂 with another 🤣😂 or 💀 if you want to keep the laughter going, or upgrade to 😭 for the louder cry. If you receive 🤣😂 on a friend's joke, reply with a sentence that engages with the humor.\n\nIf 🤣😂 arrives as a reaction to your post, mirror with a sentence that keeps the joke going. And if you want to send 🤣😂 as a soft friendly reaction, anchor the combo with a sentence that names what is so funny so the doubled laugh does not feel performative.",
+    "faqs": [
+      {
+        "question": "What does 🤣😂 mean in texting?",
+        "answer": "🤣😂 means 'this is extremely funny' or 'rolling on the floor laughing.' The doubled-laughter combo signals maximum humor reaction, more emphatic than 🤣 alone."
+      },
+      {
+        "question": "What does 🤣😂 mean from a girl?",
+        "answer": "From a girl or anyone else, 🤣😂 means the sender is reacting with strong laughter. There is no gendered meaning; the combo is about the humor, not who is sending it."
+      },
+      {
+        "question": "Is 🤣😂 flirty?",
+        "answer": "🤣😂 is not flirty. It marks laughter or humor reaction, with no romantic undercurrent. Using it on a romantic post will read as supportive rather than flirtatious."
+      },
+      {
+        "question": "What does 🤣😂 mean from a guy?",
+        "answer": "From a guy, 🤣😂 has the same meaning it has from anyone else: maximum laughter or humor reaction. The combo is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "the way she said it 🤣😂",
+      "interpretation": "Friend sharing a laugh. Mirror with 🤣😂 or a sentence that engages with the humor."
+    },
+    {
+      "setting": "social",
+      "message": "this meme destroyed me 🤣😂",
+      "interpretation": "Public reaction to a meme. Mirror with 🤣😂 or a sentence that engages with the joke."
+    },
+    {
+      "setting": "dating",
+      "message": "your joke was fire 🤣😂",
+      "interpretation": "Partner's laughter reaction. Mirror with 🤣😂 or a sentence that engages with the humor."
+    },
+    {
+      "setting": "family",
+      "message": "dad's typo in the group chat 🤣😂",
+      "interpretation": "Family group laugh. Mirror with 🤣😂 or a sentence that engages with the typo."
+    },
+    {
+      "setting": "work",
+      "message": "the sprint demo clip 🤣😂",
+      "interpretation": "Risky in a wide team channel; safe in a tight collaborator DM. If used in a team channel, anchor with a sentence that adds context."
+    }
+  ]
 }

--- a/src/data/combos/skull-laughing.json
+++ b/src/data/combos/skull-laughing.json
@@ -8,5 +8,60 @@
   "examples": ["That video 💀😂 I can't breathe", "💀😂💀😂 this thread is killing me"],
   "category": "humor",
   "seoTitle": "💀😂 Dead Laughing Combo Meaning",
-  "seoDescription": "What does 💀😂 mean? The skull and laughing emoji combo explained. Used when something is extremely funny."
+  "seoDescription": "What does 💀😂 mean? The skull and laughing emoji combo explained. Used when something is extremely funny.",
+  "tags": ["funny", "laughter", "dead", "meme"],
+  "popularity": 95,
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "💀😂 is what happens when 'I'm dead' meets 'I'm crying laughing.' The combo stacks the two strongest laughter emojis on the keyboard — skull for the slang 'I'm dead' beat and the tears-of-joy face for the rolling-on-the-floor beat — so it lands as the maximum possible reaction. On TikTok, Twitter, and Instagram it is the gold-standard reply to a clip, a take, or a thread that genuinely broke the viewer, and it has become so common that posting a single 💀😂 under something already reads as high praise.\n\nThe combo also doubles as a way to react when neither emoji alone feels strong enough. A single 💀 reads as measured amusement; a single 😂 can feel overexposed after years of overuse. Putting them together amplifies both, and the redundancy is the point — the sender wants you to know the content earned the maximum possible reaction. Writers should treat 💀😂 as the ceiling for casual humor and reserve it for content that really does deserve it.",
+    "howPeopleUseIt": "💀😂 arrives after a punchline, a cursed screenshot, or a piece of news too stupid to be real. It is often stacked two or three times in a row (💀😂💀😂) when the moment is genuinely devastating. The combo pairs naturally with a screenshot of the offending content and with phrases like 'I cannot' or 'I'm done.' It also travels well as a TikTok comment under viral videos and as a quote-tweet reaction to a public statement worth screenshotting.\n\nIn stan Twitter, sports Twitter, and group chats 💀😂 is the standard unit of shared laughter. It is rarely used alone in serious or professional contexts because the energy is performatively extreme, and sending it to a customer-support inbox will read as disrespectful. The combo also works as a soft comeback: when a friend makes a self-deprecating joke that lands, 💀😂 acknowledges the joke without having to type out 'that's so funny.'",
+    "whenNotToUse": "Skip 💀😂 when you are actually grieving, when the other person has shared something painful, or in any professional channel where the recipient may read it literally. Avoid using it as a response to bad news, layoffs, or a hospital update, even ironically; the slang has not spread far enough for the joke to land safely. In customer support or HR contexts the combo will read as disrespectful regardless of intent.\n\nAlso avoid pairing 💀😂 with sensitive topics like religion, race, illness, or politics in group chats where you do not control the audience. The skull-laugh combo is a meme, and memes age poorly when removed from their original context. When in doubt, send a softer reaction emoji like 😅 or 🙃 that signals humor without the morbidity undercurrent.",
+    "howToReply": "If someone sends you 💀😂 and you want to keep the energy, mirror them with another 💀😂 or with 😭 to keep the laugh thread going. If you want to slow the bit down, you can reply with a softer 😅 or a 'wait, actually?' to pull the conversation back to literal mode without killing the joke.\n\nIf the 💀😂 landed on something you shared and it feels like a brush-off, you can ask 'too far?' and most people will clarify that they meant it affectionately. If you are the one whose post collected a string of 💀😂, treat it as a win — the content was strong enough to break the reader.",
+    "faqs": [
+      {
+        "question": "What does 💀😂 mean?",
+        "answer": "💀😂 means something is so funny the sender is 'dead laughing' — it is the maximum possible humor reaction. The combo amplifies the skull's 'I'm dead' slang with the tears-of-joy face for emphasis."
+      },
+      {
+        "question": "Is 💀😂 flirty?",
+        "answer": "Usually no. 💀😂 is a humor reaction, not a flirtation signal. If flirtation is involved it tends to come from the surrounding message rather than the combo itself."
+      },
+      {
+        "question": "What does 💀😂 mean from a girl?",
+        "answer": "From a girl or anyone else, 💀😂 means the sender thought the content was hilarious. There is no gendered meaning; the combo is about the strength of the reaction, not who is sending it."
+      },
+      {
+        "question": "What does 💀😂 mean on TikTok?",
+        "answer": "On TikTok a single 💀😂 in the comments means the viewer laughed hard, and a string of three or more means the video genuinely broke them. Creators often count the combo as a soft metric of how well a punchline landed."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "bro that tiktok of the cat falling into the pool 💀😂",
+      "interpretation": "Friend sharing a viral video. Mirror with 💀😂 or a screenshot reply to keep the bit going."
+    },
+    {
+      "setting": "social",
+      "message": "the way the CEO announced the layoffs 💀😂",
+      "interpretation": "Group chat reaction to a tone-deaf public statement. Mirror with 💀😂 or a quote-tweet to keep the thread moving."
+    },
+    {
+      "setting": "work",
+      "message": "client just replied-all to the wrong thread 💀😂",
+      "interpretation": "Sympathetic work disaster. Mirror with 💀😂 in a tight team chat; avoid using the combo in the wider org."
+    },
+    {
+      "setting": "dating",
+      "message": "you really thought i was serious 💀😂",
+      "interpretation": "Playful teasing after a misunderstanding. A warm reply that acknowledges the joke lands better than another combo."
+    },
+    {
+      "setting": "family",
+      "message": "Dad just learned how to use emojis 💀😂",
+      "interpretation": "Family group laughter at an older relative learning the keyboard. Mirror with another combo or a supportive sentence."
+    }
+  ]
 }

--- a/src/data/combos/smirk-wink.json
+++ b/src/data/combos/smirk-wink.json
@@ -11,5 +11,58 @@
   "seoDescription": "What does 😏😉 mean? The smirk and wink combo explained. Used for flirty or knowing implications.",
   "relatedCombos": ["smirk-devil"],
   "tags": ["flirty", "suggestive", "knowing", "playful", "hint"],
-  "popularity": 78
+  "popularity": 78,
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "😏😉 is the combo that turns a smirk and a wink into a single layered signal. The smirk 😏 says 'I am up to something' and the wink 😉 says 'and I am letting you in on it,' so the combination reads as playful implication rather than a clean statement. On dating-app openers, in flirty DMs, and in playful group chats 😏😉 is the standard 'if you know what I mean' signal. The combo also works as a knowing nod between friends when one person is teasing the other about a secret.\n\nThe combo is flirty by default but it does not have to be romantic. Two friends who share an inside joke can use 😏😉 as a wink-and-nudge signal that says 'you and I both know what is going on here.' The key variable is the relationship and the context: 😏😉 from a date or crush reads as flirtation, 😏😉 from a friend reads as in-joke, and 😏😉 from a stranger reads as weird. Writers should default to the combo only when the audience will read it correctly, and avoid it in mixed or professional channels.",
+    "howPeopleUseIt": "😏😉 arrives at the end of a flirty message, after a suggestive implication, or as a stand-alone reaction that signals 'I know something you do not.' In dating-app conversations the combo is the standard closer for a flirty opener, used the way a wink works in body language. In group chats it functions as the emoji equivalent of a knowing elbow nudge — a friend hints at a secret and replies 😏😉 to acknowledge the shared knowledge.\n\nThe combo pairs naturally with other flirty emojis: 😏😉🔥 for 'that outfit is dangerous,' 😏😉😍 for 'I cannot stop thinking about you,' and 😏😉💋 for full-throated flirtation. It also works as a softener for sarcasm — a friend makes a dry joke and you reply 😏😉 to signal you caught the joke without writing it out. The combo is rarely used in professional channels because the energy is too loaded.",
+    "whenNotToUse": "Skip 😏😉 in any context where the recipient might misread the flirtation — a coworker, a customer, a manager, or anyone you are not already on flirty terms with will read the combo as inappropriate. Avoid it in customer-facing comms, where the wink reads as sleazy. And do not send 😏😉 to someone who has not signaled they are open to that kind of energy, because the combo has a low tolerance for being misdirected.\n\nAlso avoid using 😏😉 to imply something serious in a way that could be misunderstood. The combo is playful by default, so if you are trying to communicate something weighty — a real concern, a confession, a serious ask — reach for words instead. Save 😏😉 for moments that genuinely warrant the playful, suggestive energy.",
+    "howToReply": "Mirror 😏😉 with another 😏😉 if you want to keep the energy flirty, or reply with 😏 alone for a softer acknowledgment. A short flirty line ('not so fast 😏😉') or a sentence that leans into the implication lands better than a stand-alone mirror if you want to escalate the warmth.\n\nIf you receive 😏😉 and you want to push the flirtation forward, mirror the combo with a playful line of your own. If you want to soften the read without killing the bit, reply with a softer reaction like 😊 so the message registers as friendly rather than flirtatious. The combo is a conversation-closer with a wink, so most replies either match it or pivot to the next beat.",
+    "faqs": [
+      {
+        "question": "What does 😏😉 mean?",
+        "answer": "😏😉 means 'I know something you do not' or 'if you know what I mean.' It is a flirty, suggestive combo used to imply something without saying it outright."
+      },
+      {
+        "question": "Is 😏😉 flirty?",
+        "answer": "Yes, 😏😉 is inherently flirty. The smirk adds suggestive energy and the wink adds a 'letting you in on it' signal. Use it only when the recipient will read it as playful rather than creepy."
+      },
+      {
+        "question": "What does 😏😉 mean from a girl?",
+        "answer": "From a girl, 😏😉 is a flirty signal that says she is implying something without saying it. It can be flirtatious or just playful, depending on the relationship and context."
+      },
+      {
+        "question": "What does 😏😉 mean on Snapchat?",
+        "answer": "On Snapchat 😏😉 reads as flirty implication the same way it does on other platforms. The combo is a standard closer for flirty DMs and is rarely used outside of playful contexts."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "dating",
+      "message": "I might have planned a second date already 😏😉",
+      "interpretation": "Flirty hint about a planned next date. Mirror with a flirty reply or a sentence that leans into the implication."
+    },
+    {
+      "setting": "friends",
+      "message": "don't tell anyone but I already bought the tickets 😏😉",
+      "interpretation": "Friend teasing about a surprise plan. Mirror with another 😏😉 or a sentence that plays along."
+    },
+    {
+      "setting": "social",
+      "message": "and that's how I got the last slice 😏😉",
+      "interpretation": "Group chat humble brag. Mirror with a reaction or a sentence that plays along with the flex."
+    },
+    {
+      "setting": "work",
+      "message": "I may have cc'd the whole leadership team on that thread 😏😉",
+      "interpretation": "Playful inside joke about office politics. Risky in a wide team channel; safe only between tight collaborators who know the context."
+    },
+    {
+      "setting": "family",
+      "message": "I told Mom what you did 😏😉",
+      "interpretation": "Sibling teasing about a shared secret. Mirror with a reaction or a sentence that plays along."
+    }
+  ]
 }

--- a/src/data/combos/sob-broken-heart.json
+++ b/src/data/combos/sob-broken-heart.json
@@ -15,5 +15,58 @@
   "seoDescription": "What does 😭💔 mean? The sobbing and broken heart emoji combo explained. Used to express heartbreak and emotional pain.",
   "relatedCombos": [],
   "tags": ["sad", "heartbreak", "devastated", "emotional", "crying"],
-  "popularity": 88
+  "popularity": 88,
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "😭💔 is the emotional devastation combo, the one that says 'I am wrecked.' Crying face stacked with broken heart does the maximum-possible sadness on the keyboard, layering the act of crying with the visual heartbreak so the message lands as full emotional collapse. On Twitter, Instagram, and TikTok 😭💔 shows up under breakup announcements, sad-clown slip-ups, or any moment the sender wants to mark as painful. The double-emoji pattern also doubles as the dramatic-comedy reaction — a cancelled concert, a deleted tweet, a moment that warrants the sad-flute soundtrack.\n\nThe combo is unusually versatile because both readings — genuine or dramatic — land on the same visual beat. The 😭 does the crying work and the 💔 does the heartbreak work, so the meaning is clear regardless of whether the sender is being sincere or performing. Writers should reach for 😭💔 when the moment calls for maximum emotional weight and the audience will understand the tone.",
+    "howPeopleUseIt": "😭💔 arrives as the closer on a breakup announcement, the caption on a sad edit, or the punchline on a disappointing update. On Instagram captions the combo lands as the signature flourish on a personal loss, a cancelled event, or a moment that warranted the sad music. On Twitter it functions as the public 'I am devastated' reaction to a major loss or a personal share. On TikTok creators paste 😭💔 on breakup storytimes and emotional reveals as the visual tag for the heartbreaking moment.\n\nIn group chats 😭💔 works as the absorbing reaction when a friend shares a sad update. The combo also pairs naturally with 😢 for the genuinely crying alternative, with 🥺 for the pleading sadness, and with a sentence that names the loss so the combo does not feel performative.",
+    "whenNotToUse": "Skip 😭💔 in contexts where the heartbreak reading will land wrong — in serious professional channels, in customer complaint threads, or in condolences where the recipient is actually grieving. A 😭💔 in a customer complaint reply will sound tone deaf. Avoid it in genuinely sad moments where the user needs empathy, not a combo emoji.\n\nAlso avoid 😭💔 when the disappointment is too minor to warrant the heavy combination. A 😭💔 on a slow Wi-Fi day reads as dramatic and undercuts the genuine weight the emoji carries. Match the combo to the actual gravity of the moment.",
+    "howToReply": "Mirror 😭💔 with another 😭💔 or 😢 if you want to keep the heaviness going, or upgrade to a soft sentence that acknowledges the weight. If you receive 😭💔 on a breakup announcement, reply with a heart or a 'thinking of you' so the care lands without piling on more drama.\n\nIf 😭💔 arrives as a dramatic disappointment reaction, mirror with a softer reaction or a sentence that matches the actual gravity. And if you want to send 😭💔 on a friend's sad post, anchor the combo with a sentence that names what happened so the heart does not feel performative.",
+    "faqs": [
+      {
+        "question": "What does 😭💔 mean in texting?",
+        "answer": "😭💔 means 'I am devastated' or 'this is heartbreaking.' The crying-and-broken-heart combo signals maximum emotional weight and reads as either genuine heartbreak or dramatic disappointment."
+      },
+      {
+        "question": "Is 😭💔 flirty?",
+        "answer": "No, 😭💔 is not flirty. It marks emotional pain or loss, sitting on the opposite side of the spectrum from romantic interest. Using it around someone you are flirting with will read as confusing."
+      },
+      {
+        "question": "What does 😭💔 mean from a girl?",
+        "answer": "From a girl or anyone else, 😭💔 means the sender is heartbroken or dramatically disappointed. There is no gendered meaning; the combo is about the emotional weight, not who is sending it."
+      },
+      {
+        "question": "What does 😭💔 mean from a guy?",
+        "answer": "From a guy, 😭💔 has the same meaning it has from anyone else: heartbreak or serious disappointment. The combo is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "dating",
+      "message": "we broke up 😭💔",
+      "interpretation": "Friend announcing a breakup. Mirror with a soft heart or a sentence that lands care without piling on drama."
+    },
+    {
+      "setting": "social",
+      "message": "concert cancelled 😭💔",
+      "interpretation": "Public disappointment reaction. Mirror with 😭💔 or 😢 to match the sadness."
+    },
+    {
+      "setting": "friends",
+      "message": "they did not invite me 😭💔",
+      "interpretation": "Friend sharing a social exclusion. Mirror with a softer reaction or a sentence that validates the hurt."
+    },
+    {
+      "setting": "family",
+      "message": "grandma's pie is gone 😭💔",
+      "interpretation": "Family sharing a sad loss. Mirror with a soft heart or a sentence that acknowledges the moment."
+    },
+    {
+      "setting": "work",
+      "message": "the project got cut 😭💔",
+      "interpretation": "Team disappointment in a tight channel. Mirror with a softer reaction or a sentence that acknowledges the team."
+    }
+  ]
 }

--- a/src/data/combos/sob-laughing.json
+++ b/src/data/combos/sob-laughing.json
@@ -11,5 +11,58 @@
   "seoDescription": "What does 😭😂 mean? The sobbing and laughing emoji combo explained. Used when laughing uncontrollably.",
   "relatedCombos": ["skull-laughing", "weary-sob"],
   "tags": ["laughing", "crying", "hilarious", "funny", "uncontrollable"],
-  "popularity": 86
+  "popularity": 86,
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "😭😂 is the laughing-crying combo, the two-face 'I cannot stop laughing' beat that signals the emotional rollercoaster of something being too funny. The crying face stacked with the laughing face does the overflow humor work — the contradiction in the faces is the entire point, the visual 'I am laughing and crying at the same time' beat. On Twitter, TikTok, and Instagram 😭😂 shows up under content that genuinely broke the viewer, and it has become the standard reaction to moments that warrant the overflow. The combo also functions as the safer alternative to the skull-laugh combo when the sender wants to keep the humor clean of the morbidity.\n\nThe combo stays universal because the meaning is unambiguous: this is funny to the point of pain. The 😭 does the crying work and the 😂 does the laughing work, so the contradiction in the faces lands as the emotional collapse rather than the actual sadness. Writers should reach for 😭😂 when the moment genuinely warrants the overflow, because the combo is so loud that overuse dilutes the special humor the emoji is built around.",
+    "howPeopleUseIt": "😭😂 arrives as the comment on a viral clip, the closer on a friend's joke, or the punchline on a thread that broke the reader. On Twitter it functions as the 'I am crying laughing' reaction that everyone pastes on the same content at once. On TikTok the combo shows up in comments under genuinely funny clips as the visual tag for the moment the joke landed. On iMessage 😭😂 works as the standard friend-group reaction to a shared joke that needs the overflow emphasis.\n\nThe combo also pairs naturally with 💀😂 for the skull-laughing stronger version, with 😂😂😂 for the triple-laugh alternative, and with a sentence that names what was so funny. Stand-alone 😭😂 reads as overflowing laughter; in a longer stack it leans performative.",
+    "whenNotToUse": "Skip 😭😂 in contexts where the content is not actually funny — in condolences, in serious professional channels, or in customer complaint replies. A 😭😂 on a friend's breakup post reads as dismissive. Avoid it in any thread where the recipient needs empathy rather than laughter.\n\nAlso avoid 😭😂 when you want to actually offer a thoughtful reaction. The combo is so loud that it overwhelms the actual message. Reach for a sentence or a softer reaction when the moment needs nuance.",
+    "howToReply": "Mirror 😭😂 with another 😭😂 or 💀😂 if you want to keep the laughter going, or upgrade to 😂😂😂 for the triple-stack. If you receive 😭😂 on your own content, reply with 'thanks 😂' or a sentence that acknowledges the reaction.\n\nIf 😭😂 arrives on a friend's joke, mirror with a sentence that adds to the bit. And if you want to send 😭😂 as a comment on something viral, anchor it with a sentence that names what was so funny so the combo does not feel performative.",
+    "faqs": [
+      {
+        "question": "What does 😭😂 mean in texting?",
+        "answer": "😭😂 means 'I am laughing and crying at the same time.' The crying-and-laughing combo signals overflow humor, the visual tag for content that is too funny to react to with a single face."
+      },
+      {
+        "question": "Is 😭😂 flirty?",
+        "answer": "😭😂 is not flirty. It marks overwhelming laughter, with no romantic undercurrent. Using it on a romantic post will read as supportive rather than flirtatious."
+      },
+      {
+        "question": "What does 😭😂 mean from a girl?",
+        "answer": "From a girl or anyone else, 😭😂 means the sender is laughing uncontrollably. There is no gendered meaning; the combo is about the laughter, not who is sending it."
+      },
+      {
+        "question": "What does 😭😂 mean on TikTok?",
+        "answer": "On TikTok 😭😂 in the comments means the viewer thought the content was hilarious. The combo signals overflow laughter — the video broke the viewer."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "that tiktok of the cat 😭😂",
+      "interpretation": "Friend sharing a viral clip. Mirror with 😭😂 or a sentence that adds to the laughter."
+    },
+    {
+      "setting": "social",
+      "message": "the way he announced it 😭😂",
+      "interpretation": "Public reaction to a hilarious moment. Mirror with 😭😂 or a sentence that engages with the joke."
+    },
+    {
+      "setting": "work",
+      "message": "the office prank 😭😂",
+      "interpretation": "Team laughter in a tight channel. Mirror with 😭😂 or a sentence that engages with the bit."
+    },
+    {
+      "setting": "dating",
+      "message": "you really said that 😭😂",
+      "interpretation": "Partner's playful disbelief. Mirror with 😭😂 or a sentence that engages with the joke."
+    },
+    {
+      "setting": "family",
+      "message": "grandpa at the wedding 😭😂",
+      "interpretation": "Family group laughter at a relative's antics. Mirror with 😭😂 or a sentence that engages with the moment."
+    }
+  ]
 }

--- a/src/data/combos/weary-sob.json
+++ b/src/data/combos/weary-sob.json
@@ -11,5 +11,58 @@
   "seoDescription": "What does 😩😭 mean? The weary and sobbing emoji combo explained. Used when completely overwhelmed with emotion.",
   "relatedCombos": ["sob-broken-heart"],
   "tags": ["overwhelmed", "emotional", "stressed", "too much", "crying"],
-  "popularity": 82
+  "popularity": 82,
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "😩😭 is the overwhelmed-crying combo, the weary face stacked with the sobbing face for 'this is too much to handle' energy. The pairing is the universal overload reaction, used when the sender wants to mark that whatever is happening is more than they can hold. On Twitter and TikTok 😩😭 shows up under stress posts, beautiful-scene reactions, and any moment the sender is at capacity. The combo is interesting because it spans the literal overwhelmed-crying reading and the softer 'why is this so good' overwhelmed tag, making it both more emphatic than 😩 alone and more emotional than 😭 alone.\n\nThe combo also doubles as the universal 'too much, I cannot' reaction. A friend vents about a deadline and the appropriate reply is 😩😭 — the visual tag for the overload beat. The doubled emoji lands more emphatic than either single emoji, which is why the combo works best when the overwhelm is genuinely strong.",
+    "howPeopleUseIt": "😩😭 arrives as the closer on a stress share, the reaction to a beautiful-scene post, or the punchline on a 'I am at capacity' moment. On Twitter it functions as the standard reaction to a public overwhelm moment. On Instagram captions the combo lands as the signature reaction on a scene-that-destroyed-me post. On TikTok creators paste 😩😭 on reveal clips as the visual tag for the moment the overwhelm lands.\n\nIn group chats 😩😭 works as the shared 'too much' reaction when a friend vents. The combo also pairs naturally with 💪 for the powering-through sibling, with 🥲 for the smiling-through-tears variant, and with a sentence that names what is being overwhelmed about so the combo does not feel generic.",
+    "whenNotToUse": "Skip 😩😭 in contexts where the overload reading will land wrong — in serious professional feedback, in customer complaint threads, or in conversations where the recipient is actually going through a hard time and needs real support. A 😩😭 in a customer complaint reply will sound tone deaf. Avoid it on a friend's vulnerable post; the overwhelm beat will land wrong if they need actual empathy.\n\nAlso avoid 😩😭 when the actual moment calls for a different reaction. The combo is more coded than a heart alone, so 😩😭 on a friend's small win reads as performative. Reach for a heart or a sentence of care when the message warrants simple appreciation.",
+    "howToReply": "Mirror 😩😭 with another 😩😭 or 💪 if you want to keep the overwhelm going, or upgrade to ❤️ for the warmth. If you receive 😩😭 on a stress share, reply with a sentence that engages with the specific stressor.\n\nIf 😩😭 arrives as a 'why is this so good' overwhelm, mirror with a sentence that engages with the moment. And if you want to send 😩😭 as a soft friendly reaction, anchor the combo with a sentence that names what is overwhelming so the beat does not feel performative.",
+    "faqs": [
+      {
+        "question": "What does 😩😭 mean in texting?",
+        "answer": "😩😭 means 'too much to handle' or 'overwhelmed crying.' The weary-sob combo signals overwhelm that can be stress, beauty, sadness, or positive-overload, more emphatic than either emoji alone."
+      },
+      {
+        "question": "What does 😩😭 mean from a girl?",
+        "answer": "From a girl or anyone else, 😩😭 means the sender is overwhelmed or at capacity. There is no gendered meaning; the combo is about the emotion, not who is sending it."
+      },
+      {
+        "question": "Is 😩😭 flirty?",
+        "answer": "😩😭 is not flirty. It marks overwhelm or emotional overload, with no romantic undercurrent. Using it on a romantic post will read as supportive rather than flirtatious."
+      },
+      {
+        "question": "What does 😩😭 mean from a guy?",
+        "answer": "From a guy, 😩😭 has the same meaning it has from anyone else: overwhelmed or at capacity. The combo is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "this deadline 😩😭",
+      "interpretation": "Friend sharing a stress moment. Mirror with 😩😭 or a sentence that engages with the stressor."
+    },
+    {
+      "setting": "work",
+      "message": "the launch was too much 😩😭",
+      "interpretation": "Team stress share in a tight channel. Mirror with 😩😭 or a sentence that engages with the moment."
+    },
+    {
+      "setting": "social",
+      "message": "that scene destroyed me 😩😭",
+      "interpretation": "Public overwhelm share. Mirror with 😩😭 or a sentence that engages with the moment."
+    },
+    {
+      "setting": "family",
+      "message": "the kids are too much today 😩😭",
+      "interpretation": "Family overwhelm share. Mirror with a heart or a sentence that engages with the day."
+    },
+    {
+      "setting": "dating",
+      "message": "missing you tonight 😩😭",
+      "interpretation": "Partner's overwhelm share. Mirror with a heart or a sentence that engages with the moment."
+    }
+  ]
 }

--- a/src/data/emojis/100.json
+++ b/src/data/emojis/100.json
@@ -38,15 +38,19 @@
   "platformNotes": [
     {
       "platform": "TWITTER",
-      "note": "Used to cosign statements or express total agreement."
+      "note": "Twitter stacks 💯 as a one-word cosign on hot takes; threading it under a quote-tweet is shorthand for 'facts, full stop.'"
     },
     {
       "platform": "INSTAGRAM",
-      "note": "Common in comments showing full support or validation."
+      "note": "Instagram commenters spam 💯 under supportive captions and reels; it doubles as a hype reaction and an authenticity stamp."
     },
     {
       "platform": "TIKTOK",
-      "note": "Used to confirm something is true or validate a take."
+      "note": "TikTok comments treat 💯 as a 'this is true' confirmation, often stacked on political or cultural takes the viewer wants to validate."
+    },
+    {
+      "platform": "WHATSAPP",
+      "note": "WhatsApp groups use 💯 to close a debate with 'facts' energy; in older family chats it can still read literally as a school score."
     }
   ],
   "generationalNotes": [
@@ -66,5 +70,58 @@
   "warnings": [],
   "relatedCombos": ["100-fire"],
   "seoTitle": "💯 Hundred Points Emoji Meaning - What Does 💯 Really Mean?",
-  "seoDescription": "Learn what the 100 emoji 💯 really means in modern texting. Means perfect, authentic, or total agreement. Complete context guide."
+  "seoDescription": "Learn what the 100 emoji 💯 really means in modern texting. Means perfect, authentic, or total agreement. Complete context guide.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "The 💯 hundred-points emoji has two clean readings and a third slang meaning that has come to dominate. Literally it is a red 100 with double underlines, the kind a teacher scrawls on a perfect test. Slang-wise it means 'this is perfect,' 'keeping it real,' or 'one hundred percent agree,' and that reading now wins on every social platform. A third informal usage — 💯 as shorthand for telling someone they look great or did something right — has spread from Instagram comments into everyday texting.\n\nThe split matters because 💯 in a parent-facing channel may still register as a literal score, while the same emoji on TikTok reads as enthusiastic validation. Most writers should default to the slang reading on social platforms and only use the literal meaning when the context makes it obvious (a math post, a test result, a sports stat). When the audience skews older, add a word or two so the emoji does not get misread as math homework.",
+    "howPeopleUseIt": "💯 shows up as a stand-alone reaction, sandwiched in a sentence as a beat of emphasis ('this fit 💯'), or stacked on top of another emoji for compound reactions. The pairing of 🔥💯 is the most common combo, used as the maximum hype signal: hot and flawless. 💯 also pairs with ❤️ for affectionate validation and with 👏 for performance praise.\n\nIn arguments and group chats 💯 acts as a closing punctuation mark. Someone makes a take, the chat responds with 💯 or 'facts 💯' to signal the debate is over. The emoji compresses an entire 'I agree completely' into a single character, which is why it survives in tight character-count contexts like Twitter replies. It also shows up as a self-applied hype tag — people slap 💯 onto their own bios, captions, and stories as a self-rating.",
+    "whenNotToUse": "Skip 💯 when you are grading something literally and the audience is mixed, because the slang reading will undercut the message. A teacher emailing a student 'great work 💯' may land as warm to Gen Z and confusing to parents. Avoid it in customer-facing complaint threads where the slang energy reads as dismissive of the customer's frustration.\n\nAlso avoid 💯 when the agreement is partial. The emoji is binary: it says 'I am at one hundred percent.' If you only mostly agree, use 👍 or 'makes sense' instead, so the recipient does not think you are overstating your position. And in formal professional writing — decks, RFPs, client briefs — keep 💯 out entirely; it reads as casual and slightly try-hard.",
+    "howToReply": "Mirror 💯 with another 💯 if you want to keep the energy, or layer a 🔥💯 if the content truly deserves maximum hype. When you receive 💯 on your own post, a short 'appreciate it 💯' or a thank-you message closes the loop without sounding try-hard.\n\nIf you receive 💯 in a debate and want to push the conversation forward, treat it as a closing signal and ask the next question instead of restating your position. If you suspect the 💯 is sarcastic, glance at the surrounding text — sarcastic 💯 usually arrives with 'wow' or 'okay' that tips the tone. And if someone sends 💯 in a context where the literal reading makes sense (a test result, a sale total), reply with a plain thank-you rather than mirroring the emoji.",
+    "faqs": [
+      {
+        "question": "What does 💯 mean in texting?",
+        "answer": "In texting 💯 means 'this is perfect,' 'keeping it real,' or 'one hundred percent agree.' The slang reading has dominated since the mid-2010s and now wins in most contexts."
+      },
+      {
+        "question": "What does 💯 mean from a girl?",
+        "answer": "From a girl, 💯 means the same thing it means from anyone else: full validation. There is no gendered meaning, only the standard slang 'one hundred percent' reading."
+      },
+      {
+        "question": "What does 💯 mean on Snapchat?",
+        "answer": "On Snapchat 💯 is sent as a Snap reaction to signal total support or that the sender thinks the content is flawless. It functions the same way it does on other social platforms."
+      },
+      {
+        "question": "Is 💯 flirty?",
+        "answer": "💯 is not inherently flirty. It is a hype and validation reaction. On a dating-app opener or a selfie comment it can read as flirtatious, but in a group chat it is just agreement."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "this group chat is unhinged 💯",
+      "interpretation": "Affectionate agreement about a chaotic thread. Mirror with another 💯 or 'facts' to keep the energy."
+    },
+    {
+      "setting": "dating",
+      "message": "you look amazing tonight 💯",
+      "interpretation": "Soft compliment. A heart emoji or a follow-up sentence lands warmer than just mirroring the 100."
+    },
+    {
+      "setting": "work",
+      "message": "ship it on Friday 💯",
+      "interpretation": "Confident work decision. Safe inside a tight team channel; tone down for cross-company comms."
+    },
+    {
+      "setting": "social",
+      "message": "she really said that on main 💯",
+      "interpretation": "Group hype about a public statement. Drop a quote-tweet or screenshot to keep the thread moving."
+    },
+    {
+      "setting": "family",
+      "message": "nailed the driving test 💯",
+      "interpretation": "Could be literal (a test score) or slang (validation). Reply with celebration either way; the family context usually reads as genuine praise."
+    }
+  ]
 }

--- a/src/data/emojis/blue-heart.json
+++ b/src/data/emojis/blue-heart.json
@@ -36,9 +36,22 @@
     }
   ],
   "platformNotes": [
-    { "platform": "TWITTER", "note": "Often used for sports teams or causes." },
-    { "platform": "INSTAGRAM", "note": "Popular for ocean and sky aesthetic." },
-    { "platform": "TIKTOK", "note": "Used in various contexts." }
+    {
+      "platform": "TWITTER",
+      "note": "Often used for sports teams, causes, and political identity hashtags."
+    },
+    {
+      "platform": "INSTAGRAM",
+      "note": "Popular for ocean, sky, and calm aesthetic content."
+    },
+    {
+      "platform": "TIKTOK",
+      "note": "Used in fandom posts and brand-loyalty content."
+    },
+    {
+      "platform": "DISCORD",
+      "note": "Server members use it as team-color or friendship reactions."
+    }
   ],
   "generationalNotes": [
     { "generation": "GEN_Z", "note": "Chill vibes heart." },
@@ -48,5 +61,58 @@
   "warnings": [],
   "relatedCombos": [],
   "seoTitle": "💙 Blue Heart Emoji Meaning",
-  "seoDescription": "Learn what the Blue Heart emoji 💙 really means."
+  "seoDescription": "Learn what the Blue Heart emoji 💙 really means.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "💙 is the loyalty heart, the blue counterpart to ❤️ that reads as trust, calm, and team-solidarity rather than romantic love. The blue color has carried meanings of loyalty and peace for so long in the hearts-and-flowers vocabulary that the emoji lands on a meaningfully different note than the red ❤️. On Twitter, Instagram, and TikTok 💙 shows up under friendship posts, sports-team content, brand-loyalty captions, and any moment the sender wants to mark as platonic solidarity rather than romance. The emoji also functions as the calm aesthetic heart — the one ocean and sky posts use as the visual tag for the cool blue palette.\n\nThe dual reading — friendship loyalty or aesthetic calm — keeps 💙 versatile without diluting its meaning. The emoji sits in the same family as the ❤️ (red heart) and the 💜 (purple heart) but lands as quieter, less romantic, and more chill. Writers should reach for 💙 when the moment calls for loyalty over passion.",
+    "howPeopleUseIt": "💙 arrives as a stand-alone reaction, a sentence closer on a friendship message, or as the visual tag for a brand-loyalty post. On Instagram captions the emoji lands as the cool-aesthetic signature on ocean and sky content. On Twitter quote-tweets it functions as the 'standing with this' reaction to a cause or a team. On TikTok creators paste 💙 on fandom posts and brand-loyalty content as the visual tag for the community color.\n\nIn group chats 💙 works as the friendship signal when a friend shares something supportive. The emoji also pairs naturally with other hearts for layered affection (💙💜 for friendship + BTS fandom, 💙❤️ for friend-romantic split) and with 🤍 for the white-blue friendship contrast. Stand-alone 💙 reads as loyalty; in a stack it leans aesthetic.",
+    "whenNotToUse": "Skip 💙 in contexts where the romantic reading would be more appropriate — on a partner's anniversary post, on a romantic confession, or in a deeply loving message. A 💙 on a partner's birthday post will read as friend-zone energy, which may not be the intended tone. Avoid it in scenes where the passion is needed; reach for ❤️.\n\nAlso avoid 💙 in political or organizational contexts where the brand-color association may be misread. A 💙 on a hospital post reads as medical context; on a sports event it reads as the team color. Pick the appropriate alternative for the channel.",
+    "howToReply": "Mirror 💙 with another 💙 or 🤍 if you want to keep the cool loyalty vibe, or upgrade to ❤️ for stronger romantic emphasis. If you receive 💙 on a friendship post, reply with 'thanks 💙' or a sentence that acknowledges the loyalty.\n\nIf 💙 arrives as a sports-team or cause reaction, mirror with a heart in the same color family or a sentence that engages with the team. And if you want to send 💙 as a soft romantic signal, anchor the emoji with a sentence that lands the intent so the blue heart does not feel like a friend-zone read.",
+    "faqs": [
+      {
+        "question": "What does 💙 mean in texting?",
+        "answer": "💙 means 'loyalty,' 'trust,' or 'calm love.' The blue heart reads as platonic solidarity or aesthetic calm rather than romantic passion, and works for friendships, brand loyalty, and team color."
+      },
+      {
+        "question": "What does 💙 mean from a girl?",
+        "answer": "From a girl or anyone else, 💙 means the sender feels loyal or sends calm affection. There is no gendered meaning; the emoji is about the loyalty, not who is sending it."
+      },
+      {
+        "question": "Is 💙 flirty?",
+        "answer": "💙 can read as soft flirty in a dating context, but it leans toward platonic or aesthetic loyalty. It is the chill alternative to ❤️ rather than the romantic emphasis."
+      },
+      {
+        "question": "What does 💙 mean from a guy?",
+        "answer": "From a guy, 💙 has the same meaning it has from anyone else: loyalty, trust, or calm affection. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "got your back always 💙",
+      "interpretation": "Friend's loyalty message. Mirror with 💙 or a sentence that engages with the support."
+    },
+    {
+      "setting": "social",
+      "message": "team color, all season 💙",
+      "interpretation": "Public sports-team reaction. Mirror with 💙 or a sentence that engages with the team."
+    },
+    {
+      "setting": "family",
+      "message": "love you mom 💙",
+      "interpretation": "Family warmth between close relatives. Mirror with 💙 or a heart to close the loop."
+    },
+    {
+      "setting": "dating",
+      "message": "you mean so much to me 💙",
+      "interpretation": "Romantic partner's calm love. Mirror with 💙 or ❤️ to match the warmth."
+    },
+    {
+      "setting": "work",
+      "message": "team made it 💙",
+      "interpretation": "Team win in a tight channel. Mirror with 💙 or a sentence that acknowledges the team."
+    }
+  ]
 }

--- a/src/data/emojis/broken-heart.json
+++ b/src/data/emojis/broken-heart.json
@@ -36,9 +36,22 @@
     }
   ],
   "platformNotes": [
-    { "platform": "TWITTER", "note": "Common for expressing disappointment." },
-    { "platform": "INSTAGRAM", "note": "Used in sad posts." },
-    { "platform": "TIKTOK", "note": "Dramatic content and breakup stories." }
+    {
+      "platform": "TWITTER",
+      "note": "Used for breakup announcements and public disappointment reactions."
+    },
+    {
+      "platform": "INSTAGRAM",
+      "note": "Shows up under sad single posts and unrequited love captions."
+    },
+    {
+      "platform": "TIKTOK",
+      "note": "Creators paste it on breakup storytimes and dramatic relationship content."
+    },
+    {
+      "platform": "DISCORD",
+      "note": "Group chat acknowledgment when a friend shares a sad update."
+    }
   ],
   "generationalNotes": [
     { "generation": "GEN_Z", "note": "Often used dramatically or ironically." },
@@ -46,7 +59,60 @@
     { "generation": "BOOMER", "note": "Serious emotional pain." }
   ],
   "warnings": [],
-  "relatedCombos": [],
+  "relatedCombos": ["sob-broken-heart"],
   "seoTitle": "💔 Broken Heart Emoji Meaning",
-  "seoDescription": "Learn what the Broken Heart emoji 💔 really means."
+  "seoDescription": "Learn what the Broken Heart emoji 💔 really means.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "💔 is the emoji that says 'love did not work out.' The visual cue is the heart sliced down the middle, the most direct visual metaphor for heartbreak in the Unicode set. On Twitter, Instagram, and TikTok the emoji shows up under breakup announcements, unrequited love posts, and dramatic disappointment reactions — anywhere the sender wants to mark the moment as a real loss rather than a minor setback. The combo with 😭 (sob-broken-heart) is the standard intensifier when the pain is genuine.\n\nThe emoji also doubles as the standard dramatic disappointment reaction. A cancelled concert, a sold-out drop, a creator's favorite show ending — all of these collect 💔 as the 'I am genuinely gutted' shorthand. The informal reading has stretched the emoji past its romantic roots into a general grief shorthand, which is why a 💔 on a friend's post about a job rejection or a missed opportunity reads as sincere. The dual use — heartbreak or dramatic disappointment — keeps 💔 versatile without diluting the emotional weight.",
+    "howPeopleUseIt": "💔 arrives as the closer on a breakup announcement, the caption on a sad single, or as the punchline reaction on a piece of cancelled news. On Instagram captions the emoji lands as the signature flourish on a soft-launch breakup, paired with a sober black-and-white photo. On Twitter quote-tweets it functions as the 'this is painful' reaction to public news that disappointed a fanbase. On TikTok creators paste 💔 on breakup storytimes as the visual tag for the moment the relationship ended.\n\nIn group chats 💔 works as the absorbing reaction when a friend shares a sad update. The emoji also pairs naturally with 😭 (sob-broken-heart) for maximum intensity, with 🖤 for the darker aesthetic, and with a sentence that names the loss so the heart does not feel generic.",
+    "whenNotToUse": "Skip 💔 in contexts where the disappointment is too minor to warrant the heavy heart — a cancelled lunch, a slow Wi-Fi day, a friend's small mistake. A 💔 on a minor inconvenience reads as dramatic and undercuts the genuine weight the emoji carries. Also avoid it as a joke in situations where someone is actually grieving or sharing real loss; the dramatic reading will land wrong.\n\nAlso avoid 💔 when you want to actually offer support. A friend who is going through a breakup needs a sentence or a heart emoji, not a dramatic 💔 that centers your reaction. Reserve the emoji for moments where the dramatic weight matches the actual loss.",
+    "howToReply": "Mirror 💔 with another 💔 or 😭 if you want to acknowledge the weight, or upgrade to a soft sentence that asks what the sender needs. If you receive 💔 on a breakup announcement, reply with a heart or a 'thinking of you' so the care lands without piling on more drama.\n\nIf 💔 arrives as a dramatic disappointment reaction, mirror with a softer reaction or a sentence that matches the actual gravity. And if you want to send 💔 on a friend's sad post, anchor the emoji with a sentence that names what happened so the heart does not feel performative.",
+    "faqs": [
+      {
+        "question": "What does 💔 mean in texting?",
+        "answer": "💔 means heartbreak or deep disappointment. The split-heart visual reads as either a literal breakup or as dramatic disappointment about a cancelled plan, a missed opportunity, or a lost relationship."
+      },
+      {
+        "question": "What does 💔 mean from a girl?",
+        "answer": "From a girl or anyone else, 💔 means the sender is heartbroken or dramatically disappointed. There is no gendered meaning; the emoji is about the emotional weight, not who is sending it."
+      },
+      {
+        "question": "Is 💔 flirty?",
+        "answer": "No, 💔 is not flirty. It marks emotional pain or loss, so it sits on the opposite side of the spectrum from romantic interest. Using it around someone you are flirting with will read as confusing."
+      },
+      {
+        "question": "What does 💔 mean from a guy?",
+        "answer": "From a guy, 💔 has the same meaning it has from anyone else: heartbreak or serious disappointment. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "dating",
+      "message": "we broke up 💔",
+      "interpretation": "Friend announcing a breakup. Mirror with a soft heart or a sentence that lands care without piling on drama."
+    },
+    {
+      "setting": "social",
+      "message": "concert cancelled 💔",
+      "interpretation": "Public disappointment reaction. Mirror with 💔 or 😢 to match the sadness."
+    },
+    {
+      "setting": "friends",
+      "message": "they actually did not invite me 💔",
+      "interpretation": "Friend sharing a social exclusion. Mirror with a softer reaction or a sentence that validates the hurt."
+    },
+    {
+      "setting": "family",
+      "message": "grandma's garden did not survive the storm 💔",
+      "interpretation": "Family sharing a loss. Mirror with a soft heart or a sentence that acknowledges the moment."
+    },
+    {
+      "setting": "work",
+      "message": "the project got cut 💔",
+      "interpretation": "Team disappointment in a tight channel. Mirror with a softer reaction or a sentence that acknowledges the team."
+    }
+  ]
 }

--- a/src/data/emojis/check-mark.json
+++ b/src/data/emojis/check-mark.json
@@ -36,9 +36,22 @@
     }
   ],
   "platformNotes": [
-    { "platform": "TWITTER", "note": "Confirmation and completion." },
-    { "platform": "INSTAGRAM", "note": "Checklist content." },
-    { "platform": "SLACK", "note": "Common for task completion." }
+    {
+      "platform": "SLACK",
+      "note": "The standard task-completion reaction in product and engineering channels."
+    },
+    {
+      "platform": "TWITTER",
+      "note": "Common for checklist updates and confirmation reactions."
+    },
+    {
+      "platform": "INSTAGRAM",
+      "note": "Used in stories for completed goals and checklist content."
+    },
+    {
+      "platform": "DISCORD",
+      "note": "Server admins use it for completed moderation actions and confirmations."
+    }
   ],
   "generationalNotes": [
     { "generation": "GEN_Z", "note": "Quick confirmation." },
@@ -48,5 +61,58 @@
   "warnings": [],
   "relatedCombos": [],
   "seoTitle": "✔️ Check Mark Emoji Meaning",
-  "seoDescription": "Learn what the Check Mark emoji ✔️ really means."
+  "seoDescription": "Learn what the Check Mark emoji ✔️ really means.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "✔️ is the universal completion emoji, the one that says 'task done, confirmed, moving on.' The check mark has carried the completion meaning in physical to-do lists for generations, so the emoji lands in chat with the same efficiency. On Slack, Teams, and Discord ✔️ shows up as the standard task-completion reaction; on Twitter it arrives as the closer on a checklist update. The emoji is one of the few that works equally well in professional and personal contexts because the meaning is unambiguous — no slang drift, no ironic reading, just done.\n\nThe dual reading — sincere or sarcastic — is the only soft spot. A ✔️ on a real achievement reads as confirmed; a ✔️ on a clearly failed plan reads as the 'sure, that happened' sarcasm. The context decides which reading lands, which is why the emoji works in both WhatsApp group chats and GitHub PR threads.",
+    "howPeopleUseIt": "✔️ arrives as the closer on a Slack task update, the confirmation reaction in a meeting thread, or the punchline on a checklist post. On Slack it functions as the 'yep, nailed it' reaction to a teammate's completed work. On Teams the same pattern repeats — product managers paste ✔️ on shipped features as the confirmation marker. On Twitter ✔️ shows up on checklist content and goal posts as the visual tag for items crossed off.\n\nThe emoji also pairs naturally with a sentence that names the completed thing ('PR up ✔️' or 'tests passing ✔️') and with other workflow emoji like 📋 for the broader task list. Stand-alone ✔️ reads as confirmed; in a stack it leans performative.",
+    "whenNotToUse": "Skip ✔️ in contexts where the confirmation is not yet earned — in early-stage work, in speculative threads, or where the work is still in progress. A ✔️ on something that is still in flight will read as premature. Avoid it in mixed channels where the sarcasm reading will land first and confuse the message.\n\nAlso avoid ✔️ when you want to deliver careful feedback. A teacher who replies to a student essay with ✔️ and a grade communicates less than a sentence would. Use the emoji as a confirmation, not as a substitute for actual feedback.",
+    "howToReply": "Mirror ✔️ with another ✔️ if you want to confirm the same status, or upgrade to 👍 for a more human-friendly approval. If you receive ✔️ on a task update, reply with a sentence that acknowledges the work or with a 👍 to keep the thread moving.\n\nIf ✔️ arrives as a sarcastic confirmation, you can mirror with 🙃 or a sentence that acknowledges the sarcasm. And if you want to send ✔️ as a sync-up confirmation, pair it with a brief sentence that names what is actually confirmed.",
+    "faqs": [
+      {
+        "question": "What does ✔️ mean in texting?",
+        "answer": "✔️ means 'done,' 'confirmed,' or 'approved.' The check mark is the universal completion symbol and reads the same in professional and personal contexts."
+      },
+      {
+        "question": "What does ✔️ mean from a girl?",
+        "answer": "From a girl or anyone else, ✔️ means the sender is confirming or approving. There is no gendered meaning; the emoji is about the confirmation, not who is sending it."
+      },
+      {
+        "question": "Is ✔️ flirty?",
+        "answer": "No, ✔️ is not flirty. It is a confirmation or completion symbol, with no romantic undercurrent. Using it on a romantic post will read as supportive rather than flirtatious."
+      },
+      {
+        "question": "What does ✔️ mean from a guy?",
+        "answer": "From a guy, ✔️ has the same meaning it has from anyone else: confirmation that something is done or approved. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "work",
+      "message": "PR is up ✔️",
+      "interpretation": "Standard completion update in a team channel. Mirror with ✔️ or 👍 to acknowledge the work."
+    },
+    {
+      "setting": "friends",
+      "message": "we are set for tonight ✔️",
+      "interpretation": "Friend confirming plans. Mirror with ✔️ or a heart to engage with the plan."
+    },
+    {
+      "setting": "social",
+      "message": "5 things crossed off the list ✔️",
+      "interpretation": "Public checklist update. Mirror with ✔️ or a sentence that engages with the progress."
+    },
+    {
+      "setting": "family",
+      "message": "groceries picked up ✔️",
+      "interpretation": "Family confirming an errand. Mirror with ✔️ or 'thanks' to close the loop."
+    },
+    {
+      "setting": "dating",
+      "message": "8pm Friday ✔️",
+      "interpretation": "Romantic partner confirming a date. Mirror with a heart or a sentence that confirms the plan."
+    }
+  ]
 }

--- a/src/data/emojis/clapping.json
+++ b/src/data/emojis/clapping.json
@@ -38,15 +38,19 @@
   "platformNotes": [
     {
       "platform": "TWITTER",
-      "note": "Very common for emphasis between words. Often signals frustration."
+      "note": "Twitter uses 👏 between words as the default 'this is ridiculous' emphasis; the clap emoji has become the clapback pattern."
     },
     {
       "platform": "INSTAGRAM",
-      "note": "Used in comments for genuine praise or sarcastic emphasis."
+      "note": "Instagram comments use 👏 for genuine praise under creator content and for sarcastic emphasis under celebrity mishaps."
     },
     {
       "platform": "SLACK",
-      "note": "Generally used positively - genuine applause for achievements."
+      "note": "Slack treats 👏 as a clean, positive acknowledgment emoji; the per-word emphasis pattern is rare in workplace chat."
+    },
+    {
+      "platform": "TIKTOK",
+      "note": "TikTok comments use 👏👏👏 as the slow sarcastic clap at bad takes; creators paste it on their own celebration videos."
     }
   ],
   "generationalNotes": [
@@ -79,5 +83,58 @@
     "clapping-medium",
     "clapping-medium-dark",
     "clapping-dark"
+  ],
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "👏 is the emoji that started as applause and became punctuation. The clap is the cleanest positive reaction on the keyboard — 'great job 👏' is unambiguous — but the per-word emphasis pattern (THIS 👏 IS 👏 IMPORTANT) has turned it into one of the most-used sarcasm emojis on social media. The same three claps can read as celebration, slow sarcastic clap, or pointed clapback depending entirely on the surrounding text. Black Twitter popularized the per-word style and it spread across platforms, so by 2026 almost everyone recognizes the clap-as-emphasis pattern even if they have never typed it themselves.\n\nThe ambiguity is the emoji's whole point. A friend lands a good joke and 👏👏👏 reads as celebration. A friend lands a bad take and the same three claps read as the slow clap of disapproval. The emoji is loud, performative, and intentionally on-the-nose, which is why writers should pair it with clear text so the tone is unambiguous. Stand-alone 👏 is the safest; 👏👏👏 can read either way.",
+    "howPeopleUseIt": "👏 arrives as a stand-alone reaction, a sentence closer on a praise, or as the per-word emphasis that breaks a sentence into claps. In work tools and family chats 👏 reads as genuine applause — a clean way to acknowledge a win without typing a paragraph. In group chats and Twitter quote-tweets the per-word style takes over and the claps become punctuation: 'READ 👏 THE 👏 ROOM.'\n\nThe emoji also pairs naturally with celebration emoji. 'congratulations 🎉👏' stacks the confetti with the applause for maximum hype. 👏👏👏 on its own as a closing reaction works as a 'standing ovation' signal. And the per-word style can lean supportive or hostile depending on the words — 'YES 👏 QUEEN 👏' reads as hype, while 'great 👏 idea 👏 genius 👏' reads as sarcasm.",
+    "whenNotToUse": "Skip 👏 in any context where sarcasm could be misread as sincere, or where sincere emphasis could be misread as sarcasm. The per-word pattern is ambiguous on its own, so use it only when the surrounding text makes the tone obvious. Avoid it in customer-facing complaint threads where the slow-clap read will land as gloating regardless of intent.\n\nAlso avoid 👏 as the only response to a serious disclosure. A friend shares something painful and you reply with claps — the per-word style reads as performative and the slow-clap style reads as mockery. Reach for a heart or a plain sentence when the moment actually warrants sympathy, and save 👏 for moments that fit its energy.",
+    "howToReply": "Mirror 👏 with another 👏 if you want to keep the emphasis, or upgrade to 🙌 for hands-raised celebration or 🎉 for confetti energy. If you receive 👏👏👏 and you are not sure whether it is sincere or sarcastic, glance at the surrounding text — per-word emphasis is almost always sincere, while slow claps arrive with phrases like 'congratulations' or 'wow' that tip the tone.\n\nIf 👏👏👏 lands on something you shared and the sarcasm was not intentional, you can ask 'sincerely?' to draw out the actual tone. And if you want to close a debate with maximum punctuation, stack the claps three times and let the recipient decide what to make of it.",
+    "faqs": [
+      {
+        "question": "What does 👏 mean?",
+        "answer": "👏 means applause or emphasis. The clap emoji can read as genuine praise, per-word emphasis on a point, or a slow sarcastic clap aimed at a bad take. The surrounding text usually clarifies the tone."
+      },
+      {
+        "question": "Is 👏👏👏 rude?",
+        "answer": "👏👏👏 can read as rude when used as a slow sarcastic clap at someone's expense. As per-word emphasis on a real point it is supportive, and as applause under a win it is celebratory."
+      },
+      {
+        "question": "What does 👏👏👏 mean on Twitter?",
+        "answer": "On Twitter 👏👏👏 is the standard clapback pattern. It can be per-word emphasis on a take, slow sarcasm at a bad take, or enthusiastic applause under a viral moment."
+      },
+      {
+        "question": "What does 👏👏👏 mean from a girl?",
+        "answer": "From a girl or anyone else, 👏👏👏 has the same meaning it has from anyone else: emphasis or applause. There is no gendered meaning; the tone is driven by the surrounding text."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "she really said that in front of the whole team 👏",
+      "interpretation": "Group chat applause for a bold statement. Mirror with another 👏 or a sentence about the moment."
+    },
+    {
+      "setting": "social",
+      "message": "CEO: 'we're like a family here' 👏",
+      "interpretation": "Quote-tweet sarcasm. Slow clap aimed at a tone-deaf statement; usually paired with a sentence to land the joke."
+    },
+    {
+      "setting": "work",
+      "message": "FINALLY 👏 shipped",
+      "interpretation": "Team celebration of a launch. Safe in a tight team channel; tone down for cross-org comms."
+    },
+    {
+      "setting": "dating",
+      "message": "you remembered the restaurant 👏",
+      "interpretation": "Playful emphasis on a sweet gesture. Mirror with a softer reaction or a follow-up sentence."
+    },
+    {
+      "setting": "family",
+      "message": "Dad finally learned how to use the printer 👏",
+      "interpretation": "Family group applause for a small win. Mirror with another 👏 or a supportive sentence."
+    }
   ]
 }

--- a/src/data/emojis/confetti-ball.json
+++ b/src/data/emojis/confetti-ball.json
@@ -8,40 +8,120 @@
   "subcategory": "event",
   "unicodeVersion": "6.0",
   "baseMeaning": "Confetti Ball emoji.",
-  "tldr": "Confetti!",
+  "tldr": "Party time — celebration, win, or congrats.",
   "contextMeanings": [
     {
       "context": "LITERAL",
-      "meaning": "Represents Confetti Ball.",
+      "meaning": "Represents a confetti ball for celebrations.",
       "example": "Look at this 🎊",
       "riskLevel": "LOW"
     },
     {
       "context": "SLANG",
-      "meaning": "Party or celebration.",
-      "example": "Feeling 🎊",
+      "meaning": "Party or celebration moment.",
+      "example": "Big win 🎊",
       "riskLevel": "LOW"
     },
-    { "context": "IRONIC", "meaning": "Ironic usage.", "example": "Mood 🎊", "riskLevel": "LOW" },
+    {
+      "context": "IRONIC",
+      "meaning": "Ironic celebration for small or fake wins.",
+      "example": "made it to inbox zero 🎊",
+      "riskLevel": "LOW"
+    },
     {
       "context": "WORK",
-      "meaning": "Work context.",
-      "example": "Work vibes 🎊",
+      "meaning": "Team milestone or ship-it reaction.",
+      "example": "Ship it 🎊",
       "riskLevel": "LOW"
     }
   ],
   "platformNotes": [
-    { "platform": "TWITTER", "note": "Common usage." },
-    { "platform": "INSTAGRAM", "note": "Popular posts." },
-    { "platform": "TIKTOK", "note": "Trending." }
+    {
+      "platform": "TWITTER",
+      "note": "Ship announcements, milestone celebrations, and congrats on shared wins."
+    },
+    {
+      "platform": "INSTAGRAM",
+      "note": "Story celebrations, life milestones, and birthday posts."
+    },
+    {
+      "platform": "TIKTOK",
+      "note": "Trending in celebration edits and 'I did it' reveal videos."
+    },
+    {
+      "platform": "DISCORD",
+      "note": "Server members paste it as the universal win-confirmed reaction."
+    }
   ],
   "generationalNotes": [
-    { "generation": "GEN_Z", "note": "Gen Z usage." },
-    { "generation": "MILLENNIAL", "note": "Millennial usage." },
-    { "generation": "BOOMER", "note": "Boomer interpretation." }
+    {
+      "generation": "GEN_Z",
+      "note": "Congrats energy; reaction to a friend's win."
+    },
+    {
+      "generation": "MILLENNIAL",
+      "note": "Birthday or life-milestone closer."
+    },
+    {
+      "generation": "BOOMER",
+      "note": "Birthday wish or congratulations."
+    }
   ],
   "warnings": [],
-  "relatedCombos": [],
-  "seoTitle": "🎊 Confetti Ball Emoji Meaning",
-  "seoDescription": "Learn what the Confetti Ball emoji 🎊 really means."
+  "relatedCombos": ["party-fire", "party-celebrate"],
+  "seoTitle": "🎊 Confetti Ball Emoji Meaning - What Does 🎊 Really Mean?",
+  "seoDescription": "Learn what the confetti ball emoji 🎊 really means. Party vibes, congrats, or celebration reaction. Complete context guide.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "🎊 is the confetti ball emoji, the spiraling streamers that signal party, congratulations, or a milestone-hit moment. The visual cue — a ball spraying streamers — is one of the most universally readable celebration symbols in the Unicode set. On Twitter, Instagram, and TikTok 🎊 shows up as the congrats reaction on a friend's win, the milestone celebration on a ship announcement, and the closer on a birthday post. The emoji is interesting because it spans a wide range of celebration tones — from genuinely big life wins to the modest 'I finished the laundry' self-congrats — all of which land on related joy beats.\n\nThe emoji also doubles as the ironic-self-congrats reaction. A friend mentions a minor accomplishment and the appropriate reply is 🎊 — the visual tag for 'congratulations on surviving.' Compared to the related combo 🎊🥳 (party-celebrate) or 🎊🔥 (party-fire), 🎊 alone sits more in the generic celebration zone and less in the hyped reveal zone. Use 🎊 when the moment calls for the confetti signal, not as a default reaction to every nice moment.",
+    "howPeopleUseIt": "🎊 arrives as the milestone reaction on a friend's win, the ship-it reaction in a product thread, or the punchline on a 'small but proud' share. On Twitter it functions as the standard reaction to a public accomplishment. On Instagram captions the emoji lands as the signature flourish on a birthday or life-milestone share. On TikTok creators paste 🎊 on reveal videos as the visual tag for the moment the win lands.\n\nIn group chats 🎊 works as the shared 'congrats' reaction when a friend shares good news. The emoji also pairs naturally with 🥳 for the party-face sibling stack, with 🔥 for the hype-add, and with a sentence that names what is being celebrated so the confetti does not feel generic.",
+    "whenNotToUse": "Skip 🎊 in contexts where the celebration will land wrong — in condolence threads, in serious professional feedback, or in conversations where the recipient has actually lost something. A 🎊 in a condolence thread will sound tone deaf. Avoid it on a friend's vulnerable post; the confetti will land wrong.\n\nAlso avoid 🎊 when the moment is not actually celebratory. A 🎊 on a coworker's small typo fix reads as performative. Reserve the emoji for moments where the win genuinely warrants the joy.",
+    "howToReply": "Mirror 🎊 with another 🎊 or 🥳 if you want to keep the celebration going, or upgrade to a heart for the warmer affection. If you receive 🎊 on a personal win, reply with 'thanks 🎊' or a sentence that acknowledges the moment.\n\nIf 🎊 arrives as a milestone reaction, mirror with a sentence that engages with the win. And if you want to send 🎊 as a soft friendly reaction, anchor the emoji with a sentence that names what is being celebrated so the confetti does not feel performative.",
+    "faqs": [
+      {
+        "question": "What does 🎊 mean in texting?",
+        "answer": "🎊 means 'congratulations' or 'celebration.' The confetti-ball emoji signals a win, milestone, or party moment, and reads as either genuine congrats or ironic self-congrats."
+      },
+      {
+        "question": "What does 🎊 mean from a girl?",
+        "answer": "From a girl or anyone else, 🎊 means the sender is celebrating or congratulating. There is no gendered meaning; the emoji is about the moment, not who is sending it."
+      },
+      {
+        "question": "Is 🎊 flirty?",
+        "answer": "🎊 is not flirty. It marks celebration or congrats, with no romantic undercurrent. Using it on a romantic post will read as supportive rather than flirtatious."
+      },
+      {
+        "question": "What does 🎊 mean from a guy?",
+        "answer": "From a guy, 🎊 has the same meaning it has from anyone else: celebration or congratulations. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "got the job 🎊",
+      "interpretation": "Friend sharing a win. Mirror with 🎊 or a sentence that engages with the news."
+    },
+    {
+      "setting": "work",
+      "message": "ship it 🎊",
+      "interpretation": "Team shipping reaction in a tight channel. Mirror with 🎊 or a sentence that acknowledges the launch."
+    },
+    {
+      "setting": "social",
+      "message": "promotion confirmed 🎊",
+      "interpretation": "Public milestone share. Mirror with 🎊 or a sentence that celebrates the win."
+    },
+    {
+      "setting": "family",
+      "message": "birthday girl 🎊",
+      "interpretation": "Family birthday share. Mirror with 🎊 or a sentence that engages with the day."
+    },
+    {
+      "setting": "dating",
+      "message": "made it to your neighborhood 🎊",
+      "interpretation": "Partner's arrival share. Mirror with a heart or a sentence that acknowledges the moment."
+    }
+  ]
 }

--- a/src/data/emojis/crossed-fingers.json
+++ b/src/data/emojis/crossed-fingers.json
@@ -38,15 +38,19 @@
   "platformNotes": [
     {
       "platform": "TWITTER",
-      "note": "Common for expressing hope and anticipation."
+      "note": "Common for expressing hope and anticipation on milestones."
     },
     {
       "platform": "SLACK",
-      "note": "Used for deployments and hoping things work."
+      "note": "Used for deployments and hoping things work in tight channels."
     },
     {
       "platform": "WHATSAPP",
       "note": "Popular for wishing luck to friends and family."
+    },
+    {
+      "platform": "INSTAGRAM",
+      "note": "Pasted on wishful posts and hoping-for-good-news stories."
     }
   ],
   "generationalNotes": [
@@ -73,5 +77,58 @@
     "crossed-fingers-medium",
     "crossed-fingers-medium-dark",
     "crossed-fingers-dark"
+  ],
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "🤞 is the universal hope emoji, the index-and-middle-fingers crossed that signals wishing for luck, nervous anticipation, or hiding a lie. The hand gesture has carried the luck meaning for so long across cultures that the emoji lands with the same simplicity. On Slack, Twitter, and WhatsApp 🤞 shows up as the standard pre-deploy hype reaction, the hopeful 'fingers crossed' message to a friend's challenge, and the sarcastic 'sure I will be on time' closer on a known lie. The emoji is one of the cleanest hope signals on the keyboard because the meaning is unambiguous across age groups and platforms.\n\nThe emoji also doubles as the 'fingers crossed behind the back' reaction. A friend says 'I will be there for sure' and the appropriate reply is 🤞 — the visual tag for 'I am doubting this but wishing you well.' The dual reading — genuine hope or skeptical lie — keeps 🤞 versatile without diluting the wishing beat. Use 🤞 when the moment calls for the hope signal, not as a default reaction to every uncertain moment.",
+    "howPeopleUseIt": "🤞 arrives as the pre-deploy hype reaction, the hopeful message to a friend's challenge, or the punchline on a 'sure I will' lie. On Slack the emoji lands as the standard 'fingers crossed' reaction in product-launch threads. On Twitter it functions as the hopeful reaction to a public challenge. On WhatsApp the same pattern repeats between friends and family as the visual tag for wishing luck.\n\nIn group chats 🤞 works as the shared 'here is hoping' reaction when a friend shares a goal. The emoji also pairs naturally with 🍀 for the luck-emphasis, with 🙏 for the hope-with-prayer, and with a sentence that names what is being wished for so the hope does not feel generic.",
+    "whenNotToUse": "Skip 🤞 in contexts where the hope reading will land wrong — in serious professional commitments where 'fingers crossed' undercuts the actual commitment, in customer complaint threads where the hope is misplaced, or in conversations where the recipient needs more than a casual wish. A 🤞 in a customer complaint reply will sound tone deaf. Avoid it in moments where the emoji will read as ambiguity rather than encouragement.\n\nAlso avoid 🤞 when you actually want to commit. The 'fingers crossed' emoji is the wishful thinking signal, so sending it on a real commitment will read as 'I am not sure I will deliver.' Reach for a clear sentence or a stronger confirmation emoji when the message needs to land as committed.",
+    "howToReply": "Mirror 🤞 with another 🤞 or 🍀 if you want to keep the wish going, or upgrade to 🙏 for the prayer-emphasis. If you receive 🤞 on a personal challenge, reply with a sentence that acknowledges the hope.\n\nIf 🤞 arrives as a sarcastic 'sure I will' reaction, mirror with a sentence that calls out the lie. And if you want to send 🤞 as a friend-wish, anchor the emoji with a sentence that names what is being hoped for so the fingers-crossed does not feel generic.",
+    "faqs": [
+      {
+        "question": "What does 🤞 mean in texting?",
+        "answer": "🤞 means 'fingers crossed' or 'hoping for luck.' The crossed-fingers emoji is the universal hope signal and reads as either genuine wishing or skeptical lie depending on context."
+      },
+      {
+        "question": "What does 🤞 mean from a girl?",
+        "answer": "From a girl or anyone else, 🤞 means the sender is hoping for luck or expressing nervous anticipation. There is no gendered meaning; the emoji is about the hope, not who is sending it."
+      },
+      {
+        "question": "Is 🤞 flirty?",
+        "answer": "🤞 is not flirty. It marks hope or anticipation, with no romantic undercurrent. Using it on a romantic post will read as supportive rather than flirtatious."
+      },
+      {
+        "question": "What does 🤞 mean from a guy?",
+        "answer": "From a guy, 🤞 has the same meaning it has from anyone else: hope or wishful thinking. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "interview tomorrow 🤞",
+      "interpretation": "Friend's hopeful pre-interview share. Mirror with 🤞 or a sentence that engages with the hope."
+    },
+    {
+      "setting": "social",
+      "message": "hope this works 🤞",
+      "interpretation": "Public hope reaction. Mirror with 🤞 or a sentence that engages with the wish."
+    },
+    {
+      "setting": "work",
+      "message": "deploy going out 🤞",
+      "interpretation": "Team hype in a tight channel. Mirror with 🤞 or a sentence that acknowledges the launch."
+    },
+    {
+      "setting": "dating",
+      "message": "hope you say yes 🤞",
+      "interpretation": "Romantic partner's hopeful moment. Mirror with a heart or a sentence that engages with the wish."
+    },
+    {
+      "setting": "family",
+      "message": "mom's surgery went well 🤞",
+      "interpretation": "Family hopeful reaction. Mirror with a heart or a sentence that acknowledges the moment."
+    }
   ]
 }

--- a/src/data/emojis/droplet.json
+++ b/src/data/emojis/droplet.json
@@ -36,9 +36,22 @@
     }
   ],
   "platformNotes": [
-    { "platform": "TWITTER", "note": "Hydration or drip aesthetic." },
-    { "platform": "INSTAGRAM", "note": "Style and aesthetic." },
-    { "platform": "TIKTOK", "note": "Often related to style or thirst." }
+    {
+      "platform": "TWITTER",
+      "note": "Hydration reminders or fashion-drip aesthetic."
+    },
+    {
+      "platform": "INSTAGRAM",
+      "note": "Style and aesthetic on fashion posts and glow-ups."
+    },
+    {
+      "platform": "TIKTOK",
+      "note": "Often used for style moments or suggestive thirst-trap captions."
+    },
+    {
+      "platform": "DISCORD",
+      "note": "Server members paste it for the 'drip' aesthetic reaction."
+    }
   ],
   "generationalNotes": [
     { "generation": "GEN_Z", "note": "Drip = style, can be suggestive." },
@@ -48,5 +61,58 @@
   "warnings": [],
   "relatedCombos": [],
   "seoTitle": "💧 Droplet Emoji Meaning",
-  "seoDescription": "Learn what the Droplet emoji 💧 really means."
+  "seoDescription": "Learn what the Droplet emoji 💧 really means.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "💧 is the droplet emoji, the single water drop that signals either literal hydration, fashion 'drip,' or the suggestive 'thirst' reading. The visual cue — a blue droplet — has stretched far past its root meaning because the slang adoption has been so wide. On Twitter, Instagram, and TikTok 💧 shows up as the hydration reminder, the 'drip' aesthetic marker on a fashion post, and the more suggestive variant on a thirst-trap caption. The emoji is interesting because it spans three genuinely different uses — water, style, and thirst — all of which land on related visual beats.\n\nThe emoji also doubles as the universal 'drip' reaction. A friend shares a fire fit and the appropriate reply is 💧 — the visual tag for 'the drip is real.' The dual reading — water or style — keeps 💧 versatile without diluting the recognition. Use 💧 when the moment calls for the water or drip signal, being mindful of the suggestive reading in close contexts.",
+    "howPeopleUseIt": "💧 arrives as the hydration reminder, the drip-aesthetic reaction on a fashion post, or the punchline on a suggestive thirst-trap caption. On Twitter it functions as the 'stay hydrated' reminder on a wellness thread. On Instagram captions the emoji lands as the signature flourish on a fashion post or a glow-up share. On TikTok creators paste 💧 on thirst-trap captions as the visual tag for the suggestive beat.\n\nIn group chats 💧 works as the shared 'drip' reaction when a friend shares a fit. The emoji also pairs naturally with 💦 for the more aggressive thirst sibling, with 🔥 for the hype-add, and with a sentence that names what is being dripped so the droplet does not feel generic.",
+    "whenNotToUse": "Skip 💧 in contexts where the suggestive reading will land wrong — in cold professional channels, in customer complaint replies, or in mixed-age groups where the thirst reference may not land safely. A 💧 in a customer complaint reply will sound tone deaf. Avoid it in conversations where the recipient does not want the suggestive undertone.\n\nAlso avoid 💧 when the actual context calls for a different water moment. The emoji is more style-coded than hydration-coded in modern texting, so a 💧 on a friend's sick-day post may read as 'drip' rather than 'feel better.' Reach for a heart or a sentence of care when the moment warrants empathy.",
+    "howToReply": "Mirror 💧 with another 💧 or 🔥 if you want to keep the drip going, or upgrade to 💦 for the more aggressive thirst variant. If you receive 💧 on a fashion post, reply with a heart or a sentence that engages with the look.\n\nIf 💧 arrives as a hydration reminder, mirror with a heart or a sentence that acknowledges the wellness moment. And if you want to send 💧 as a soft friendly reaction, anchor the emoji with a sentence that names what is being dripped so the droplet does not feel performative.",
+    "faqs": [
+      {
+        "question": "What does 💧 mean in texting?",
+        "answer": "💧 means 'water,' 'drip,' or 'thirst.' The droplet emoji signals hydration, fashion style, or the suggestive 'thirst' reading depending on context and the relationship."
+      },
+      {
+        "question": "What does 💧 mean from a girl?",
+        "answer": "From a girl or anyone else, 💧 means the sender is referencing water, style, or suggestive content. There is no gendered meaning; the emoji is about the vibe, not who is sending it."
+      },
+      {
+        "question": "Is 💧 flirty?",
+        "answer": "💧 can read as flirty or suggestive in a dating context, especially paired with a thirst-trap caption. In other contexts it stays in the hydration or style zone."
+      },
+      {
+        "question": "What does 💧 mean from a guy?",
+        "answer": "From a guy, 💧 has the same meaning it has from anyone else: water, drip, or thirst. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "got that drip 💧",
+      "interpretation": "Friend's style compliment. Mirror with 💧 or a sentence that engages with the look."
+    },
+    {
+      "setting": "social",
+      "message": "stay hydrated 💧",
+      "interpretation": "Public wellness reminder. Mirror with 💧 or a sentence that acknowledges the moment."
+    },
+    {
+      "setting": "dating",
+      "message": "you make me 💧",
+      "interpretation": "Partner's suggestive moment. Mirror with a sentence that engages with the vibe."
+    },
+    {
+      "setting": "family",
+      "message": "drank my water today 💧",
+      "interpretation": "Family wellness share. Mirror with a heart or a sentence that acknowledges the moment."
+    },
+    {
+      "setting": "work",
+      "message": "remember to hydrate 💧",
+      "interpretation": "Team wellness reminder in a tight channel. Mirror with a heart or a sentence that acknowledges the reminder."
+    }
+  ]
 }

--- a/src/data/emojis/eyes.json
+++ b/src/data/emojis/eyes.json
@@ -36,9 +36,22 @@
     }
   ],
   "platformNotes": [
-    { "platform": "TWITTER", "note": "Tea, gossip, or something noteworthy." },
-    { "platform": "INSTAGRAM", "note": "Checking out content." },
-    { "platform": "TIKTOK", "note": "When you see something interesting." }
+    {
+      "platform": "TWITTER",
+      "note": "Twitter quote-tweets lean on 👀 as the universal 'I see you' or 'spill the tea' reaction, especially on relationship drama and celebrity posts."
+    },
+    {
+      "platform": "INSTAGRAM",
+      "note": "Instagram comments use 👀 under soft-launch posts and celebrity sightings; the emoji doubles as engagement bait and genuine curiosity."
+    },
+    {
+      "platform": "TIKTOK",
+      "note": "TikTok creators paste 👀 onto captions before a reveal; viewers spam it in the comments as anticipation for the payoff."
+    },
+    {
+      "platform": "DISCORD",
+      "note": "Discord treats 👀 as the watching reaction; moderators and friends use it when someone says something that needs a follow-up."
+    }
   ],
   "generationalNotes": [
     { "generation": "GEN_Z", "note": "Tea and gossip." },
@@ -48,5 +61,58 @@
   "warnings": [],
   "relatedCombos": [],
   "seoTitle": "👀 Eyes Emoji Meaning",
-  "seoDescription": "Learn what the Eyes emoji 👀 really means."
+  "seoDescription": "Learn what the Eyes emoji 👀 really means.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "👀 is the emoji that says 'I am watching this' without typing it. The two-eye glyph has become the universal reaction to anything juicy — celebrity gossip, group-chat drama, a friend's soft-launch post, or a public statement that begs for follow-up. On Twitter and TikTok 👀 is the standard 'spill the tea' emoji, used as a stand-alone reaction to imply 'I see what you did there' or 'tell me more.' In dating-app conversations 👀 flirts by signaling interest without committing, the way a long look across a room works in person.\n\nThe emoji also functions as anticipation bait. A TikTok creator captions a video 'wait for it 👀' and the eyes do the work of building suspense. The same pattern shows up on Twitter when a teaser tweet drops with 👀 attached. Writers should treat 👀 as the most flexible reaction emoji on the keyboard — it can read as gossip, flirtation, anticipation, or simply 'I noticed,' and it rarely clutters the message it lands in.",
+    "howPeopleUseIt": "👀 shows up as a stand-alone reaction, a sentence closer on a teasing statement, or as the joke reaction when someone shares something questionable. In group chats 👀 is the default emoji when a friend shares gossip — 'he said WHAT 👀' — and it works as a soft prompt to keep the story going. On Twitter quote-tweets 👀 marks a take as worth watching, and on Instagram comments 👀 signals that the viewer noticed something the poster may not have intended to highlight.\n\nIn dating-app conversations 👀 is the soft-flirt emoji. 'I like your taste 👀' reads as interest without crossing into direct compliment territory. The emoji pairs naturally with 😏 for flirtatious implication, with 🤔 for suspicious-but-curious watching, and with 🍿 for full spectator mode.",
+    "whenNotToUse": "Skip 👀 in professional or work channels where the gossip reading can undercut the message. A 👀 under a coworker status update sounds like you are watching them, which can feel surveillance-coded. Avoid it in customer-facing comms where the customer needs confidence — 'we are keeping an eye on it 👀' sounds like you are enjoying the drama.\n\nAlso avoid 👀 in serious discussions about consent, surveillance, or stalking. The eyes glyph has a voyeuristic undercurrent that can read as creepy in those contexts, even when used innocently. Pick a different emoji to signal 'I am paying attention' when the topic is sensitive.",
+    "howToReply": "Mirror 👀 with another 👀 if you want to keep the watching going, or pair it with 🍿 for full spectator mode. If you receive 👀 on a post or a story, treat it as interest — a short 'want the details 👀?' reply keeps the thread moving.\n\nIf 👀 lands on a soft launch or a tease, lean into the suspense. Reply with another 👀 or 'tell me everything' to draw out the rest of the story. And if 👀 arrives in a dating context and you want to escalate, mirror with a soft compliment rather than just the eyes.",
+    "faqs": [
+      {
+        "question": "What does 👀 mean in texting?",
+        "answer": "👀 means 'I am watching' or 'I see you.' It is the universal reaction to gossip, juicy reveals, soft launches, and anything that warrants a follow-up."
+      },
+      {
+        "question": "What does 👀 mean from a girl?",
+        "answer": "From a girl or anyone else, 👀 signals interest, gossip, or flirtation. There is no gendered meaning; the reading is driven by context."
+      },
+      {
+        "question": "What does 👀 mean on TikTok?",
+        "answer": "On TikTok 👀 is the anticipation emoji; creators paste it before a reveal and viewers spam it as they wait for the payoff."
+      },
+      {
+        "question": "What does 👀 mean from a guy?",
+        "answer": "From a guy, 👀 has the same meaning it has from anyone else: interest, gossip, or flirtation. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "social",
+      "message": "did you see what she just posted 👀",
+      "interpretation": "Friend flagging gossip. Reply with another 👀 or 'tell me everything' to keep the story going."
+    },
+    {
+      "setting": "dating",
+      "message": "you have great taste 👀",
+      "interpretation": "Soft flirt that signals interest. Mirror with a softer reaction or a follow-up question to keep the energy going."
+    },
+    {
+      "setting": "friends",
+      "message": "so what happened with the date 👀",
+      "interpretation": "Friend requesting a follow-up. Reply with another 👀 or a sentence that spills the details."
+    },
+    {
+      "setting": "work",
+      "message": "looking into it 👀",
+      "interpretation": "Workplace placeholder. Replace with 'we are investigating, will update by Friday' so the customer or team gets a real timeline."
+    },
+    {
+      "setting": "family",
+      "message": "Dad just discovered emoji 👀",
+      "interpretation": "Family group curiosity. Reply with another 👀 or a sentence that plays along with the joke."
+    }
+  ]
 }

--- a/src/data/emojis/face-blowing-a-kiss.json
+++ b/src/data/emojis/face-blowing-a-kiss.json
@@ -72,5 +72,58 @@
   ],
   "relatedCombos": ["kiss-heart"],
   "seoTitle": "😘 Face Blowing a Kiss Meaning - What Does 😘 Really Mean?",
-  "seoDescription": "Learn what the blowing a kiss emoji 😘 really means in modern texting. Sending love and kisses. Complete context guide."
+  "seoDescription": "Learn what the blowing a kiss emoji 😘 really means in modern texting. Sending love and kisses. Complete context guide.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "😘 is the emoji that says 'I am sending you a kiss,' the most direct romantic reaction on the keyboard. The face shows puckered lips and a small heart drifting away — visual cues that leave no doubt about the intent. In dating-app conversations 😘 functions as the romantic closer, the emoji you send at the end of a flirty message or after a good-night text. It also works between close family members, where the meaning tilts toward platonic affection rather than romance.\n\nThe reason 😘 reads clearly is that it does not have slang drift or ironic readings. It means exactly what it shows, and the recipient usually knows whether the sender is being romantic or affectionate based on the relationship. Writers should reserve 😘 for moments that genuinely warrant the kiss — overusing it can make the emoji feel performative, and sending it to a contact who has not earned the intimacy will read as creepy. When the moment is right, though, 😘 is the cleanest possible romantic signal.",
+    "howPeopleUseIt": "😘 arrives as a sentence closer on a flirty message, a good-night reaction from a partner, or a softener after a sweet gesture. In dating-app conversations it functions as the romantic closer — 'good morning 😘' or 'thinking of you 😘' — that signals the relationship is moving toward something serious. It also works in family group chats as a warm closer to a parent's text or a sibling's birthday wish.\n\nThe emoji pairs naturally with hearts (😘❤️) for maximum affection and with text like 'miss you' or 'can't wait' to anchor the romantic reading. It rarely appears in work channels, where it would feel mismatched, and on Slack or Teams it is generally avoided.",
+    "whenNotToUse": "Skip 😘 in any context where romantic affection would be inappropriate — in cold work channels, in customer-facing support, or in first-contact messages where the relationship has not been established. A 😘 in a work email will read as unprofessional, and a 😘 in a customer complaint reply will sound tone deaf. Avoid it in mixed-age group chats where some recipients may read the kiss as forward.\n\nAlso avoid 😘 in serious discussions about consent, boundaries, or rejection. The emoji carries warmth, but the recipient may not feel the same energy, and forcing the kiss reading on someone who has signaled otherwise is uncomfortable. When in doubt, reach for a heart or a plain sentence.",
+    "howToReply": "Mirror 😘 with another 😘 if you want to keep the romantic energy going, or upgrade to ❤️ for a more sincere affection signal. If you receive 😘 from a romantic partner, a short 'miss you too 😘' or 'good night ❤️' closes the loop warmly.\n\nIf 😘 arrives in a family context, mirror with the same or a heart emoji so the platonic reading stays clear. And if you are not sure whether the 😘 is romantic or platonic, glance at the relationship and the surrounding text — a partner's 😘 reads differently from a parent's 😘, even when the emoji is identical.",
+    "faqs": [
+      {
+        "question": "What does 😘 mean in texting?",
+        "answer": "😘 means 'I am sending you a kiss.' It is the most direct romantic reaction emoji on the keyboard and reads as flirtatious or affectionate depending on the relationship."
+      },
+      {
+        "question": "What does 😘 mean from a girl?",
+        "answer": "From a girl or anyone else, 😘 means the sender is sending a kiss. There is no gendered meaning; the emoji is about the romantic or affectionate intent, not who is sending it."
+      },
+      {
+        "question": "Is 😘 flirty?",
+        "answer": "Yes, 😘 is inherently flirty in most contexts. Inside an established romantic relationship it is the default love signal; in other relationships it can feel forward if the warmth is not mutual."
+      },
+      {
+        "question": "What does 😘 mean from a guy?",
+        "answer": "From a guy, 😘 has the same meaning it has from anyone else: a kiss being sent. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "dating",
+      "message": "good morning beautiful 😘",
+      "interpretation": "Romantic partner's morning message. Mirror with 😘 or a follow-up sweet line."
+    },
+    {
+      "setting": "family",
+      "message": "love you mom 😘",
+      "interpretation": "Family warmth between parent and adult child. Mirror with 😘 or 'love you too' to close the loop."
+    },
+    {
+      "setting": "friends",
+      "message": "thanks for covering for me today 😘",
+      "interpretation": "Friend thanks with affectionate energy. Mirror with a heart emoji or 'you're the best' to match."
+    },
+    {
+      "setting": "social",
+      "message": "love your energy 😘",
+      "interpretation": "Friendly comment on a creator's content. Mirror with a heart or 'thanks' to engage."
+    },
+    {
+      "setting": "work",
+      "message": "appreciate you 😘",
+      "interpretation": "Too personal for most workplace channels; risky to send to a coworker. Replace with 'thanks' or a thumbs-up if needed."
+    }
+  ]
 }

--- a/src/data/emojis/face-savoring-food.json
+++ b/src/data/emojis/face-savoring-food.json
@@ -8,7 +8,7 @@
   "subcategory": "face-tongue",
   "unicodeVersion": "6.0",
   "baseMeaning": "A face with tongue out and closed eyes, savoring delicious food.",
-  "tldr": "Yummy! Expressing that something is delicious.",
+  "tldr": "Yummy! Food is delicious, or flirty anticipation.",
   "contextMeanings": [
     {
       "context": "LITERAL",
@@ -36,17 +36,92 @@
     }
   ],
   "platformNotes": [
-    { "platform": "INSTAGRAM", "note": "Essential for food posts." },
-    { "platform": "TWITTER", "note": "Used for food content." },
-    { "platform": "TIKTOK", "note": "Popular in food videos." }
+    {
+      "platform": "INSTAGRAM",
+      "note": "Essential for food posts and restaurant-story reactions from creators."
+    },
+    {
+      "platform": "TWITTER",
+      "note": "Used for food content, restaurant recaps, and recipe shares."
+    },
+    {
+      "platform": "TIKTOK",
+      "note": "Popular in food videos and recipe reveal moments across creators."
+    },
+    {
+      "platform": "DISCORD",
+      "note": "Server members paste it as the standard 'that looks fire' food reaction."
+    }
   ],
   "generationalNotes": [
-    { "generation": "GEN_Z", "note": "Food appreciation and flirty." },
-    { "generation": "MILLENNIAL", "note": "Delicious and yummy." },
-    { "generation": "BOOMER", "note": "Food is tasty." }
+    {
+      "generation": "GEN_Z",
+      "note": "Food appreciation and flirty anticipation."
+    },
+    {
+      "generation": "MILLENNIAL",
+      "note": "Delicious and yummy vibes."
+    },
+    {
+      "generation": "BOOMER",
+      "note": "Food is tasty."
+    }
   ],
   "warnings": [],
   "relatedCombos": [],
-  "seoTitle": "😋 Face Savoring Food Emoji Meaning",
-  "seoDescription": "Learn what the yum face emoji 😋 really means. Delicious food appreciation."
+  "seoTitle": "😋 Face Savoring Food Emoji Meaning - What Does 😋 Really Mean?",
+  "seoDescription": "Learn what the yum face emoji 😋 really means. Food appreciation, flirty anticipation, or delicious reaction. Complete context guide.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "😋 is the face savoring food emoji, the tongue-out smiling face that signals delicious food or the flirty-anticipation beat. The visual cue — closed eyes and a tongue peeking out — has stretched far past its literal food reading because the emoji has been adopted as the universal 'I am looking forward to this' reaction. On Instagram, Twitter, and TikTok 😋 shows up as the food-reaction on a friend's dish, the flirty-anticipation marker on a date plan, and the punchline on a recipe reveal. The emoji is interesting because it spans three genuinely different uses — food, anticipation, and flirty beat — all of which land on related yum energy.\n\nThe emoji also doubles as the flirty-anticipation reaction. A partner messages 'see you tonight' and the appropriate reply is 😋 — the visual tag for 'I am looking forward to it.' The dual reading — food or flirty — keeps 😋 versatile without diluting the yum beat. Use 😋 when the moment calls for the savory signal, not as a default reaction to every nice moment.",
+    "howPeopleUseIt": "😋 arrives as the food reaction on a friend's dish post, the flirty-anticipation reply on a date plan, or the punchline on a recipe reveal. On Instagram it functions as the standard reaction to a restaurant-story. On Twitter the emoji lands as the signature reaction on a food-tweet thread. On TikTok creators paste 😋 on food reveal videos as the visual tag for the moment the dish lands.\n\nIn group chats 😋 works as the shared 'yummy' reaction when a friend shares a meal. The emoji also pairs naturally with 🍕 for the food-pair, with 🥰 for the warm admiration, and with a sentence that names what is being savored so the yum-face does not feel generic.",
+    "whenNotToUse": "Skip 😋 in contexts where the flirty reading will land wrong — in cold professional channels, in customer complaint replies, or in formal client emails. A 😋 in a customer complaint thread will sound tone deaf. Avoid it in conversations where the recipient does not want the suggestive undertone.\n\nAlso avoid 😋 when the actual context calls for a different moment. The emoji is more coded than a heart, so a 😋 on a coworker's lunch may read as performative. Reach for a sentence or a heart when the message warrants simple appreciation.",
+    "howToReply": "Mirror 😋 with another 😋 or 🍽️ if you want to keep the food going, or upgrade to 🥰 for the warm admiration. If you receive 😋 on a flirty message, reply with a sentence that engages with the anticipation.\n\nIf 😋 arrives as a food reaction, mirror with a sentence that engages with the dish. And if you want to send 😋 as a soft friendly reaction, anchor the emoji with a sentence that names what is being savored so the yum-face does not feel performative.",
+    "faqs": [
+      {
+        "question": "What does 😋 mean in texting?",
+        "answer": "😋 means 'delicious' or 'flirty anticipation.' The yum-face emoji signals food appreciation or romantic anticipation depending on context and the relationship."
+      },
+      {
+        "question": "What does 😋 mean from a girl?",
+        "answer": "From a girl or anyone else, 😋 means the sender is reacting to food or signaling flirty anticipation. There is no gendered meaning; the emoji is about the vibe, not who is sending it."
+      },
+      {
+        "question": "Is 😋 flirty?",
+        "answer": "😋 can read as flirty in a dating context, especially when paired with a date plan. In other contexts it stays in the food or yum zone."
+      },
+      {
+        "question": "What does 😋 mean from a guy?",
+        "answer": "From a guy, 😋 has the same meaning it has from anyone else: food appreciation or flirty anticipation. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "this pasta 😋",
+      "interpretation": "Friend sharing a meal. Mirror with 😋 or a sentence that engages with the dish."
+    },
+    {
+      "setting": "social",
+      "message": "homemade ramen 😋",
+      "interpretation": "Public food share. Mirror with 😋 or a sentence that engages with the recipe."
+    },
+    {
+      "setting": "dating",
+      "message": "see you tonight 😋",
+      "interpretation": "Partner's flirty anticipation. Mirror with 😋 or a sentence that engages with the plan."
+    },
+    {
+      "setting": "family",
+      "message": "grandma's cookies 😋",
+      "interpretation": "Family food share. Mirror with 😋 or a sentence that engages with the recipe."
+    },
+    {
+      "setting": "work",
+      "message": "team lunch was fire 😋",
+      "interpretation": "Team meal share in a tight channel. Mirror with 😋 or a sentence that engages with the lunch."
+    }
+  ]
 }

--- a/src/data/emojis/face-with-rolling-eyes.json
+++ b/src/data/emojis/face-with-rolling-eyes.json
@@ -38,15 +38,19 @@
   "platformNotes": [
     {
       "platform": "TWITTER",
-      "note": "Common for expressing frustration with news, takes, or people."
+      "note": "Common for expressing frustration with takes, news, or people."
     },
     {
       "platform": "IMESSAGE",
-      "note": "Can escalate tension quickly - clearly signals displeasure."
+      "note": "Can escalate tension quickly; clearly signals displeasure."
     },
     {
       "platform": "SLACK",
       "note": "Generally too negative for workplace communication."
+    },
+    {
+      "platform": "DISCORD",
+      "note": "Server members use it as the 'not this again' reaction."
     }
   ],
   "generationalNotes": [
@@ -72,5 +76,58 @@
   ],
   "relatedCombos": ["rolling-eyes-sigh"],
   "seoTitle": "🙄 Rolling Eyes Emoji Meaning - What Does 🙄 Really Mean?",
-  "seoDescription": "Learn what the rolling eyes emoji 🙄 really means in modern texting. Universal sign of annoyance or dismissiveness. Complete context guide."
+  "seoDescription": "Learn what the rolling eyes emoji 🙄 really means in modern texting. Universal sign of annoyance or dismissiveness. Complete context guide.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "🙄 is the universal eye-roll emoji, the one that signals 'I cannot believe this' or 'not this again' with maximum clarity. The visual cue — eyes rolled upward, flat mouth — is the most direct contempt signal in the Unicode face set. On Twitter, iMessage, and Discord 🙄 shows up as the go-to reaction to a take that deserves dismissal, a person who is being exhausting, or a situation that has happened so many times that the only response is exasperation. The emoji is unambiguous in a way few others are: there is no soft read, no ironic rescue, no romantic undercurrent. It means what it shows.\n\nThe emoji also doubles as the meta-reaction to things that are eye-roll worthy in the obvious sense — a basic take, a recycled joke, a public statement that misses the point. The dual reading — 'I am annoyed' or 'this is so predictable' — lands on the same beat: disengagement. Reserve 🙄 for moments that genuinely warrant the eye-roll, because the emoji escalates quickly and can damage relationships if used carelessly.",
+    "howPeopleUseIt": "🙄 arrives as the quote-tweet reaction to a tired take, the direct reply to a friend's exhausting update, or the punchline on a 'here we go again' reaction. On Twitter it functions as the standard dismissal reaction to bad takes, recycled jokes, and predictable public statements. On iMessage it lands as the direct response to a friend who is being extra — the clear signal that the sender has had enough.\n\nIn group chats 🙄 works as the shared 'cannot believe this' reaction when a friend shares news that warrants the eye-roll. The emoji pairs naturally with 😒 for the cooler unamused variant, with 🤦 for the facepalm, and with a sentence that names the frustration so the eye-roll does not feel performative.",
+    "whenNotToUse": "Skip 🙄 in contexts where the dismissive reading will cause damage — in workplace feedback, in customer-facing comms, or in serious personal conversations. A 🙄 on a coworker's idea will read as hostile and will damage trust. Avoid it on a friend's vulnerable post; the contempt will land wrong.\n\nAlso avoid 🙄 when the frustration is real but the conversation warrants care. A partner who is going through a hard time needs empathy, not contempt. Reach for a softer reaction or a sentence that engages with the actual emotional weight.",
+    "howToReply": "Mirror 🙄 with another 🙄 or 😒 if you want to keep the dismissive energy going, or upgrade to a softer reaction if the conversation warrants care. If you receive 🙄 as a reaction to your own take, treat it as a signal that the content landed wrong and consider whether to clarify or let it go.\n\nIf 🙄 arrives on a friend's shared frustration, mirror with a sentence that engages with the actual issue. And if you want to send 🙄 as a meta-reaction to something predictable, anchor the emoji with a sentence that names what was so eye-roll-worthy so it does not feel pointed.",
+    "faqs": [
+      {
+        "question": "What does 🙄 mean in texting?",
+        "answer": "🙄 means 'I cannot believe this' or 'not this again.' The rolling-eyes face is the universal dismissal reaction and signals clear contempt or exasperation."
+      },
+      {
+        "question": "What does 🙄 mean from a girl?",
+        "answer": "From a girl or anyone else, 🙄 means the sender is annoyed or dismissive. There is no gendered meaning; the emoji is about the contempt, not who is sending it."
+      },
+      {
+        "question": "Is 🙄 rude?",
+        "answer": "🙄 can read as rude, especially in workplace or vulnerable contexts. The contempt is unambiguous, so use it carefully to avoid escalating conflicts."
+      },
+      {
+        "question": "What does 🙄 mean from a guy?",
+        "answer": "From a guy, 🙄 has the same meaning it has from anyone else: clear annoyance or dismissiveness. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "they really did it again 🙄",
+      "interpretation": "Friend sharing a recurring frustration. Mirror with 🙄 or a sentence that engages with the situation."
+    },
+    {
+      "setting": "social",
+      "message": "groundbreaking observation 🙄",
+      "interpretation": "Public sarcasm on a tired take. Mirror with 🙄 or a sentence that adds to the dismissal."
+    },
+    {
+      "setting": "work",
+      "message": "the meeting was 'optional' 🙄",
+      "interpretation": "Risky in a wide team channel; safe in a tight collaborator DM. If used in a team channel, anchor with a sentence that adds context."
+    },
+    {
+      "setting": "dating",
+      "message": "sure, you remembered 🙄",
+      "interpretation": "Partner's skeptical reaction. Mirror with a softer reaction or a sentence that addresses the doubt."
+    },
+    {
+      "setting": "family",
+      "message": "dad's jokes at dinner 🙄",
+      "interpretation": "Family group laughter at a relative's joke. Mirror with 🙄 or a sentence that engages with the humor."
+    }
+  ]
 }

--- a/src/data/emojis/face-with-tears-of-joy.json
+++ b/src/data/emojis/face-with-tears-of-joy.json
@@ -38,15 +38,19 @@
   "platformNotes": [
     {
       "platform": "WHATSAPP",
-      "note": "Very common in family and older friend group chats."
+      "note": "Family WhatsApp groups over-index on 🤣; older relatives treat it as the default reaction to anything mildly funny in the chat."
     },
     {
       "platform": "TIKTOK",
-      "note": "Often seen as a 'boomer' or 'millennial' emoji."
+      "note": "TikTok comments still see 🤣 but it trends older; Gen Z creators sometimes read it as a giveaway that a viewer is not their target audience."
     },
     {
       "platform": "INSTAGRAM",
-      "note": "Used by older demographics for genuine laughter."
+      "note": "On Instagram 🤣 clusters in family, lifestyle, and wholesome meme accounts; Gen Z meme pages usually swap it for 💀 or 😭 for the same beat."
+    },
+    {
+      "platform": "TWITTER",
+      "note": "Twitter uses 🤣 less than it used to; older threads and quote-tweets still have it, but the platform is splitting between 💀 and 😭 for the same laugh beat."
     }
   ],
   "generationalNotes": [
@@ -72,5 +76,58 @@
   ],
   "relatedCombos": ["rofl-laughing"],
   "seoTitle": "🤣 Rolling on Floor Laughing Meaning - What Does 🤣 Really Mean?",
-  "seoDescription": "Learn what the ROFL emoji 🤣 really means in modern texting. Intense laughter, but seen as outdated by Gen Z. Complete context guide."
+  "seoDescription": "Learn what the ROFL emoji 🤣 really means in modern texting. Intense laughter, but seen as outdated by Gen Z. Complete context guide.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "The 🤣 face-with-tears-of-joy emoji is the loudest laugh in the keyboard and the one with the most generational baggage. It was Oxford Dictionaries' Word of the Year in 2015 because nothing captured 'I am crying laughing' as cleanly. For most of the 2010s 🤣 was the universal reaction to anything funny, used across age groups and platforms without anyone thinking twice. The emoji still works exactly that way for Boomers, Gen X, and most Millennials: it is shorthand for 'this is hilarious, I cannot breathe.'\n\nThen Gen Z went through a multi-year phase of declaring 🤣 cringe, partly because it was overused and partly because they replaced it with 💀, 😭, or a string of smaller reactions. The slang stigma is real on TikTok, Twitter, and Instagram among under-25s, but it has not spread evenly. Family group chats, work channels, and Facebook comments still lean on 🤣 the way they always have, which means the emoji is now split between 'genuine laugh' and 'age marker' depending on who is sending it and where. Knowing the audience is the difference between 🤣 landing as warm and 🤣 landing as a tell.",
+    "howPeopleUseIt": "🤣 is the exclamation point of laughter. It is sent solo as a reaction, doubled up (🤣🤣) when something is genuinely side-splitting, or stacked on a sentence ('the way he walked away 🤣🤣') to underline the punchline. It also travels well in family and friend group chats where it functions as the default 'I am dying' response.\n\nOutside the slang-stigma zones, people use 🤣 the way they always have. In a parents' group chat it is the safest possible laugh. In a Slack or Teams thread it reads as a friendly reaction without breaking formality. And on Facebook 🤣 is still the most common reaction on viral wholesome content, where Boomer and Millennial audiences dominate. The stigma is real but it is concentrated on Gen Z-skewing platforms, which is why context still drives the read.",
+    "whenNotToUse": "Skip 🤣 in Gen Z-skewing spaces if you want to land as current: the meme association has not fully worn off, and younger readers may treat it as a signal that you are out of touch. Avoid it in serious or formal contexts — a 🤣 in a condolence thread or a workplace incident report will read as wildly inappropriate. And do not send 🤣 as your only response to bad news; even if you intended it as nervous laughter, it will land as tone deaf.\n\nAlso avoid using 🤣 to react to dark humor you have not set up. If the recipient does not already know you are joking, the laugh reads as gleeful rather than awkward. Pair the emoji with a phrase that establishes tone ('this is awful but 🤣') when the topic is sensitive. When in doubt, send a softer 😂 or a plain 'lol' and let the recipient decide whether to escalate.",
+    "howToReply": "Mirror 🤣 with another 🤣 if you want to keep the energy, or downgrade to 😂 or 💀 if the bit is funnier than devastating. When you receive 🤣 on your own post, treat it as a clean laugh — a short 'right?' or another 🤣 keeps the moment going without overthinking it.\n\nIf you receive 🤣 in a context where the slang stigma matters, mirror back with the emoji your audience would use instead. Younger contacts might prefer 😭 or 💀 for the same laugh; matching the room is a small social cue that pays off. And if someone sends 🤣 sarcastically, glance at the surrounding text — sarcastic 🤣 usually arrives with 'wow' or 'amazing' that tips the tone.",
+    "faqs": [
+      {
+        "question": "Is 🤣 still cool to use?",
+        "answer": "It depends on the audience. In family chats, work tools, and Facebook comments 🤣 is the default laugh and reads as warm. Among Gen Z on TikTok or Twitter it has aged into a meme and can read as cringe or out of touch."
+      },
+      {
+        "question": "What does 🤣 mean from a girl?",
+        "answer": "From a girl, 🤣 means the same thing it means from anyone else: intense laughter. There is no gendered twist, only a generational one."
+      },
+      {
+        "question": "What does 🤣 mean on Snapchat?",
+        "answer": "On Snapchat 🤣 is treated as a normal laugh reaction. Snapchat's audience skews younger but the platform has not picked up the same slang stigma as TikTok, so the emoji is still safe."
+      },
+      {
+        "question": "What does 🤣 mean from a guy?",
+        "answer": "From a guy, 🤣 is a clean laugh reaction. The slang stigma applies equally to anyone sending it in Gen Z-heavy feeds, regardless of gender."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "the way he blamed the projector 🤣",
+      "interpretation": "Shared group chat laugh. Mirror with another 🤣 or a follow-up emoji to keep the bit rolling."
+    },
+    {
+      "setting": "work",
+      "message": "the all-hands meeting went off the rails 🤣",
+      "interpretation": "Friendly vent about a chaotic meeting. Safe in a tight work chat; risky in a wide broadcast channel where tone matters."
+    },
+    {
+      "setting": "family",
+      "message": "Dad just tried to make a reel 🤣",
+      "interpretation": "Family group laugh at a parent's first attempt at a new app. Reply with another 🤣 or a supportive comment."
+    },
+    {
+      "setting": "dating",
+      "message": "you really said that with your whole chest 🤣",
+      "interpretation": "Playful tease. A laughing emoji back or 'I stand by it' lands as flirty without overcommitting."
+    },
+    {
+      "setting": "social",
+      "message": "the comments under that CEO's tweet are sending me 🤣",
+      "interpretation": "Group hype about a public thread. Drop the screenshot or quote-tweet to keep the thread moving."
+    }
+  ]
 }

--- a/src/data/emojis/fire.json
+++ b/src/data/emojis/fire.json
@@ -38,15 +38,19 @@
   "platformNotes": [
     {
       "platform": "TIKTOK",
-      "note": "Used to indicate viral or trending content, or to compliment creators."
+      "note": "TikTok creators stack 🔥 under their own videos as a self-applied hype tag; viewers return it as the default 'this slapped' comment."
     },
     {
       "platform": "INSTAGRAM",
-      "note": "Common compliment on photos and stories, especially for fashion or fitness."
+      "note": "Instagram story replies with 🔥 are read as genuine aesthetic approval, especially for fit pics, food shots, and travel content."
     },
     {
       "platform": "TWITTER",
-      "note": "Often used to highlight hot takes or trending topics."
+      "note": "Twitter uses 🔥 to cosign a hot take or single out a punchline; the emoji doubles as a bookmark on flame-worthy threads."
+    },
+    {
+      "platform": "WHATSAPP",
+      "note": "In family and work WhatsApp groups 🔥 still tilts literal (campfire, kitchen fire) so context matters more than on social feeds."
     }
   ],
   "generationalNotes": [
@@ -66,5 +70,58 @@
   "warnings": [],
   "relatedCombos": ["fire-heart"],
   "seoTitle": "🔥 Fire Emoji Meaning - What Does 🔥 Really Mean?",
-  "seoDescription": "Learn what the fire emoji 🔥 really means in modern texting. Usually means something is hot, exciting, or impressive. Complete context guide."
+  "seoDescription": "Learn what the fire emoji 🔥 really means in modern texting. Usually means something is hot, exciting, or impressive. Complete context guide.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "The 🔥 fire emoji has split into two clean readings: the literal fire of campfires, candles, kitchen mishaps, and weather reports, and the slang 'this is excellent' that took over social feeds in the mid-2010s. On TikTok, Instagram, and Twitter 🔥 is overwhelmingly used as a hype marker, applied to outfits, dance clips, dunk highlights, late-night tweets, and any content the sender wants to elevate. The slang reading is now so dominant that some users instinctively read it as a compliment even when the literal meaning makes sense, so context still matters but defaults to praise.\n\nOutside of social media the emoji tilts back toward literal use, especially in family and work WhatsApp threads where the slang has not fully landed. The split is a useful reminder that 🔥 is one of the few emojis whose meaning genuinely changes by platform: a flame next to a beach photo on Instagram is approval, while the same flame next to a camping story in a family group is description. Writers should treat the default reading as 'excellent' on social platforms and as 'literally on fire' anywhere else, and should add words or a follow-up emoji when the intent could go either way.",
+    "howPeopleUseIt": "🔥 shows up as a solo reaction, a string of two or three for extra emphasis, or as a sticker layered on top of a screenshot or selfie. TikTok creators paste it onto their own videos as a self-applied hype tag the same way Instagram users spam it on someone else's fit pic. In dating-app bios it acts as a soft 'look at me' opener that signals confidence without sounding try-hard.\n\nIn group chats 🔥 functions like a modern applause line. A friend shares a screenshot of a wild work email and you reply 🔥 to mark it as entertaining without writing a paragraph. It also pairs well with 🔥💯 for 'this is flawless,' with 🔥👀 for 'this is scandalous,' and with 💯 alone for straight-up validation. The pattern of stacking two strong-reaction emojis has become its own shorthand, and writers should resist the urge to overthink it.",
+    "whenNotToUse": "Skip 🔥 in any context where literal fire, burns, or disaster relief is the topic, because the slang will sound flippant even if that is not the intent. Avoid it on posts about wildfires, house fires, or cooking accidents unless you want to acknowledge you are being ironic. In serious professional emails about risk, safety incidents, or insurance, the emoji reads as tone deaf and should be replaced with plain language.\n\nAlso avoid stacking 🔥 on criticism you are trying to soften. 'The deck was mid 🔥' sounds dismissive rather than friendly. When the message is negative, lean on 😅 or 'haha' instead so the warmth does not contradict the critique. And in cross-cultural business communication, default to words: the slang reading has not spread evenly, and a fire emoji in a pitch deck will read as unprofessional to international clients.",
+    "howToReply": "Mirror 🔥 with another flame if you want to keep the energy, or upgrade to 💯 if the content truly deserves full marks. If you are complimenting someone and want to land it as sincere rather than performative, add a sentence: '🔥, that fit is insane' reads as more genuine than a stand-alone flame because it explains what you are reacting to.\n\nIf you receive 🔥 on your own post, treat it as a win and resist the urge to explain or downplay it. A short 'ty 🔥' or a flame right back is the right reply. If you suspect someone sent 🔥 sarcastically, glance at the surrounding message — sarcastic 🔥 usually comes with a 'sure' or 'okay' that tips the tone.",
+    "faqs": [
+      {
+        "question": "What does 🔥 mean from a girl?",
+        "answer": "From a girl, 🔥 usually means the same thing it means from anyone else: 'this is excellent.' On dating apps it can read as a soft compliment on a profile or photo, but it is rarely a flirtation signal on its own."
+      },
+      {
+        "question": "Is 🔥 flirty?",
+        "answer": "🔥 is not inherently flirty. It is a hype reaction. On a dating-app opener or a comment under someone's selfie it can read as flirtatious, but in a group chat or comment thread it is just approval."
+      },
+      {
+        "question": "What does 🔥 mean on TikTok?",
+        "answer": "On TikTok 🔥 means the viewer thinks the content is great. Creators often paste it onto their own videos as a self-applied hype sticker before posting."
+      },
+      {
+        "question": "What does 🔥 mean from a guy?",
+        "answer": "From a guy, 🔥 is almost always the slang hype reaction. There is no gendered twist — the emoji is about content quality, not the sender."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "she posted the fit pic from last night 🔥",
+      "interpretation": "Sender is hyping a mutual friend's photo. Mirror with another flame or a compliment emoji like 😍."
+    },
+    {
+      "setting": "dating",
+      "message": "first date went well 🔥",
+      "interpretation": "Soft brag with positive vibes. Reply with excitement or a follow-up question about the date."
+    },
+    {
+      "setting": "work",
+      "message": "client loved the new mockups 🔥",
+      "interpretation": "Work hype. Safe to mirror with another flame or a celebratory phrase; avoid an all-caps reply in a professional channel."
+    },
+    {
+      "setting": "social",
+      "message": "this club is actually insane tonight 🔥",
+      "interpretation": "Real-time hype from a night out. A flame back or a fire-stack (🔥🔥🔥) keeps the energy going."
+    },
+    {
+      "setting": "family",
+      "message": "made the turkey on the new smoker 🔥",
+      "interpretation": "Likely literal — family bragging about a holiday cook. Reply with a celebratory message rather than just a flame emoji."
+    }
+  ]
 }

--- a/src/data/emojis/flexed-biceps.json
+++ b/src/data/emojis/flexed-biceps.json
@@ -38,15 +38,19 @@
   "platformNotes": [
     {
       "platform": "INSTAGRAM",
-      "note": "Fitness content."
+      "note": "Fitness content and motivational posts across creator stories."
     },
     {
       "platform": "TWITTER",
-      "note": "Motivation."
+      "note": "Motivation and 'get it done' reactions on work and fitness posts."
     },
     {
       "platform": "SLACK",
-      "note": "Team encouragement."
+      "note": "Team encouragement and powering-through reactions."
+    },
+    {
+      "platform": "DISCORD",
+      "note": "Server members paste it as the pre-event hype reaction."
     }
   ],
   "generationalNotes": [
@@ -64,7 +68,7 @@
     }
   ],
   "warnings": [],
-  "relatedCombos": [],
+  "relatedCombos": ["flexed-biceps-fire"],
   "seoTitle": "💪 Flexed Biceps Emoji Meaning - What Does 💪 Really Mean?",
   "seoDescription": "Learn what the flexed biceps emoji 💪 really means. Strong or motivation vibes. Complete context guide.",
   "skinToneVariations": [
@@ -73,5 +77,58 @@
     "flexed-biceps-medium",
     "flexed-biceps-medium-dark",
     "flexed-biceps-dark"
+  ],
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "💪 is the strength emoji, the flexed bicep that signals 'you got this,' personal power, or the gym-day baseline. The visual cue — a muscular arm with a flexed bicep — is the most direct strength symbol in the Unicode set, and it has stayed consistent across the literal fitness reading and the motivational reading. On Twitter, Instagram, and Slack 💪 shows up as the standard encouragement reaction to a friend's challenge, the celebration marker on a personal-fitness post, and the 'weird flex but ok' ironic closer on a humble brag. The emoji is one of the cleanest positive-encouragement signals on the keyboard because the meaning is unambiguous across age groups and platforms.\n\nThe emoji also doubles as the 'weird flex but ok' reaction. A friend shares an oddly specific accomplishment and the appropriate reply is 💪 — the visual tag for 'I see you flexing and I am amused.' The dual reading — genuine encouragement or ironic flex — keeps 💪 versatile without diluting the strength. Use 💪 when the moment calls for genuine power-energy or motivation, not as a default reaction to every mundane task.",
+    "howPeopleUseIt": "💪 arrives as the encouragement reaction to a friend's challenge, the celebration marker on a personal-fitness post, or the punchline on a 'weird flex' humble brag. On Instagram the emoji lands as the standard reaction to a gym post or a workout milestone. On Twitter it functions as the 'you got this' reaction to a public challenge. On Slack the same pattern repeats in team channels as the pre-launch hype reaction.\n\nIn group chats 💪 works as the shared hype reaction when a friend shares a goal. The emoji also pairs naturally with 🔥 for the flexed-biceps-fire stronger stack, with 💯 for the full validation, and with a sentence that names what is being cheered so the strength does not feel generic.",
+    "whenNotToUse": "Skip 💪 in contexts where the strength reading will land wrong — in serious professional feedback, in customer complaint threads, or in conversations where the recipient needs empathy rather than encouragement. A 💪 in a customer complaint reply will sound tone deaf. Avoid it in actual moments of grief where strength is not the right energy.\n\nAlso avoid 💪 when the flex is not actually warranted. A 💪 on a friend's first attempt at something will read as condescending. Use the emoji when the moment genuinely calls for the encouragement beat.",
+    "howToReply": "Mirror 💪 with another 💪 or 🔥 if you want to keep the strength going, or upgrade to 💯 for the '100 percent' validation. If you receive 💪 on a personal challenge, reply with a sentence that acknowledges the effort.\n\nIf 💪 arrives as a 'weird flex' reaction, mirror with a sentence that engages with the joke. And if you want to send 💪 as a team-encouragement whisper, anchor the emoji with a sentence that names what is being celebrated so the strength does not feel generic.",
+    "faqs": [
+      {
+        "question": "What does 💪 mean in texting?",
+        "answer": "💪 means 'strong' or 'you got this.' The flexed-bicep emoji is the universal strength and motivation signal and reads as either genuine encouragement or ironic flex."
+      },
+      {
+        "question": "What does 💪 mean from a girl?",
+        "answer": "From a girl or anyone else, 💪 means the sender is encouraging or hyping. There is no gendered meaning; the emoji is about the strength, not who is sending it."
+      },
+      {
+        "question": "Is 💪 flirty?",
+        "answer": "💪 is not flirty. It marks strength or encouragement, with no romantic undercurrent. Using it on a romantic post will read as supportive rather than flirtatious."
+      },
+      {
+        "question": "What does 💪 mean from a guy?",
+        "answer": "From a guy, 💪 has the same meaning it has from anyone else: strength or motivation. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "you got this 💪",
+      "interpretation": "Friend's encouragement. Mirror with 💪 or a sentence that matches the hype."
+    },
+    {
+      "setting": "social",
+      "message": "weird flex but ok 💪",
+      "interpretation": "Public ironic reaction to a humble brag. Mirror with 💪 or a sentence that engages with the flex."
+    },
+    {
+      "setting": "work",
+      "message": "we are shipping it 💪",
+      "interpretation": "Team hype reaction in a tight channel. Mirror with 💪 or a sentence that acknowledges the launch."
+    },
+    {
+      "setting": "dating",
+      "message": "i crushed the presentation 💪",
+      "interpretation": "Romantic partner's personal win. Mirror with a heart or a sentence that engages with the win."
+    },
+    {
+      "setting": "family",
+      "message": "going to the gym mom 💪",
+      "interpretation": "Family sharing a fitness moment. Mirror with 💪 or a sentence that joins the encouragement."
+    }
   ]
 }

--- a/src/data/emojis/folded-hands.json
+++ b/src/data/emojis/folded-hands.json
@@ -38,15 +38,19 @@
   "platformNotes": [
     {
       "platform": "TWITTER",
-      "note": "Gratitude and hope."
+      "note": "Twitter replies end with 🙏 as the default 'thanks for this' reaction, often used sincerely but sometimes with a hint of gratitude fatigue."
     },
     {
       "platform": "INSTAGRAM",
-      "note": "Thankful posts."
+      "note": "Instagram story replies with 🙏 land as warm thanks without being performative; creators use it on captions to acknowledge fan support."
     },
     {
       "platform": "SLACK",
-      "note": "Thank you messages."
+      "note": "Slack uses 🙏 as the workplace-safe default for 'thanks for the help' without needing to type a full acknowledgment sentence."
+    },
+    {
+      "platform": "WHATSAPP",
+      "note": "WhatsApp family chats use 🙏 in the literal prayer sense — sending it before an exam, a hospital visit, or any family milestone."
     }
   ],
   "generationalNotes": [
@@ -73,5 +77,58 @@
     "folded-hands-medium",
     "folded-hands-medium-dark",
     "folded-hands-dark"
+  ],
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "🙏 is the most overloaded emoji in the 'gratitude' category, and it means three different things depending on who is sending it and where. For Boomer and religious readers 🙏 still reads as literal prayer, sent before a hospital visit, an exam, or any moment that warrants divine attention. For Millennial and Gen Z readers 🙏 has shifted toward a generic 'please' or 'thanks' that loses the prayer connotation entirely. And there is the long-running joke that 🙏 is actually a high-five — Apple, Google, and Microsoft render the emoji differently and only Microsoft's interpretation actually looks like two hands going up for a high-five, which has fueled a decade of 'the 🙏 emoji is not what you think it is' meme threads.\n\nThe triple-meaning makes 🙏 one of the most context-dependent emojis on the keyboard. It can read as prayer, as a thank-you, or as a high-five, and which one the recipient sees depends entirely on their age, their platform, and how the surrounding sentence is framed. Writers should default to 🙏 in work tools and family WhatsApp groups where the thanks or prayer reading is safe, and avoid it in mixed-age group chats where the high-five joke is well known and may undercut a sincere moment.",
+    "howPeopleUseIt": "🙏 arrives as the closer on a sentence that asks for something ('please approve 🙏') or as a stand-alone reaction to a favor, a kind gesture, or a stressful milestone. It is the default Slack reaction to 'thanks for the help' and the standard tweet-reply closer when someone wants to acknowledge a good take without writing a paragraph. In religious and family contexts 🙏 shows up before exams, hospital visits, and life events as literal prayer.\n\nThe emoji also works as a 'please let this work' reaction. A friend shares an upcoming interview and you reply 🙏 to mark the moment as anxious but hopeful. The slang 'praying for you' has migrated online — people who have never prayed in their lives send 🙏 as a synonym for 'I hope this works out.' It pairs naturally with hearts (🙏❤️) for added warmth and with 💪 for 'fingers crossed plus strength.'",
+    "whenNotToUse": "Skip 🙏 in contexts where the high-five joke could undercut a sincere moment. Sending 🙏 to a religious recipient when you meant 'thanks for the help' may read as more spiritual than intended, which can be awkward if the recipient reads prayer as weighty. Avoid it in crisis contexts where the recipient may take the prayer reading literally and then feel unsupported — a friend going through a divorce may need words and presence more than 🙏.\n\nAlso avoid 🙏 when a clearer thanks emoji would land better. 🙏 is the soft default; ❤️ or 🙌 read as more enthusiastic, and 👍 reads as more neutral. Pick the emoji that matches the energy of the thanks rather than defaulting to 🙏 every time.",
+    "howToReply": "Mirror 🙏 with another 🙏 if you want to keep the warmth, or upgrade to 🙌 or ❤️ for more enthusiastic appreciation. A short 'you're welcome 🙏' closes the loop without sounding performative. If 🙏 arrives in a context where the high-five joke could land, you can lean into the joke with '🙏 = high-five' for a playful reply, or just mirror the emoji sincerely.\n\nIf you receive 🙏 before a stressful moment — a friend about to take an exam or go into surgery — treat it as a soft 'I am rooting for you.' Reply with 'thanks 🙏' or a sentence that acknowledges the gesture, and resist the urge to make the high-five joke in a moment that genuinely warrants the prayer reading.",
+    "faqs": [
+      {
+        "question": "Does 🙏 mean prayer or high-five?",
+        "answer": "🙏 can mean prayer, please, thanks, or high-five depending on who is sending it. Religious and family-skewing audiences read it as prayer; younger audiences often read it as thanks or hope; the high-five reading is a long-running meme about how the emoji renders across platforms."
+      },
+      {
+        "question": "What does 🙏 mean from a girl?",
+        "answer": "From a girl or anyone else, 🙏 has the same triple-meaning it has for any sender. The reading is driven by context, platform, and audience age, not by gender."
+      },
+      {
+        "question": "What does 🙏 mean on Twitter?",
+        "answer": "On Twitter 🙏 is the default closer for a thank-you reply or a hopeful 'please let this work' reaction. It rarely reads as literal prayer on Twitter; the thanks or hope reading dominates."
+      },
+      {
+        "question": "What does 🙏 mean on Slack?",
+        "answer": "On Slack 🙏 is the workplace-safe default for 'thanks for the help.' It is the lowest-friction way to acknowledge a favor without spawning a follow-up message."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "work",
+      "message": "thanks for covering my shift 🙏",
+      "interpretation": "Workplace thanks. Mirror with 🙏 or 'appreciate it' to close the thread warmly."
+    },
+    {
+      "setting": "family",
+      "message": "exam in the morning, praying I pass 🙏",
+      "interpretation": "Family pre-exam anxiety. Mirror with 🙏 or 'you've got this' to acknowledge the prayer reading."
+    },
+    {
+      "setting": "friends",
+      "message": "please let this job offer come through 🙏",
+      "interpretation": "Friend hoping for a job offer. Mirror with 🙏 or a sentence of support to keep the energy going."
+    },
+    {
+      "setting": "dating",
+      "message": "thank you for tonight 🙏❤️",
+      "interpretation": "Romantic thanks after a date. Mirror with 🙏❤️ or a follow-up sweet line to match the warmth."
+    },
+    {
+      "setting": "social",
+      "message": "rip 🙏",
+      "interpretation": "Group chat condolence or rest-in-peace reaction. Mirror with 🙏 or a sentence that acknowledges the loss."
+    }
   ]
 }

--- a/src/data/emojis/gem.json
+++ b/src/data/emojis/gem.json
@@ -36,9 +36,22 @@
     }
   ],
   "platformNotes": [
-    { "platform": "TWITTER", "note": "Crypto culture." },
-    { "platform": "INSTAGRAM", "note": "Jewelry content." },
-    { "platform": "DISCORD", "note": "Diamond hands." }
+    {
+      "platform": "TWITTER",
+      "note": "Crypto culture and 'diamond hands' meme references."
+    },
+    {
+      "platform": "INSTAGRAM",
+      "note": "Jewelry content and hidden-gem aesthetic posts."
+    },
+    {
+      "platform": "DISCORD",
+      "note": "Crypto and trading-channel diamond-hands reaction on shared market posts."
+    },
+    {
+      "platform": "TWITTER",
+      "note": "Frequent in crypto and investment communities and HODL threads."
+    }
   ],
   "generationalNotes": [
     { "generation": "GEN_Z", "note": "Diamond hands." },
@@ -48,5 +61,58 @@
   "warnings": [],
   "relatedCombos": [],
   "seoTitle": "💎 Gem Stone Emoji Meaning - What Does 💎 Really Mean?",
-  "seoDescription": "Learn what the gem emoji 💎 really means. Diamond hands or precious vibes. Complete context guide."
+  "seoDescription": "Learn what the gem emoji 💎 really means. Diamond hands or precious vibes. Complete context guide.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "💎 is the gem stone emoji, the blue diamond that signals value, preciousness, or the crypto-culture 'diamond hands' phrase. The visual cue — a sparkling blue diamond — has stretched far past its literal jewelry meaning because the slang adoption has been so wide. On Twitter, Reddit, and Discord 💎 shows up as the crypto 'diamond hands' reaction, the 'you are a gem' compliment on a friend's post, and the 'hidden gem' reaction to an underrated share. The emoji is interesting because it spans three genuinely different uses — jewelry, crypto, and compliment — all of which land on related visual beats.\n\nThe emoji also doubles as the universal 'you are precious' reaction. A friend shares a thoughtful gesture and the appropriate reply is 💎 — the visual tag for 'you are valuable.' The dual reading — crypto or compliment — keeps 💎 versatile without diluting the value beat. Use 💎 when the moment calls for the diamond signal, not as a default reaction to every nice moment.",
+    "howPeopleUseIt": "💎 arrives as the diamond-hands reaction on a crypto thread, the 'you are precious' compliment on a warm post, or the punchline on a hidden-gem share. On Twitter it functions as the standard crypto reaction to a market update. On Instagram captions the emoji lands as the signature flourish on a jewelry post or a self-care share. On Discord the same pattern repeats in trading channels as the visual tag for holding.\n\nIn group chats 💎 works as the shared 'you are a gem' reaction when a friend shares a thoughtful gesture. The emoji also pairs naturally with 🤲 for the 'thanks for the gems' reaction, with ✨ for the sparkle emphasis, and with a sentence that names what is being valued so the gem does not feel generic.",
+    "whenNotToUse": "Skip 💎 in contexts where the crypto reading will land wrong — in serious professional channels where the slang reading is missed, in customer complaint replies where the value framing is misplaced, or in conversations where the recipient has not opted into the diamond-hands references. A 💎 in a customer complaint reply will sound tone deaf. Avoid it in conversations where the precious reading does not actually fit.\n\nAlso avoid 💎 when the situation actually calls for a different value moment. The emoji is more coded than a plain heart, so a 💎 on a friend's simple thank-you may read as performative. Reach for a heart or a sentence of warmth when the moment warrants simple appreciation.",
+    "howToReply": "Mirror 💎 with another 💎 or ✨ if you want to keep the sparkle going, or upgrade to a heart for the warmer affection. If you receive 💎 on a personal share, reply with 'thanks 💎' or a sentence that acknowledges the value.\n\nIf 💎 arrives as a diamond-hands reaction, mirror with a sentence that engages with the crypto vibe. And if you want to send 💎 as a soft friendly reaction, anchor the emoji with a sentence that names what is being valued so the gem does not feel performative.",
+    "faqs": [
+      {
+        "question": "What does 💎 mean in texting?",
+        "answer": "💎 means 'precious,' 'diamond hands,' or 'hidden gem.' The gem-stone emoji signals value, crypto conviction, or genuine appreciation depending on context and the relationship."
+      },
+      {
+        "question": "What does 💎 mean from a girl?",
+        "answer": "From a girl or anyone else, 💎 means the sender is valuing or complimenting. There is no gendered meaning; the emoji is about the appreciation, not who is sending it."
+      },
+      {
+        "question": "Is 💎 flirty?",
+        "answer": "💎 can read as flirty in a dating context, especially when paired with a romantic compliment. In other contexts it stays in the precious or value zone."
+      },
+      {
+        "question": "What does 💎 mean from a guy?",
+        "answer": "From a guy, 💎 has the same meaning it has from anyone else: precious value or appreciation. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "you are a gem 💎",
+      "interpretation": "Friend's appreciation. Mirror with 💎 or a heart to engage with the affection."
+    },
+    {
+      "setting": "social",
+      "message": "HODL 💎",
+      "interpretation": "Crypto conviction reaction. Mirror with 💎 or a sentence that acknowledges the market."
+    },
+    {
+      "setting": "dating",
+      "message": "you are precious to me 💎",
+      "interpretation": "Romantic partner's warm message. Mirror with 💎 or a heart to engage with the warmth."
+    },
+    {
+      "setting": "family",
+      "message": "found a hidden gem 💎",
+      "interpretation": "Family sharing a discovery. Mirror with 💎 or a sentence that engages with the find."
+    },
+    {
+      "setting": "work",
+      "message": "this codebase is a 💎",
+      "interpretation": "Team appreciation in a tight channel. Mirror with 💎 or a sentence that acknowledges the work."
+    }
+  ]
 }

--- a/src/data/emojis/grimacing.json
+++ b/src/data/emojis/grimacing.json
@@ -42,21 +42,25 @@
     },
     {
       "platform": "SLACK",
-      "note": "Used for awkward work moments - relatively professional."
+      "note": "Used for awkward work moments; relatively professional."
     },
     {
       "platform": "TIKTOK",
-      "note": "Standard cringe reaction in comments."
+      "note": "Standard cringe reaction in comments under awkward or unbelievable clips."
+    },
+    {
+      "platform": "DISCORD",
+      "note": "Server members use it as the 'yikes' reaction on awkward calls."
     }
   ],
   "generationalNotes": [
     {
       "generation": "GEN_Z",
-      "note": "The 'yikes' face - used for anything cringe."
+      "note": "The 'yikes' face; used for anything cringe."
     },
     {
       "generation": "MILLENNIAL",
-      "note": "Same usage - awkwardness and cringe."
+      "note": "Same usage; awkwardness and cringe."
     },
     {
       "generation": "BOOMER",
@@ -72,5 +76,58 @@
   ],
   "relatedCombos": ["grimace-yikes"],
   "seoTitle": "😬 Grimacing Face Emoji Meaning - What Does 😬 Really Mean?",
-  "seoDescription": "Learn what the grimacing emoji 😬 really means in modern texting. The 'yikes' emoji for awkwardness and cringe. Complete context guide."
+  "seoDescription": "Learn what the grimacing emoji 😬 really means in modern texting. The 'yikes' emoji for awkwardness and cringe. Complete context guide.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "😬 is the 'yikes' emoji, the clenched-teeth-and-wide-eyes face that signals awkwardness, cringe, or a moment that is uncomfortable to witness. On Twitter, TikTok, and Slack 😬 shows up as the universal reaction to a take that missed, a moment that did not land, or a situation that is so tense the only safe response is the grimace. The emoji is interesting because it sits in the corner of the negative face set that is not hostile — it acknowledges the awkwardness rather than attacking the source. A 😬 on a friend's bad take reads as 'I see what happened and we are not going to talk about it,' which is usually the kindest possible read.\n\nThe emoji also doubles as the self-aware reaction to one's own mistakes. A user sends a message that did not land and then pastes 😬 on their own follow-up as the 'I see the problem' tag. The dual reading — external cringe or self-deprecation — keeps 😬 versatile without diluting the awkwardness. Use 😬 when the moment warrants the yikes without the explicit contempt.",
+    "howPeopleUseIt": "😬 arrives as the quote-tweet reaction to a take that missed, the self-deprecating closer on a friend's bad sentence, or the punchline on a tense-but-not-hostile situation. On Twitter it functions as the standard 'yikes' reaction to a public statement that crossed into awkward territory. On TikTok creators paste 😬 on cringe moments as the visual tag for the unbelievable scene.\n\nIn group chats 😬 works as the gentle acknowledgment of a friend's awkward mistake. The emoji also pairs naturally with 🙈 for the see-no-evil embarrassed vibe, with 🤦 for the facepalm, and with a sentence that names the awkwardness so the grimace does not feel pointed.",
+    "whenNotToUse": "Skip 😬 in contexts where the cringe reading will land wrong — in genuine hurt, in serious professional feedback, or in moments where the recipient did not do anything wrong. A 😬 on a coworker's careful presentation will read as dismissive. Avoid it on a friend's vulnerable post; the awkwardness will land wrong.\n\nAlso avoid 😬 when the situation actually warrants stronger reaction. Some moments call for 😒 or 🙄 instead of the gentler grimace. Use 😬 for the awkward-but-not-hostile cases where the yikes is the right energy.",
+    "howToReply": "Mirror 😬 with another 😬 or 🙈 if you want to keep the awkward energy going, or upgrade to a softer reaction if the conversation warrants care. If you receive 😬 as a reaction to your own take, treat it as a signal that the content landed awkwardly and consider whether to clarify or let it go.\n\nIf 😬 arrives on a friend's self-deprecating post, mirror with a sentence that reassures rather than piles on. And if you want to send 😬 as a meta-reaction to something cringe, anchor the emoji with a sentence that names what was so yikes-worthy so the grimace does not feel pointed.",
+    "faqs": [
+      {
+        "question": "What does 😬 mean in texting?",
+        "answer": "😬 means 'awkward' or 'yikes.' The grimacing face signals cringe or discomfort without the hostility of the eye-roll, and reads as either external judgment or self-deprecation."
+      },
+      {
+        "question": "What does 😬 mean from a girl?",
+        "answer": "From a girl or anyone else, 😬 means the sender finds the moment awkward or cringe. There is no gendered meaning; the emoji is about the cringe, not who is sending it."
+      },
+      {
+        "question": "Is 😬 rude?",
+        "answer": "😬 is gentler than the eye-roll but can still read as dismissive. Use it carefully when the recipient is in a vulnerable context, since the awkwardness can land wrong."
+      },
+      {
+        "question": "What does 😬 mean from a guy?",
+        "answer": "From a guy, 😬 has the same meaning it has from anyone else: awkwardness or cringe. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "I just sent that to the wrong person 😬",
+      "interpretation": "Friend sharing a cringe mistake. Mirror with 😬 or a softer reaction that reassures rather than piles on."
+    },
+    {
+      "setting": "social",
+      "message": "that reply was... something 😬",
+      "interpretation": "Public reaction to an awkward take. Mirror with 😬 or a sentence that engages with the cringe."
+    },
+    {
+      "setting": "work",
+      "message": "the meeting ran two hours over 😬",
+      "interpretation": "Acknowledge the awkward work moment. Mirror with 😬 or a sentence that names the strain."
+    },
+    {
+      "setting": "dating",
+      "message": "I locked myself out of the apartment 😬",
+      "interpretation": "Partner's self-deprecating share. Mirror with a softer reaction or a sentence that supports without piling on."
+    },
+    {
+      "setting": "family",
+      "message": "I called my boss 'dad' on the call 😬",
+      "interpretation": "Family group laughter at an awkward moment. Mirror with 😬 or a sentence that engages with the story."
+    }
+  ]
 }

--- a/src/data/emojis/handshake.json
+++ b/src/data/emojis/handshake.json
@@ -38,15 +38,19 @@
   "platformNotes": [
     {
       "platform": "TWITTER",
-      "note": "Agreements and deals."
+      "note": "Agreements and deal announcements on brand accounts."
     },
     {
       "platform": "INSTAGRAM",
-      "note": "Business and collaboration."
+      "note": "Business and collaboration announcements."
     },
     {
       "platform": "SLACK",
-      "note": "Deal confirmed."
+      "note": "Standard deal-confirmed reaction in product and partnership channels."
+    },
+    {
+      "platform": "SLACK",
+      "note": "Standard deal-confirmed reaction in partnership and product channels."
     }
   ],
   "generationalNotes": [
@@ -73,5 +77,58 @@
     "handshake-medium",
     "handshake-medium-dark",
     "handshake-dark"
+  ],
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "🤝 is the universal deal-confirmed emoji, the two-hands-shaking pair that signals agreement, partnership, or a deal sealed. The visual cue — two hands clasped in a handshake — is the most direct agreement symbol in the Unicode set, and it has stayed consistent across cultures and contexts. On Slack, Twitter, and LinkedIn 🤝 shows up as the standard reaction to a partnership announcement, the closer on a deal-confirmed thread, and the agreement tag on a stakeholder reply. The emoji is one of the cleanest professional signals on the keyboard because the meaning is unambiguous across age groups and platforms.\n\nThe emoji also doubles as the soft-fake-agreement reaction. A friend says something absurd and the appropriate reply is 🤝 — the visual tag for 'I am agreeing because the joke is worth it.' The dual reading — real agreement or sarcastic compliance — keeps 🤝 versatile without diluting the meaning. Use 🤝 when the moment calls for partner-energy agreement, not as a default reaction to casual agreement.",
+    "howPeopleUseIt": "🤝 arrives as the closer on a partnership announcement, the deal-confirmed reaction in a Slack thread, or the punchline on a sarcastic agreement. On LinkedIn the emoji lands as the standard reaction to a professional milestone or a collaboration post. On Twitter it functions as the quote-tweet reaction to a deal-confirmed announcement. On Slack the same pattern repeats in product or partnership channels as the visual tag for the moment the deal lands.\n\nIn group chats 🤝 works as the shared 'we are aligned' reaction when a friend agrees with a take. The emoji also pairs naturally with 💼 for the business variant, with 👀 for the seeing-eye check, and with a sentence that names what is being agreed to so the handshake does not feel generic.",
+    "whenNotToUse": "Skip 🤝 in contexts where the agreement reading will land wrong — in sarcastic compliance where the recipient does not get the joke, in customer complaint threads where the partnership energy is misplaced, or in hot takes where the agreement is not actually mutual. A 🤝 in a customer complaint reply will read as cynical. Avoid it where genuine disagreement is the right move.\n\nAlso avoid 🤝 when you want to actually offer detailed feedback. The emoji is the agreement signal, so sending it on a friend's first draft of something will read as 'looks good, do not change it' rather than 'here are my notes.' Reach for words or a sentence when the message needs nuance.",
+    "howToReply": "Mirror 🤝 with another 🤝 if you want to keep the agreement going, or upgrade to 💼 for the business variant. If you receive 🤝 on a partnership announcement, reply with a sentence that acknowledges the milestone.\n\nIf 🤝 arrives as a sarcastic agreement, mirror with a sentence that engages with the joke. And if you want to send 🤝 as a deal-confirmed whisper, anchor the emoji with a sentence that names what is being agreed to so the handshake does not feel generic.",
+    "faqs": [
+      {
+        "question": "What does 🤝 mean in texting?",
+        "answer": "🤝 means 'agreement' or 'deal sealed.' The handshake emoji is the universal deal-confirmed symbol and reads as either genuine partnership or sarcastic compliance."
+      },
+      {
+        "question": "What does 🤝 mean from a girl?",
+        "answer": "From a girl or anyone else, 🤝 means the sender is agreeing or confirming a deal. There is no gendered meaning; the emoji is about the agreement, not who is sending it."
+      },
+      {
+        "question": "Is 🤝 flirty?",
+        "answer": "🤝 is not flirty. It marks agreement or partnership, with no romantic undercurrent. Using it on a romantic post will read as supportive rather than flirtatious."
+      },
+      {
+        "question": "What does 🤝 mean from a guy?",
+        "answer": "From a guy, 🤝 has the same meaning it has from anyone else: agreement or partnership. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "work",
+      "message": "deal confirmed 🤝",
+      "interpretation": "Team confirmation in a partner channel. Mirror with 🤝 or a sentence that acknowledges the deal."
+    },
+    {
+      "setting": "friends",
+      "message": "we good 🤝",
+      "interpretation": "Friend confirming agreement. Mirror with 🤝 or a sentence that engages with the deal."
+    },
+    {
+      "setting": "social",
+      "message": "new partnership announced 🤝",
+      "interpretation": "Public partnership announcement. Mirror with 🤝 or a sentence that celebrates the collaboration."
+    },
+    {
+      "setting": "family",
+      "message": "we agreed no more pineapple on pizza 🤝",
+      "interpretation": "Family agreement on a divisive topic. Mirror with 🤝 or a sentence that engages with the rule."
+    },
+    {
+      "setting": "dating",
+      "message": "monday is our day 🤝",
+      "interpretation": "Romantic partner confirming a recurring plan. Mirror with a heart or a sentence that engages with the date."
+    }
   ]
 }

--- a/src/data/emojis/heart-hands.json
+++ b/src/data/emojis/heart-hands.json
@@ -38,15 +38,19 @@
   "platformNotes": [
     {
       "platform": "TWITTER",
-      "note": "Extremely popular in K-pop communities."
+      "note": "Extremely popular in K-pop fandoms and stan communities."
     },
     {
       "platform": "INSTAGRAM",
-      "note": "Common in appreciation and love posts."
+      "note": "Common in appreciation and love posts across creators."
     },
     {
       "platform": "TIKTOK",
-      "note": "Viral gesture emoji, especially in fan content."
+      "note": "Viral gesture emoji, especially in fan content and edits."
+    },
+    {
+      "platform": "DISCORD",
+      "note": "Server members paste it as the appreciation reaction on shared wins."
     }
   ],
   "generationalNotes": [
@@ -73,5 +77,58 @@
     "heart-hands-medium",
     "heart-hands-medium-dark",
     "heart-hands-dark"
+  ],
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "🫶 is the heart hands emoji, the two hands forming a heart shape that signals love, appreciation, or the K-pop fan-culture gesture. The visual cue — palms together, fingers forming a heart — is a relatively recent Unicode addition (2021) that has rapidly become one of the most-used love emoji on the keyboard. On Twitter, Instagram, and TikTok 🫶 shows up as the universal 'sending love' reaction, the fan-culture marker on K-pop appreciation posts, and the cute affection closer on a friend's wholesome message. The emoji is interesting because it spans romantic warmth, friendship appreciation, and fandom culture all on the same beat.\n\nThe emoji also doubles as the cute-affection reaction. A friend shares something sweet and the appropriate reply is 🫶 — the visual tag for 'I am sending you love.' The dual reading — romantic, friendship, or fan-appreciation — keeps 🫶 versatile without diluting the warmth. Use 🫶 when the moment calls for the cute love signal, not as a default reaction to every nice moment.",
+    "howPeopleUseIt": "🫶 arrives as the love reaction to a friend's wholesome post, the fan-culture marker on a K-pop tweet, or the punchline on a cute affection message. On Twitter it functions as the fandom reaction to a favorite artist's post. On Instagram captions the emoji lands as the signature flourish on a love post or a glow-up share. On TikTok creators paste 🫶 on fan edits as the visual tag for the appreciation moment.\n\nIn group chats 🫶 works as the shared 'sending love' reaction when a friend shares something sweet. The emoji also pairs naturally with ❤️ for layered affection, with 🥰 for the warm admiration, and with a sentence that names what is being loved so the heart-hands does not feel generic.",
+    "whenNotToUse": "Skip 🫶 in contexts where the love reading will land wrong — in cold professional channels, in customer complaint replies, or in formal client emails. A 🫶 in a customer complaint thread will sound tone deaf. Avoid it in serious discussions about grief or loss where the cuteness cannot reach the actual pain.\n\nAlso avoid 🫶 when you want to actually deliver careful feedback. A manager who replies to a missed deadline with 🫶 sounds as if they are softening bad news with cuteness rather than delivering clear direction. Reach for words or a more neutral emoji when the message needs to land as honest.",
+    "howToReply": "Mirror 🫶 with another 🫶 or ❤️ if you want to keep the warmth going, or upgrade to 🥰 for the warm admiration. If you receive 🫶 on a wholesome post, reply with 'thanks 🫶' or a sentence that acknowledges the love.\n\nIf 🫶 arrives as a fan-culture reaction, mirror with a heart or a sentence that engages with the fandom. And if you want to send 🫶 as a soft friendly reaction, anchor the emoji with a sentence that names the warmth so the heart-hands does not feel generic.",
+    "faqs": [
+      {
+        "question": "What does 🫶 mean in texting?",
+        "answer": "🫶 means 'I love you' or 'sending love.' The heart-hands emoji is the universal cute-affection signal and reads as romantic, friendship, or fandom appreciation depending on context."
+      },
+      {
+        "question": "What does 🫶 mean from a girl?",
+        "answer": "From a girl or anyone else, 🫶 means the sender is sending love or affection. There is no gendered meaning; the emoji is about the warmth, not who is sending it."
+      },
+      {
+        "question": "Is 🫶 flirty?",
+        "answer": "🫶 can read as flirty in a dating context, especially paired with romantic content. In other contexts it stays in the wholesome or fandom zone."
+      },
+      {
+        "question": "What does 🫶 mean from a guy?",
+        "answer": "From a guy, 🫶 has the same meaning it has from anyone else: cute love or appreciation. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "love you bestie 🫶",
+      "interpretation": "Friend's warm affection. Mirror with 🫶 or a heart to close the loop."
+    },
+    {
+      "setting": "social",
+      "message": "my bias did the thing 🫶",
+      "interpretation": "Fan-culture reaction. Mirror with 🫶 or a sentence that engages with the fandom."
+    },
+    {
+      "setting": "dating",
+      "message": "you mean everything to me 🫶",
+      "interpretation": "Romantic partner's love message. Mirror with 🫶 or a heart to engage with the warmth."
+    },
+    {
+      "setting": "family",
+      "message": "love you mom 🫶",
+      "interpretation": "Family warmth. Mirror with 🫶 or a heart to close the loop."
+    },
+    {
+      "setting": "work",
+      "message": "thanks for the handoff 🫶",
+      "interpretation": "Risky in a wide team channel; safe in a tight collaborator DM. If used in a team channel, anchor with a sentence that adds context."
+    }
   ]
 }

--- a/src/data/emojis/heart.json
+++ b/src/data/emojis/heart.json
@@ -38,15 +38,19 @@
   "platformNotes": [
     {
       "platform": "INSTAGRAM",
-      "note": "The default heart when double-tapping to like. Very common in comments."
+      "note": "Instagram's double-tap like is the red heart by default, and the same heart shows up as a comment reaction under photos, reels, and close-friend stories."
     },
     {
       "platform": "IMESSAGE",
-      "note": "Carries more weight than other platforms - implies genuine affection."
+      "note": "iMessage treats the red heart as the strongest of the heart set; younger users reach for pink or sparkles hearts to soften the read."
     },
     {
       "platform": "SLACK",
-      "note": "Use sparingly in work contexts - may seem unprofessional or overly familiar."
+      "note": "Slack usage of the red heart is read as overly familiar; a :white_heart: reaction or a :raised_hands: lands better in cross-team channels."
+    },
+    {
+      "platform": "TIKTOK",
+      "note": "TikTok comments under couple content use the red heart as a stand-in for 'goals'; creators paste it on their own videos as a relationship flex."
     }
   ],
   "generationalNotes": [
@@ -72,5 +76,58 @@
   ],
   "relatedCombos": ["heart-eyes", "double-hearts"],
   "seoTitle": "❤️ Red Heart Emoji Meaning - What Does ❤️ Really Mean?",
-  "seoDescription": "Learn what the red heart emoji ❤️ really means in modern texting. The classic love symbol for romantic and deep affection. Complete context guide."
+  "seoDescription": "Learn what the red heart emoji ❤️ really means in modern texting. The classic love symbol for romantic and deep affection. Complete context guide.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "The ❤️ red heart is the oldest and most loaded emoji in the Unicode set. It was among the first batch of emoji standardized in the late 1990s, and it has carried the same basic meaning — love, deep affection, romantic attachment — for almost three decades. Unlike the laughing faces or the skull, the red heart has not lost its charge; if anything, Gen Z has tightened the meaning by preferring other colors and shapes for casual appreciation, leaving ❤️ as the most serious heart in the palette.\n\nIn practice ❤️ is used for romantic love, family love, close friendship love, and as a generic 'I love this' reaction. The key variable is the relationship: ❤️ from a long-term partner reads as romantic, ❤️ from a parent reads as familial, and ❤️ from a coworker can read as overly familiar. The same emoji means different things in different relationships, which is why context and history with the sender matter more than the platform. Writers should reserve ❤️ for moments that genuinely warrant deep affection and reach for the pink, orange, or sparkling hearts when the read should be lighter.",
+    "howPeopleUseIt": "❤️ is the default heart on Instagram and the most common heart in personal iMessage threads. People send it at the end of messages the way a kiss works in old-fashioned letter writing — as a softener and a signal of warmth. In dating-app conversations ❤️ tends to land as a relationship escalation; users escalate from 👀 to 😍 to ❤️ as a way of marking how serious the conversation is getting.\n\nIn group chats ❤️ shows up as a low-effort way to react to a photo, an announcement, or a sweet moment without typing a sentence. It also pairs naturally with other emojis: ❤️😊 for family warmth, ❤️🔥 for romantic heat, and ❤️💯 for full validation. The red heart is the only heart that universally signals 'I love this,' which is why writers should keep it for moments that actually warrant that weight.",
+    "whenNotToUse": "Skip ❤️ in cold work channels where the relationship does not justify the warmth — it reads as overly familiar or flirtatious when sent to a coworker you barely know. Avoid it in customer-facing comms where the sentiment can be misread as romantic: a ❤️ from a brand account under a complaint reply sounds tone deaf. And do not default to ❤️ when a softer heart (🩷, 💛, 🤍) would do the same job without the romantic weight.\n\nAlso avoid ❤️ in any context where love is not actually on the table. A ❤️ sent as a quick reaction to a meme, a deal, or a transactional message reads as mismatched. If you want to express appreciation in those moments, use 👍, 🙌, or a 👍 emoji. The red heart is a meaningful signal and using it casually dilutes its impact.",
+    "howToReply": "Mirror ❤️ with another ❤️ if you want to keep the warmth, or upgrade to ❤️❤️ for emphasis on a moment that really landed. A short 'love you' or 'thank you ❤️' closes the loop without sounding performative. If you receive ❤️ in a context where the relationship is unclear, glance at the surrounding text: ❤️ in a romantic context usually pairs with 'I love you' or 'miss you,' while ❤️ in a friendship context pairs with 'love this' or a photo.\n\nIf you want to escalate the warmth, layer a second emoji (❤️😊 or ❤️🔥) and a short sentence. If you want to soften the read, switch to 🩷 or 💛 so the message registers as friendly rather than romantic. The choice of which heart to send back is a small social cue that pays off.",
+    "faqs": [
+      {
+        "question": "What does ❤️ mean from a girl?",
+        "answer": "From a girl, ❤️ means she has warm feelings — romantic, familial, or close friendship, depending on the relationship. There is no universal 'flirty' meaning; the read depends on who is sending it and how."
+      },
+      {
+        "question": "Is ❤️ flirty?",
+        "answer": "❤️ can read as flirty when it lands unexpectedly from someone you are not already close with. Inside an established romantic relationship it is the default love signal."
+      },
+      {
+        "question": "What does ❤️ mean from a guy?",
+        "answer": "From a guy, ❤️ has the same meaning it has from anyone else: deep affection. The gendered read is mostly cultural; in most modern contexts the emoji is just warmth."
+      },
+      {
+        "question": "What does ❤️ mean on Instagram?",
+        "answer": "On Instagram ❤️ is the default like button. As a comment reaction it carries more weight than the heart-shaped reactions under stories and implies genuine affection."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "family",
+      "message": "made it home safe ❤️",
+      "interpretation": "Family member checking in with warmth. Mirror with another ❤️ or 'love you' to close the loop."
+    },
+    {
+      "setting": "dating",
+      "message": "good morning ❤️",
+      "interpretation": "Romantic good morning from a partner. Mirror with another ❤️ or a follow-up sweet line."
+    },
+    {
+      "setting": "friends",
+      "message": "love you guys ❤️",
+      "interpretation": "Platonic affection in a group chat. Mirror with the same or 'love you right back' to keep the warmth."
+    },
+    {
+      "setting": "work",
+      "message": "thanks for covering my shift ❤️",
+      "interpretation": "Could read as overly familiar in a wide team channel. Safer to reply with 'appreciate it' or a thumbs-up rather than mirroring the heart."
+    },
+    {
+      "setting": "social",
+      "message": "this is the couple that gives me hope ❤️",
+      "interpretation": "Group chat commentary on a relationship post. Mirror with another ❤️ or a sentence about the post."
+    }
+  ]
 }

--- a/src/data/emojis/hugging-face.json
+++ b/src/data/emojis/hugging-face.json
@@ -42,11 +42,15 @@
     },
     {
       "platform": "WHATSAPP",
-      "note": "Common for sending comfort to friends and family."
+      "note": "Common for sending comfort to friends and family in hard moments."
     },
     {
       "platform": "TWITTER",
-      "note": "Used for supportive messages or community building."
+      "note": "Used for supportive messages or community-building replies."
+    },
+    {
+      "platform": "DISCORD",
+      "note": "Server members paste it as a comfort reaction on hard-share moments."
     }
   ],
   "generationalNotes": [
@@ -66,5 +70,58 @@
   "warnings": [],
   "relatedCombos": [],
   "seoTitle": "🤗 Hugging Face Emoji Meaning - What Does 🤗 Really Mean?",
-  "seoDescription": "Learn what the hugging face emoji 🤗 really means. Used for virtual hugs, warmth, and welcoming gestures. Complete context guide."
+  "seoDescription": "Learn what the hugging face emoji 🤗 really means. Used for virtual hugs, warmth, and welcoming gestures. Complete context guide.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "🤗 is the universal virtual hug emoji, the smile-plus-open-hands face that signals warmth, support, or welcome. The visual cue — a smiling face with arms opened wide as if offering a hug — is the most direct friendly gesture in the Unicode face set. On Slack, WhatsApp, and Twitter 🤗 shows up as the standard reaction to a friend's hard moment, the closer on a new team member's welcome, and the warmth sign-off on a casual thank-you. The emoji is one of the cleanest positive-affection signals on the keyboard because the meaning is unambiguous across age groups and platforms.\n\nThe emoji also doubles as the soft comfort reaction when a friend shares bad news. Compared to a heart ❤️ — which reads as romantic or deep affection — 🤗 sits in the friendly-support zone. The dual reading — friendly welcome or genuine comfort — keeps 🤗 versatile without diluting the warmth. Use 🤗 when the moment calls for kindness without the romantic or overly enthusiastic weight of other positive emoji.",
+    "howPeopleUseIt": "🤗 arrives as the closer on a friend's hard-day message, the welcome reaction in a new team channel, or the punchline on a wholesome share. On Slack the emoji lands as the standard 'welcome to the team' reaction in product launches and onboarding threads. On WhatsApp it shows up as the comforting sibling to a friend in a hard moment. On Twitter quote-tweets 🤗 functions as the supportive reaction to a public statement that deserves warmth.\n\nIn group chats 🤗 works as the absorbing reaction when a friend shares a sad update. The emoji also pairs naturally with ❤️ for layered warmth, with 🙏 for the grateful variant, and with a sentence that names what the sender is comforting. Stand-alone 🤗 reads as warm; in a stack it leans performative.",
+    "whenNotToUse": "Skip 🤗 in contexts where the warmth would feel mismatched — in cold professional channels, in customer complaint replies, or in formal client emails. A 🤗 in a customer complaint thread sounds tone deaf. Avoid it in serious discussions about grief or loss where the warmth cannot reach the actual pain.\n\nAlso avoid 🤗 when you want to actually deliver careful feedback. A manager who replies to a missed deadline with 🤗 sounds as if they are softening bad news with cuteness rather than delivering clear direction. Reach for words or a more neutral emoji when the message needs to land as honest.",
+    "howToReply": "Mirror 🤗 with another 🤗 or ❤️ if you want to keep the warmth going, or upgrade to a sentence that acknowledges the moment. If you receive 🤗 on a hard-day message, reply with 'thanks 🤗' or a soft heart so the warmth lands without piling on.\n\nIf 🤗 arrives as a welcome reaction in a team channel, mirror with a sentence that introduces the work. And if you want to send 🤗 as a soft friendly reaction, anchor the emoji with a sentence that names the warmth so the hug does not feel generic.",
+    "faqs": [
+      {
+        "question": "What does 🤗 mean in texting?",
+        "answer": "🤗 means 'sending a virtual hug' or 'warm welcome.' The hugging face is the universal friendly-comfort emoji and reads as supportive across age groups and platforms."
+      },
+      {
+        "question": "What does 🤗 mean from a girl?",
+        "answer": "From a girl or anyone else, 🤗 means the sender is offering warmth or comfort. There is no gendered meaning; the emoji is about the support, not who is sending it."
+      },
+      {
+        "question": "Is 🤗 flirty?",
+        "answer": "🤗 is not flirty. It marks warmth or friendly support, with no romantic undercurrent. Using it on a romantic post will read as supportive rather than flirtatious."
+      },
+      {
+        "question": "What does 🤗 mean from a guy?",
+        "answer": "From a guy, 🤗 has the same meaning it has from anyone else: friendly warmth or comfort. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "rough day, sending hugs 🤗",
+      "interpretation": "Friend offering comfort. Mirror with 🤗 or a sentence that engages with the hard day."
+    },
+    {
+      "setting": "work",
+      "message": "welcome to the team 🤗",
+      "interpretation": "Welcoming tone in a team channel. Mirror with a sentence that introduces the work."
+    },
+    {
+      "setting": "family",
+      "message": "miss you grammy 🤗",
+      "interpretation": "Family warmth to a relative. Mirror with 🤗 or 'love you too' to close the loop."
+    },
+    {
+      "setting": "dating",
+      "message": "proud of you 🤗",
+      "interpretation": "Romantic partner's support. Mirror with 🤗 or a heart to engage with the warmth."
+    },
+    {
+      "setting": "social",
+      "message": "great to have you here 🤗",
+      "interpretation": "Friendly comment on a creator's content. Mirror with 🤗 or a heart to engage."
+    }
+  ]
 }

--- a/src/data/emojis/kiss-mark.json
+++ b/src/data/emojis/kiss-mark.json
@@ -36,17 +36,88 @@
     }
   ],
   "platformNotes": [
-    { "platform": "TWITTER", "note": "Used for kisses and sassy sign-offs." },
-    { "platform": "INSTAGRAM", "note": "Popular in makeup and romantic content." },
-    { "platform": "TIKTOK", "note": "Common in GRWM and confidence content." }
+    {
+      "platform": "TWITTER",
+      "note": "Lands as the sassy confidence closer on bold takes and beauty content."
+    },
+    {
+      "platform": "INSTAGRAM",
+      "note": "Popular in makeup captions and romantic content as the signature flourish."
+    },
+    {
+      "platform": "TIKTOK",
+      "note": "Creators paste this emoji on GRWM reveals and confident sign-offs to land the look."
+    }
   ],
   "generationalNotes": [
-    { "generation": "GEN_Z", "note": "Used for sassy confidence and romance." },
-    { "generation": "MILLENNIAL", "note": "Classic kiss emoji." },
-    { "generation": "BOOMER", "note": "Interpreted as romantic kisses." }
+    {
+      "generation": "GEN_Z",
+      "note": "Used for sassy confidence and romance."
+    },
+    {
+      "generation": "MILLENNIAL",
+      "note": "Classic kiss emoji."
+    },
+    {
+      "generation": "BOOMER",
+      "note": "Interpreted as romantic kisses."
+    }
   ],
   "warnings": [],
   "relatedCombos": [],
   "seoTitle": "💋 Kiss Mark Emoji Meaning - What Does 💋 Really Mean?",
-  "seoDescription": "Learn what the kiss mark emoji 💋 really means. From romantic kisses to sassy sign-offs, discover all its uses."
+  "seoDescription": "Learn what the kiss mark emoji 💋 really means. From romantic kisses to sassy sign-offs, discover all its uses.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "💋 is the lipstick kiss emoji, the one that signals romance, sass, or leaving your mark — sometimes all three at once. The red kiss glyph carries a distinctly feminine energy in modern internet culture; it shows up on GRWM TikToks, beauty Instagram posts, and sassy sign-offs where the sender wants to mark the moment as confident and unbothered. As a romantic signal 💋 reads as a kiss with lipstick on it, which feels more deliberate than the casual face-blowing-a-kiss 😘.\n\nThe dual reading — romantic kiss or sassy goodbye — makes 💋 one of the most versatile positive emoji. In dating-app conversations it lands as flirtatious, in work channels it would feel mismatched, and on Twitter or Instagram it functions as the standard confidence closer for posts that want a little extra drama. Writers should reserve 💋 for moments that genuinely warrant the kiss-mark drama, because overusing it can start to feel performative.",
+    "howPeopleUseIt": "💋 arrives as a sentence closer on a flirty message, a sign-off after a confident statement, or as the punctuation mark on a beauty post. On TikTok creators paste 💋 on GRWM reveals and confidence edits as the signature closing emoji. On Instagram the same pattern repeats in makeup and beauty captions, where the kiss-mark doubles as both romance and aesthetic. On Twitter 💋 shows up as the sassy closer — 'bye to my haters 💋' or 'said what I said 💋' — that lands the moment with confidence.\n\nThe emoji pairs naturally with hearts (💋❤️) for romantic emphasis and with sunglasses or fire for confident energy (💋🔥). It is rare to see 💋 in work channels or formal contexts; the lipstick energy is too performative for most professional reading.",
+    "whenNotToUse": "Skip 💋 in cold work channels or customer-facing comms where the lipstick energy would feel mismatched. A 💋 in a customer complaint reply sounds as if you are enjoying the drama, and a 💋 in a formal email undercuts the seriousness of the message. Avoid it in first-contact dating messages where the romance has not been established — 💋 is loud and direct, so leading with it can feel forward.\n\nAlso avoid 💋 in serious discussions about consent, grief, or loss. The kiss-mark energy is too playful for moments that warrant empathy, and using it there will read as tone deaf.",
+    "howToReply": "Mirror 💋 with another 💋 if you want to keep the sassy or romantic energy going, or upgrade to ❤️ for a softer affection signal. If you receive 💋 from a romantic partner, a short 'kiss back 💋' or a heart emoji closes the loop.\n\nIf 💋 arrives as a sassy sign-off, mirror with the same emoji or a fire reaction to match the confidence. And if you want to send 💋 as a flirty closer in an established relationship, pair it with a sentence that lands the romantic intent so the kiss-mark does not feel like a generic sign-off.",
+    "faqs": [
+      {
+        "question": "What does 💋 mean in texting?",
+        "answer": "💋 means 'kiss' or 'sassy sign-off.' It reads as romantic in dating contexts and as confident closer on social media, with the lipstick energy carrying both readings."
+      },
+      {
+        "question": "What does 💋 mean from a girl?",
+        "answer": "From a girl or anyone else, 💋 means the sender is sending a kiss or closing a moment with confidence. There is no gendered meaning; the emoji is about the energy, not who is sending it."
+      },
+      {
+        "question": "Is 💋 flirty?",
+        "answer": "💋 can read as flirty in a dating context, especially paired with romantic content. On social media it more often reads as a sassy confident closer."
+      },
+      {
+        "question": "What does 💋 mean from a guy?",
+        "answer": "From a guy, 💋 has the same meaning it has from anyone else: kiss or sassy sign-off. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "dating",
+      "message": "can't wait to see you tonight 💋",
+      "interpretation": "Romantic partner's anticipation message. Mirror with 💋 or a follow-up sweet line."
+    },
+    {
+      "setting": "social",
+      "message": "my work here is done 💋",
+      "interpretation": "Sassy confident closer on a viral post. Mirror with 💋 or 🔥 to match the swagger."
+    },
+    {
+      "setting": "family",
+      "message": "xoxo grandma 💋",
+      "interpretation": "Family warmth between grandparent and grandchild. Mirror with 💋 or 'love you' to close the loop."
+    },
+    {
+      "setting": "friends",
+      "message": "she really ended him with that reply 💋",
+      "interpretation": "Group chat appreciation of a friend's clapback. Mirror with 💋 or 🔥 to match the energy."
+    },
+    {
+      "setting": "work",
+      "message": "thanks for the handoff 💋",
+      "interpretation": "Too personal for most workplace channels; risky to send to a coworker. Replace with 'thanks' or a thumbs-up if needed."
+    }
+  ]
 }

--- a/src/data/emojis/loudly-crying-face.json
+++ b/src/data/emojis/loudly-crying-face.json
@@ -38,15 +38,19 @@
   "platformNotes": [
     {
       "platform": "TIKTOK",
-      "note": "More often means laughing than actually crying."
+      "note": "TikTok comments lean overwhelmingly on 😭 as the 'I cannot stop laughing' reaction; literal crying is the rare reading on this platform."
     },
     {
       "platform": "TWITTER",
-      "note": "Dual meaning - intense emotion of any kind."
+      "note": "Twitter quote-tweets use 😭 as the universal 'this is too much' reaction; works for both laughing and being emotionally wrecked."
     },
     {
       "platform": "INSTAGRAM",
-      "note": "Used for both sad and hilarious content."
+      "note": "Instagram comments use 😭 for both sad story content and hilarious reels, so the platform splits the meaning roughly evenly."
+    },
+    {
+      "platform": "WHATSAPP",
+      "note": "WhatsApp family groups still read 😭 more literally than younger-skewing platforms, so context matters when messaging older relatives."
     }
   ],
   "generationalNotes": [
@@ -72,5 +76,58 @@
   ],
   "relatedCombos": [],
   "seoTitle": "😭 Loudly Crying Face Emoji Meaning - What Does 😭 Really Mean?",
-  "seoDescription": "Learn what the loudly crying face emoji 😭 really means in texting. Can mean intense sadness OR laughing hard. Complete context guide."
+  "seoDescription": "Learn what the loudly crying face emoji 😭 really means in texting. Can mean intense sadness OR laughing hard. Complete context guide.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "😭 is the most overloaded emoji in the keyboard, a face that means two opposite things at once and has been the source of a decade of cross-generational confusion. On Gen Z-heavy platforms 😭 almost always means 'I am laughing so hard I am crying' — it is the universal reaction to a TikTok, a meme, a chaotic group chat story, or any moment that breaks the viewer. On Boomer-heavy platforms 😭 tilts back toward the literal reading, used for genuine grief, sadness, or being overwhelmed.\n\nThe split matters because the same emoji can land as warmth or as cold comfort depending on the audience. 😭 from a Gen Z friend in response to a meme is supportive laughter; 😭 from an older relative responding to bad news is empathy. The humor-vs-literally-sad divide has been the meme itself for years, with plenty of Twitter jokes about Boomer parents sending 😭 in response to a joke and the kid having to explain. Writers should default to the laughter reading on social platforms and switch to words when the moment is actually sad, especially with audiences who have not adopted the slang.",
+    "howPeopleUseIt": "😭 shows up as a stand-alone reaction, doubled up (😭😭) when something is genuinely devastating, or stacked in a chain with other emojis like 😂💀😭 for compound emotions. On TikTok and Twitter the emoji functions as the soft alternative to 💀 for 'I cannot handle this content,' and it pairs naturally with 😂 for 'I am crying laughing.' In dating-app conversations 😭 arrives when the sender misses the recipient or feels emotionally overwhelmed in a romantic sense, where the literal-crying reading is more likely.\n\nThe emoji also works as a tiny exclamation point. 'the way he said that 😭' lands as light commentary where the same sentence without 😭 would feel flat. It is the most common single-emoji reply in group chats because it can flex with whatever the moment actually means — laughter, secondhand embarrassment, missing someone, or being emotionally wrecked.",
+    "whenNotToUse": "Skip 😭 in professional or work channels where the literal crying reading can undercut the message. A 😭 in a status update about a missed deadline will read as unprofessional, and a 😭 in a customer-facing complaint reply will sound tone deaf. Avoid it in condolence messages where the slang may not have landed — older recipients will read it literally and may find it jarring.\n\nAlso avoid 😭 when the moment is actually serious and the audience is mixed. If a friend shares a real loss and you send 😭, Gen Z readers will assume it is the slang laughter and may misread the tone. Switch to 'I am so sorry' or a heart emoji when the moment actually calls for literal sympathy, and save 😭 for moments where the slang reading is safe.",
+    "howToReply": "Mirror 😭 with another 😭 if you want to keep the energy, or pair it with 😂 if the moment is genuinely hilarious. If you receive 😭 and you are not sure whether it is sincere or ironic, glance at the surrounding message — sincere 😭 usually pairs with serious life events or missing someone, while ironic 😭 pairs with jokes, memes, or chaotic content.\n\nIf 😭 lands on your own post, treat it as a strong reaction and reply with 'glad it landed 😭' or a sentence that acknowledges the moment. And if you want to soften the read for an older audience, add a clarifying word like 'literally 😭' for sad moments or 'no literally I am crying laughing 😭' for the slang version so the meaning is unambiguous.",
+    "faqs": [
+      {
+        "question": "Does 😭 mean laughing or sad?",
+        "answer": "😭 usually means laughing hard on TikTok, Twitter, and Instagram — it is Gen Z shorthand for 'I am dead from laughing.' On older-skewing platforms and family chats it tilts back toward literal crying."
+      },
+      {
+        "question": "What does 😭 mean from a girl?",
+        "answer": "From a girl or anyone else, 😭 has the same slang/literal split it has for any sender. Context matters more than gender."
+      },
+      {
+        "question": "What does 😭 mean on Snapchat?",
+        "answer": "On Snapchat 😭 is the universal reaction to a funny Snap or a sentimental moment. The platform skews younger, so the laughter reading is the safer default."
+      },
+      {
+        "question": "What does 😭 mean from a guy?",
+        "answer": "From a guy, 😭 has the same slang/literal split it has for anyone. There is no gendered twist; context and platform drive the read."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "bro that tiktok of the dog at the wedding 😭",
+      "interpretation": "Friend sharing a wholesome video. Mirror with 😭 or a heart emoji to keep the thread moving."
+    },
+    {
+      "setting": "social",
+      "message": "the way she ended that thread 😭😭",
+      "interpretation": "Group chat appreciation of a viral post. Mirror with 😭 or quote-tweet to keep the energy going."
+    },
+    {
+      "setting": "dating",
+      "message": "wish you were here tonight 😭",
+      "interpretation": "Romantic miss-you from a partner. Mirror with 😭 or 'I miss you too' to close the loop."
+    },
+    {
+      "setting": "family",
+      "message": "Dad just discovered emojis 😭",
+      "interpretation": "Family group laughter at an older relative learning the keyboard. Mirror with 😭 or a sentence that plays along."
+    },
+    {
+      "setting": "work",
+      "message": "client just rejected the entire deck 😭",
+      "interpretation": "Sympathetic work vent. Mirror with 😭 in a tight team chat; avoid using it in a wide org channel."
+    }
+  ]
 }

--- a/src/data/emojis/melting-face.json
+++ b/src/data/emojis/melting-face.json
@@ -36,9 +36,22 @@
     }
   ],
   "platformNotes": [
-    { "platform": "TWITTER", "note": "Overwhelmed posts." },
-    { "platform": "INSTAGRAM", "note": "Crush content." },
-    { "platform": "TIKTOK", "note": "This is fine meme." }
+    {
+      "platform": "TWITTER",
+      "note": "Overwhelmed posts and 'this is fine' meme energy."
+    },
+    {
+      "platform": "INSTAGRAM",
+      "note": "Crush content and embarrassed confession captions."
+    },
+    {
+      "platform": "TIKTOK",
+      "note": "This is fine meme variations and overwhelmed confession videos."
+    },
+    {
+      "platform": "DISCORD",
+      "note": "Friend-group reaction to a relatable complaint or crush share."
+    }
   ],
   "generationalNotes": [
     { "generation": "GEN_Z", "note": "Overwhelmed mood." },
@@ -48,5 +61,58 @@
   "warnings": [],
   "relatedCombos": [],
   "seoTitle": "🫠 Melting Face Emoji Meaning - What Does 🫠 Really Mean?",
-  "seoDescription": "Learn what the melting face emoji 🫠 really means. Overwhelmed or embarrassed vibes. Complete context guide."
+  "seoDescription": "Learn what the melting face emoji 🫠 really means. Overwhelmed or embarrassed vibes. Complete context guide.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "🫠 is the 'this is fine' emoji, the melting face that signals overwhelming embarrassment, a crush-induced spiral, or the literal 'too hot' weather complaint. The visual cue — a face literally melting — is the most expressive disaster emoji in the recent Unicode set, and it has earned its place as the Gen Z shorthand for the 'I am coming undone' moment. On Twitter, TikTok, and Instagram 🫠 shows up as the signature reaction to a relatable complaint, the embarrassed crush confession, and the soft 'too hot' complaint about weather. The emoji is uniquely versatile because three different uses — overwhelm, embarrassment, and weather — all land on the same melting beat.\n\nThe emoji also doubles as the standard 'this is fine' reaction. The 'this is fine' meme of a dog in a burning room has been re-skinned with 🫠 as the visual tag for the moment the situation is actually not fine but the sender is coping. The dual reading — actual overwhelm or coping with humor — keeps 🫠 versatile without diluting the meltdown. Use 🫠 when the moment warrants the melting beat, not as a default reaction to minor stress.",
+    "howPeopleUseIt": "🫠 arrives as the relatable 'this is fine' reaction, the embarrassed crush confession, or the literal 'too hot' weather post. On Twitter it functions as the 'I am melting' reaction to an overwhelming situation. On TikTok creators paste 🫠 on relatable confession videos as the visual tag for the moment the sender comes undone. On Instagram captions the emoji lands as the signature flourish on a crush share or a meltdown confession.\n\nIn dating-app conversations 🫠 works as the flirty embarrassed reaction — 'they are so cute 🫠' or 'I cannot even 🫠' — that signals the crush is winning. The emoji also pairs naturally with 😩 for the weary sibling, with 🥲 for the bittersweet variant, and with a sentence that names what is melting so the meltdown does not feel performative.",
+    "whenNotToUse": "Skip 🫠 in contexts where the meltdown reading will land wrong — in serious professional feedback, in customer complaint threads, or in conversations where the recipient needs sincere empathy. A 🫠 in a customer complaint reply sounds tone deaf. Avoid it in actually-genuine crises where the user needs support, not a relatable emoji.\n\nAlso avoid 🫠 when the situation is genuinely concerning and the user needs help. A friend in a real meltdown needs a sentence and a heart, not a melting-face emoji. Use the emoji for the relatable cases where the meltdown is the energy.",
+    "howToReply": "Mirror 🫠 with another 🫠 or 😩 if you want to keep the meltdown going, or upgrade to a softer reaction if the conversation warrants care. If you receive 🫠 on a crush share, reply with a heart or a sentence that engages with the crush.\n\nIf 🫠 arrives as a relatable complaint, mirror with a sentence that shares the same overwhelm. And if you want to send 🫠 as a flirty embarrassed reaction, anchor the emoji with a sentence that names what was so melting so the meltdown does not feel performative.",
+    "faqs": [
+      {
+        "question": "What does 🫠 mean in texting?",
+        "answer": "🫠 means 'I am melting' or 'this is fine.' The melting-face emoji signals overwhelm, embarrassment, or crush-induced meltdown, and reads as either relatable drama or genuine distress."
+      },
+      {
+        "question": "What does 🫠 mean from a girl?",
+        "answer": "From a girl or anyone else, 🫠 means the sender is overwhelmed or melting. There is no gendered meaning; the emoji is about the meltdown, not who is sending it."
+      },
+      {
+        "question": "Is 🫠 flirty?",
+        "answer": "🫠 can read as flirty in a dating context, especially paired with a crush confession. In other contexts it stays in the overwhelmed or embarrassed zone."
+      },
+      {
+        "question": "What does 🫠 mean from a guy?",
+        "answer": "From a guy, 🫠 has the same meaning it has from anyone else: overwhelm or melting. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "i am at my limit 🫠",
+      "interpretation": "Friend overwhelmed complaint. Mirror with 🫠 or a sentence that engages with the stress."
+    },
+    {
+      "setting": "social",
+      "message": "this is fine 🫠",
+      "interpretation": "Public 'everything is fine' reaction. Mirror with 🫠 or a sentence that adds to the bit."
+    },
+    {
+      "setting": "dating",
+      "message": "they are so cute 🫠",
+      "interpretation": "Romantic crush confession. Mirror with a heart or a sentence that engages with the crush."
+    },
+    {
+      "setting": "family",
+      "message": "it's 100 degrees out here 🫠",
+      "interpretation": "Family weather complaint. Mirror with 🫠 or a sentence that joins the complaint."
+    },
+    {
+      "setting": "work",
+      "message": "the deadline is tomorrow 🫠",
+      "interpretation": "Team stress in a tight channel. Mirror with a softer reaction or a sentence that addresses the pressure."
+    }
+  ]
 }

--- a/src/data/emojis/nail-polish.json
+++ b/src/data/emojis/nail-polish.json
@@ -38,15 +38,19 @@
   "platformNotes": [
     {
       "platform": "TWITTER",
-      "note": "Sassy and unbothered attitude."
+      "note": "Sassy and unbothered attitude on drama denials."
     },
     {
       "platform": "INSTAGRAM",
-      "note": "Beauty and self-care."
+      "note": "Beauty and self-care moments on stories."
     },
     {
       "platform": "TIKTOK",
-      "note": "Iconic sassy moments."
+      "note": "Iconic sassy moments and unbothered-comments reactions."
+    },
+    {
+      "platform": "DISCORD",
+      "note": "Friend-group reaction to a 'do not know her' moment."
     }
   ],
   "generationalNotes": [
@@ -64,7 +68,7 @@
     }
   ],
   "warnings": [],
-  "relatedCombos": [],
+  "relatedCombos": ["nail-polish-sparkles", "nail-unbothered"],
   "seoTitle": "💅 Nail Polish Emoji Meaning",
   "seoDescription": "Learn what the Nail Polish emoji 💅 really means.",
   "skinToneVariations": [
@@ -73,5 +77,58 @@
     "nail-polish-medium",
     "nail-polish-medium-dark",
     "nail-polish-dark"
+  ],
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "💅 is the unbothered-queen emoji, the nail-polish hand that signals sassy confidence, self-care, or 'I am too fabulous to be involved' energy. The visual cue — a hand with painted nails — has come to mean so much more than the literal manicure because the emoji has been adopted as the universal Gen Z / millennial shorthand for confident indifference. On Twitter, Instagram, and TikTok 💅 shows up as the sassy reaction to a drama post, the self-care closer on a glow-up share, and the 'do not know her' marker on a public statement. The dual reading — actual manicure or unbothered sass — keeps the emoji versatile without diluting the queen energy.\n\nThe emoji also doubles as the literal manicure reaction. A friend shares a nail-fresh post and the appropriate reply is 💅 — the visual tag for 'the nails are fire.' Compared to the related combo 💅✨ (nail-polish-sparkles), 💅 alone sits more in the unbothered confident zone and less in the sparkle-aesthetic zone. Use 💅 when the moment calls for the sassy confidence signal, not as a default reaction to every nice moment.",
+    "howPeopleUseIt": "💅 arrives as the sassy reaction to a drama post, the self-care closer on a glow-up share, or the punchline on a 'do not know her' moment. On Twitter it functions as the unbothered commenter reaction to a public mess. On Instagram captions the emoji lands as the signature flourish on a self-care post or a manicure reveal. On TikTok creators paste 💅 on GRWM and confidence edits as the visual tag for the moment the unbothered energy lands.\n\nIn group chats 💅 works as the shared 'I am too fabulous' reaction when a friend shares drama. The emoji also pairs naturally with ✨ for the sparkle-sibling stack, with 👑 for the queen-emphasis, and with a sentence that names what is being unbothered about so the sass does not feel performative.",
+    "whenNotToUse": "Skip 💅 in contexts where the sassy confidence would feel mismatched — in friendly conversations where warmth is needed, in serious professional channels, or in customer complaint replies. A 💅 in a customer complaint thread will read as tone deaf. Avoid it in moments where the recipient actually needs empathy or support.\n\nAlso avoid 💅 when the sass is not actually warranted. A 💅 on a friend's small win reads as dismissive. Reserve the emoji for moments where the unbothered energy genuinely matches the situation.",
+    "howToReply": "Mirror 💅 with another 💅 or 💅✨ if you want to keep the queen energy going, or upgrade to 👑 for the royal-emphasis. If you receive 💅 on a glow-up post, reply with a soft heart or a sentence that acknowledges the shift.\n\nIf 💅 arrives as a drama reaction, mirror with a sentence that engages with the actual observation. And if you want to send 💅 as a self-affirmation, anchor the emoji with a sentence that names what specifically is being celebrated so the sass does not feel performative.",
+    "faqs": [
+      {
+        "question": "What does 💅 mean in texting?",
+        "answer": "💅 means 'I am too fabulous to be bothered' or 'unbothered queen energy.' The nail-polish emoji signals confident indifference and sassy self-assurance, and reads as either literal manicure or unbothered attitude."
+      },
+      {
+        "question": "What does 💅 mean from a girl?",
+        "answer": "From a girl or anyone else, 💅 means the sender is feeling unbothered or sassy. There is no gendered meaning; the emoji is about the confidence, not who is sending it."
+      },
+      {
+        "question": "Is 💅 flirty?",
+        "answer": "💅 is not flirty. It marks confident indifference or self-care, with no romantic undercurrent. Using it on a romantic post will read as supportive rather than flirtatious."
+      },
+      {
+        "question": "What does 💅 mean from a guy?",
+        "answer": "From a guy, 💅 has the same meaning it has from anyone else: unbothered sass or self-care. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "drama? don't know her 💅",
+      "interpretation": "Friend unbothered reaction. Mirror with 💅 or a sentence that engages with the nonchalance."
+    },
+    {
+      "setting": "social",
+      "message": "fresh manicure 💅",
+      "interpretation": "Public manicure share. Mirror with 💅 or a heart to engage with the nails."
+    },
+    {
+      "setting": "dating",
+      "message": "they tried it 💅",
+      "interpretation": "Partner's unbothered reaction. Mirror with 💅 or a sentence that engages with the situation."
+    },
+    {
+      "setting": "family",
+      "message": "self-care day 💅",
+      "interpretation": "Family sharing a self-care moment. Mirror with a heart or a sentence that engages with the day."
+    },
+    {
+      "setting": "work",
+      "message": "the meeting could not hold me 💅",
+      "interpretation": "Risky in a wide team channel; safe in a tight collaborator DM. If used in a team channel, anchor with a sentence that adds context."
+    }
   ]
 }

--- a/src/data/emojis/ok-hand.json
+++ b/src/data/emojis/ok-hand.json
@@ -38,15 +38,19 @@
   "platformNotes": [
     {
       "platform": "SLACK",
-      "note": "Common for acknowledging messages or tasks."
+      "note": "Common for acknowledging messages and confirming tasks."
     },
     {
       "platform": "INSTAGRAM",
-      "note": "Used for 'perfect' or 'chef's kiss' moments."
+      "note": "Used for 'perfect' or 'chef's kiss' moments on food content."
     },
     {
       "platform": "TWITTER",
-      "note": "Generally positive usage for approval."
+      "note": "Generally positive usage for approval and approval reactions."
+    },
+    {
+      "platform": "WHATSAPP",
+      "note": "Standard approval reaction between friends and family."
     }
   ],
   "generationalNotes": [
@@ -79,5 +83,58 @@
     "ok-hand-medium",
     "ok-hand-medium-dark",
     "ok-hand-dark"
+  ],
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "👌 is the universal OK sign emoji, the thumb-and-index-finger-circle that signals 'perfect,' 'all good,' or the chef's-kiss moment. The hand gesture has carried the OK meaning for so long that the emoji lands with the same simplicity in most contexts. On Slack, Instagram, and Twitter 👌 shows up as the standard approval reaction to a job well done, the chef's-kiss closer on a perfect meal, and the soft 'sounds good' confirmation in a friend group. The emoji is one of the cleanest approval signals on the keyboard because the meaning is mostly unambiguous.\n\nThe emoji also doubles as the chef's-kiss reaction. A friend shares a perfect-looking meal and the appropriate reply is 👌 — the visual tag for 'this is just right.' The dual reading — approval or chef's-kiss — keeps 👌 versatile without diluting the positive beat. Use 👌 when the moment calls for the OK or perfect signal, being mindful of the cultural context where the gesture has been co-opted with different meanings.",
+    "howPeopleUseIt": "👌 arrives as the approval reaction to a friend's job well done, the chef's-kiss closer on a perfect meal, or the punchline on a 'sounds good' confirmation. On Slack the emoji lands as the standard acknowledgment reaction to a completed task. On Instagram it functions as the chef's-kiss reaction to a perfect food post. On Twitter the same pattern repeats in quote-tweets as the approval confirmation.\n\nIn group chats 👌 works as the shared 'all good' reaction when a friend proposes a plan. The emoji also pairs naturally with 🤌 for the chef's-kiss stack, with 🔥 for the hyped approval, and with a sentence that names what is being approved so the OK does not feel generic.",
+    "whenNotToUse": "Skip 👌 in contexts where the OK reading will land wrong — in certain cultural contexts where the gesture has been reclaimed with a different meaning, in serious professional feedback where the casual OK is underweighted, or in customer complaint replies where the approval is misplaced. A 👌 in a customer complaint reply will sound tone deaf. Avoid it in conversations where the recipient needs more than a casual approval.\n\nAlso avoid 👌 when the situation actually warrants a stronger approval. The OK sign is the chill version of approval, so a 👌 on a meaningful accomplishment will feel underweighted. Reach for 💯 or 🔥 for the moments that warrant weight.",
+    "howToReply": "Mirror 👌 with another 👌 or 🤌 if you want to keep the chef's-kiss vibe going, or upgrade to 🔥 for the hyped approval. If you receive 👌 on a personal win, reply with a sentence that acknowledges the moment.\n\nIf 👌 arrives as a casual approval, mirror with the same or a sentence that closes the loop. And if you want to send 👌 as a soft OK reaction, anchor the emoji with a sentence that names what is being approved so the OK does not feel generic.",
+    "faqs": [
+      {
+        "question": "What does 👌 mean in texting?",
+        "answer": "👌 means 'OK' or 'perfect.' The OK hand emoji is the universal approval signal and reads as either genuine acceptance or chef's-kiss perfection depending on context."
+      },
+      {
+        "question": "What does 👌 mean from a girl?",
+        "answer": "From a girl or anyone else, 👌 means the sender is approving or signaling perfection. There is no gendered meaning; the emoji is about the approval, not who is sending it."
+      },
+      {
+        "question": "Is 👌 flirty?",
+        "answer": "👌 is not flirty. It marks approval or perfection, with no romantic undercurrent. Using it on a romantic post will read as supportive rather than flirtatious."
+      },
+      {
+        "question": "What does 👌 mean from a guy?",
+        "answer": "From a guy, 👌 has the same meaning it has from anyone else: approval or OK. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "this pad thai 👌",
+      "interpretation": "Friend's chef's-kiss reaction. Mirror with 👌 or a sentence that engages with the meal."
+    },
+    {
+      "setting": "work",
+      "message": "sounds good 👌",
+      "interpretation": "Team approval in a tight channel. Mirror with 👌 or a sentence that acknowledges the plan."
+    },
+    {
+      "setting": "social",
+      "message": "that sunset 👌",
+      "interpretation": "Public chef's-kiss reaction. Mirror with 👌 or a sentence that engages with the look."
+    },
+    {
+      "setting": "family",
+      "message": "looks great mom 👌",
+      "interpretation": "Family approval. Mirror with 🤌 or a sentence that engages with the work."
+    },
+    {
+      "setting": "dating",
+      "message": "perfect date night 👌",
+      "interpretation": "Romantic partner's approval. Mirror with a heart or a sentence that engages with the date."
+    }
   ]
 }

--- a/src/data/emojis/party-popper.json
+++ b/src/data/emojis/party-popper.json
@@ -31,9 +31,22 @@
     }
   ],
   "platformNotes": [
-    { "platform": "TWITTER", "note": "Common usage." },
-    { "platform": "INSTAGRAM", "note": "Popular posts." },
-    { "platform": "TIKTOK", "note": "Trending." }
+    {
+      "platform": "TWITTER",
+      "note": "Twitter replies use 🎉 as the default 'congratulations on the win' reaction, especially for launches, releases, and personal milestones."
+    },
+    {
+      "platform": "INSTAGRAM",
+      "note": "Instagram story reposts and shoutouts lean on 🎉 as the celebratory default; the emoji arrives on captions for birthdays and engagements."
+    },
+    {
+      "platform": "TIKTOK",
+      "note": "TikTok creators stack 🎉 in milestone captions and fan-edit shoutouts; viewers spam it under big announcements."
+    },
+    {
+      "platform": "SLACK",
+      "note": "Slack treats 🎉 as the channel-wide celebration emoji; it is the cleanest way to mark a launch or team win without typing a sentence."
+    }
   ],
   "generationalNotes": [
     { "generation": "GEN_Z", "note": "Gen Z usage." },
@@ -43,5 +56,58 @@
   "warnings": [],
   "relatedCombos": [],
   "seoTitle": "🎉 Party Popper Emoji Meaning",
-  "seoDescription": "Learn what the Party Popper emoji 🎉 really means."
+  "seoDescription": "Learn what the Party Popper emoji 🎉 really means.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "🎉 is the universal celebration emoji, the one that arrives when something genuinely good happens — a job offer, a relationship milestone, a launch, a personal win, or any moment that warrants confetti. On Twitter, Instagram, and TikTok 🎉 functions as the default 'congratulations' reaction; on Slack it is the channel-wide celebration marker; in personal iMessage threads it is the emoji you send when a friend finally does the thing they have been working toward. The emoji carries no slang baggage, no generational drift, and no ironic overlay by default — it is one of the cleanest positive signals in the keyboard.\n\n🎉 also works as a milestone marker. Birthday posts, New Year's messages, engagement announcements, and graduation stories all default to 🎉 as the celebratory punctuation mark. The emoji rarely needs a sentence alongside it — a stand-alone 🎉 or a '🎉🎉🎉' stack says everything the moment needs. Writers should treat 🎉 as the cleanest positive reaction on the keyboard and reserve it for moments that genuinely warrant confetti, because overuse dilutes the impact.",
+    "howPeopleUseIt": "🎉 shows up as a stand-alone reaction, a sentence closer on a congratulatory message, or as a stack (🎉🎉🎉) when the moment is genuinely huge. It is the default reply to a friend's good news — a new job, an engagement, a personal record, a launch. The emoji also marks personal milestones in bios and captions; creators write 'new music friday 🎉' as the celebratory closer to a release announcement.\n\nIn Slack 🎉 functions as the channel-wide celebration emoji that HR and managers use to acknowledge team wins. The same pattern shows up in Discord for server milestones. And in dating-app conversations 🎉 arrives when a partner shares good news — 'got the promotion 🎉' is a moment that earns the confetti emoji as a reply.",
+    "whenNotToUse": "Skip 🎉 in any context where celebration is inappropriate — condolence threads, bad-news announcements, or serious professional channels where the confetti feels mismatched. A 🎉 in a status update about a missed deadline reads as tone deaf. And avoid it in customer complaint replies where the customer needs empathy, not celebration.\n\nAlso avoid stacking 🎉 on minor moments. A friend shares a normal lunch photo and you reply with 🎉🎉🎉 — the confetti stops feeling celebratory and starts feeling performative. Match the emoji stack to the magnitude of the moment.",
+    "howToReply": "Mirror 🎉 with another 🎉 if you want to keep the celebration going, or upgrade to 🙌 or 🥳 for even more enthusiasm. If you receive 🎉 on your own post, treat it as a warm congratulations and reply with a short 'thanks 🎉' or a sentence about the win.\n\nIf 🎉 arrives on a friend's milestone, lean into the celebration. A sentence like 'so happy for you 🎉' or a follow-up question about the moment keeps the thread moving. And if you want to add a heart, 🎉❤️ reads as warm congratulations with affection.",
+    "faqs": [
+      {
+        "question": "What does 🎉 mean in texting?",
+        "answer": "🎉 means 'congratulations' or 'celebration.' It is the default emoji for wins, milestones, and personal good news across all platforms."
+      },
+      {
+        "question": "What does 🎉 mean from a girl?",
+        "answer": "From a girl or anyone else, 🎉 means the sender is celebrating with you. There is no gendered meaning; the emoji is about the moment, not who is sending it."
+      },
+      {
+        "question": "What does 🎉 mean on Slack?",
+        "answer": "On Slack 🎉 is the channel-wide celebration emoji that HR, managers, and teammates use to acknowledge launches, milestones, and team wins."
+      },
+      {
+        "question": "What does 🎉 mean from a guy?",
+        "answer": "From a guy, 🎉 has the same meaning it has from anyone else: celebration or congratulations. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "she said yes 🎉",
+      "interpretation": "Friend announcing an engagement. Mirror with 🎉 or 'congratulations' to acknowledge the milestone."
+    },
+    {
+      "setting": "work",
+      "message": "we shipped v2 🎉",
+      "interpretation": "Team celebration of a launch. Mirror with 🎉 or 'great work' in the channel to acknowledge the team."
+    },
+    {
+      "setting": "family",
+      "message": "i got into college 🎉",
+      "interpretation": "Family milestone announcement. Mirror with 🎉 or 'so proud' to keep the celebration going."
+    },
+    {
+      "setting": "dating",
+      "message": "got the promotion 🎉",
+      "interpretation": "Romantic partner sharing a career win. Mirror with 🎉 or a follow-up sentence about the celebration."
+    },
+    {
+      "setting": "social",
+      "message": "new music friday 🎉",
+      "interpretation": "Creator release announcement. Reply with 🎉 or a sentence about the new track to engage."
+    }
+  ]
 }

--- a/src/data/emojis/pleading.json
+++ b/src/data/emojis/pleading.json
@@ -38,15 +38,19 @@
   "platformNotes": [
     {
       "platform": "TIKTOK",
-      "note": "Extremely popular for expressing anything cute or wholesome."
+      "note": "TikTok comments and captions over-index on 🥺 for soft launch announcements, wholesome pet content, and emotionally loaded fan edits."
     },
     {
       "platform": "TWITTER",
-      "note": "Used for soft moments, begging, or expressing vulnerability."
+      "note": "Twitter threads use 🥺 as a soft-loud signal — saying 'I'm begging' without sounding aggressive, often paired with a plea or a confession."
+    },
+    {
+      "platform": "INSTAGRAM",
+      "note": "Instagram story replies with 🥺 read as the most affectionate engagement emoji; creators save it for genuine appreciation rather than routine replies."
     },
     {
       "platform": "IMESSAGE",
-      "note": "Common between close friends and romantic partners."
+      "note": "iMessage uses 🥺 between close friends and romantic partners; it reads as intimate and vulnerable, so it lands oddly in casual group chats."
     }
   ],
   "generationalNotes": [
@@ -66,5 +70,58 @@
   "warnings": [],
   "relatedCombos": ["pleading-hearts"],
   "seoTitle": "🥺 Pleading Face Emoji Meaning - What Does 🥺 Really Mean?",
-  "seoDescription": "Learn what the pleading emoji 🥺 really means in modern texting. The puppy eyes emoji for begging or expressing cuteness. Complete context guide."
+  "seoDescription": "Learn what the pleading emoji 🥺 really means in modern texting. The puppy eyes emoji for begging or expressing cuteness. Complete context guide.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "The 🥺 pleading face is one of the most expressive emojis on the keyboard, designed to look exactly like a puppy asking for a treat — large shiny eyes, raised eyebrows, and a small mouth that softens whatever the sender says next. It was added to Unicode in 2018 and immediately became a Gen Z staple because it does emotional work that no sentence can. Where 😢 reads as sad and 🙄 reads as annoyed, 🥺 reads as vulnerable, soft, and genuinely trying to convince you of something. It is the emoji you send when you want to be cute, when you are begging for a favor, or when something moved you so much you cannot form real words.\n\nThe power of 🥺 is that it inverts the typical posture of digital communication. Most emojis add confidence or sarcasm to a message; 🥺 does the opposite and removes armor. That makes it hugely effective in dating-app openers, in group chats where someone wants to soften a request, and in fan communities where the sender wants to signal that they are at your mercy. The risk is overuse — once 🥺 becomes the default closer for every message it loses its punch, and the recipient may start reading it as performative. Writers should reserve 🥺 for moments that genuinely deserve the softener.",
+    "howPeopleUseIt": "🥺 arrives as the closer on a sentence that asks for something — 'one more slice? 🥺' — or as a stand-alone reaction to something adorable. It works as a 'puppy eyes' emoji you send when a sentence alone would sound too forward, like asking a partner for a favor, a friend to come out, or a parent for permission. It is also the standard fan-creator emoji: a TikTok creator drops a teaser and the comments fill with 🥺 as the audience performs excitement without typing a paragraph.\n\nIn dating-app conversations 🥺 is the standard softener on a flirty line. 'I wish you were here 🥺' reads as vulnerable rather than demanding, and the emoji softens the rest of the sentence so the ask lands as cute instead of intense. In family WhatsApp groups 🥺 works the same way — 'Grandma can I have seconds 🥺' registers as charming rather than pushy. The emoji pairs naturally with heart emojis (🥺❤️) for maximum vulnerability and with ✨ for added sparkle.",
+    "whenNotToUse": "Skip 🥺 in any context where vulnerability reads as inappropriate — in work emails, in client-facing support, or in threads where you need to project competence. The emoji in a B2B request will read as unprofessional and may undercut the seriousness of the ask. Avoid it in customer complaint replies where the customer needs confidence that their issue is being taken seriously.\n\nAlso avoid stacking 🥺 on critical feedback. A manager who replies 'your work needs improvement 🥺' sounds as if they are apologizing for the critique rather than delivering it. The emoji softens whatever comes before it, so it works against clear boundaries. And in family or relationship conversations, sending 🥺 too often can start to read as a manipulation tactic rather than genuine vulnerability — balance the softener with words that show you are capable of asking without leaning on the emoji.",
+    "howToReply": "If someone sends you 🥺 and you want to give in, mirror the energy with another 🥺 or with a sentence that grants the ask warmly ('okay fine, you win 🥺'). If you want to resist but still keep the bit going, reply with a softener like 😅 or 'nice try' so the conversation stays playful without giving up your position.\n\nIf 🥺 lands on something you shared — a photo, a story, a creative project — treat it as genuine appreciation. A simple 'thank you 🥺' closes the loop without sounding performative. And if you are not sure whether the 🥺 is sincere or joking, glance at the surrounding sentence; sincere 🥺 usually pairs with a concrete request or a confession, while ironic 🥺 pairs with absurd demands like 'give me your dog 🥺'.",
+    "faqs": [
+      {
+        "question": "What does 🥺 mean from a girl?",
+        "answer": "From a girl or anyone else, 🥺 means 'please' or 'I'm being cute on purpose.' It can read as flirty in a dating context or affectionate in a friendship, but it is not gendered."
+      },
+      {
+        "question": "Is 🥺 flirty?",
+        "answer": "🥺 can read as flirty when paired with romantic content ('miss you 🥺'). In other contexts it is simply a softener that signals vulnerability or a request."
+      },
+      {
+        "question": "What does 🥺 mean on TikTok?",
+        "answer": "On TikTok 🥺 is the standard emoji for soft launches, fan edits, and emotionally loaded content. Creators use it in captions and viewers use it in comments to react to cute or vulnerable moments."
+      },
+      {
+        "question": "What does 🥺 mean from a guy?",
+        "answer": "From a guy, 🥺 has the same meaning it has from anyone else: vulnerability, begging, or cuteness. There is no gendered twist; the emoji is about the softness of the moment, not who is sending it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "dating",
+      "message": "i wish you were still here 🥺",
+      "interpretation": "Vulnerable miss-you line from a partner. Mirror with another 🥺 or a sentence about missing them back."
+    },
+    {
+      "setting": "friends",
+      "message": "come to the party 🥺 please",
+      "interpretation": "Friend begging you to show up. Mirror with 🥺 to give in, or 'nice try' to keep the bit going."
+    },
+    {
+      "setting": "family",
+      "message": "grandma can i have seconds 🥺",
+      "interpretation": "Family-table cute begging. Mirror with a serving emoji or 'of course' to grant the ask."
+    },
+    {
+      "setting": "social",
+      "message": "did you see what she just posted 🥺",
+      "interpretation": "Group chat appreciation of a friend's content. Reply with another 🥺 or 'iconic' to keep the thread moving."
+    },
+    {
+      "setting": "work",
+      "message": "could you approve my PR before lunch 🥺",
+      "interpretation": "Risky in a wide team channel; safe in a tight collaborator DM. If used, add a sentence that anchors the professional context."
+    }
+  ]
 }

--- a/src/data/emojis/raising-hands.json
+++ b/src/data/emojis/raising-hands.json
@@ -38,15 +38,19 @@
   "platformNotes": [
     {
       "platform": "SLACK",
-      "note": "Very common for celebrating team achievements."
+      "note": "The standard celebration reaction in team wins and shipped-feature announcements."
     },
     {
       "platform": "TWITTER",
-      "note": "Used for enthusiastic agreement or celebration."
+      "note": "Used for enthusiastic agreement, hallelujah posts, and hype reactions."
     },
     {
       "platform": "INSTAGRAM",
-      "note": "Common in celebratory posts and comments."
+      "note": "Common in celebratory captions and milestone announcements."
+    },
+    {
+      "platform": "DISCORD",
+      "note": "Server admins paste it on big announcements as the celebration marker."
     }
   ],
   "generationalNotes": [
@@ -73,5 +77,58 @@
     "raising-hands-medium",
     "raising-hands-medium-dark",
     "raising-hands-dark"
+  ],
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "🙌 is the universal celebration emoji, the two hands raised in triumph that lands as the visual 'hallelujah' for any moment worth cheering. On Slack, Teams, and Discord 🙌 shows up as the standard team-win reaction — the closer on a shipped feature, the visual tag for a milestone achieved, the celebration marker on a company-wide announcement. On Twitter and Instagram the emoji functions as the personal victory closer on a goal reached, a Friday afternoon, or a major life update. The visual cue is unmistakable: hands thrown up means it's time to celebrate.\n\nThe emoji also carries a softer hallelujah / praise reading. Religious-adjacent contexts use 🙌 as the visual shorthand for 'praise be' or 'thank God,' and the dual reading — secular celebration or spiritual praise — keeps it versatile. Reserve 🙌 for the moments that genuinely warrant the celebration, because the emoji is loud and overusing it begins to undercut the rare triumph beat.",
+    "howPeopleUseIt": "🙌 arrives as the team-channel reaction to a shipped feature, the personal-caption closer on a milestone, or the punchline on a 'finally Friday' moment. On Slack the emoji lands as the celebration marker in product-launch threads and team-win announcements. On Instagram captions 🙌 shows up on engagement posts, job announcements, and milestone celebrations as the signature flourish.\n\nIn family group chats 🙌 doubles as the celebration emoji for a graduation, a new baby, or a big move. The emoji pairs naturally with 🎉 for party energy, with 🏆 for the win, and with a sentence that names what is being celebrated. Stand-alone 🙌 reads as celebration; in a stack it leans performative.",
+    "whenNotToUse": "Skip 🙌 in contexts where the celebration would feel mismatched — in serious professional channels, in customer complaint threads, or in condolences. A 🙌 in a customer complaint reply will read as tone deaf. Avoid it in discussions about grief or loss; the celebration energy will not land where empathy is needed.\n\nAlso avoid 🙌 when the achievement is too minor to warrant the celebration. A 🙌 for remembering to take a lunch break reads as sarcastic, and the irony note may not land in mixed channels. Match the emoji to the actual weight of the moment.",
+    "howToReply": "Mirror 🙌 with another 🙌 or 🎉 if you want to keep the celebration going, or upgrade to 🏆 for the elite-win emphasis. If you receive 🙌 on a personal milestone, reply with 'thanks 🙌' or a sentence that acknowledges the celebration.\n\nIf 🙌 arrives as a team win, mirror with a sentence that names the specific work that earned the celebration. And if you want to send 🙌 as a praise / hallelujah moment, anchor the emoji with a sentence that lands the spiritual reading so the celebration does not feel performative.",
+    "faqs": [
+      {
+        "question": "What does 🙌 mean in texting?",
+        "answer": "🙌 means 'celebration' or 'hallelujah.' The two raised hands are the universal visual tag for triumph, and the emoji reads as either personal celebration or team win depending on context."
+      },
+      {
+        "question": "What does 🙌 mean from a girl?",
+        "answer": "From a girl or anyone else, 🙌 means the sender is celebrating something. There is no gendered meaning; the emoji is about the triumph, not who is sending it."
+      },
+      {
+        "question": "Is 🙌 flirty?",
+        "answer": "No, 🙌 is not flirty. It marks celebration or praise, with no romantic undercurrent. Using it on a romantic post will read as supportive rather than flirtatious."
+      },
+      {
+        "question": "What does 🙌 mean from a guy?",
+        "answer": "From a guy, 🙌 has the same meaning it has from anyone else: celebration or strong approval. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "work",
+      "message": "shipped it 🙌",
+      "interpretation": "Team win in a tight channel. Mirror with 🙌 or 🎉 to match the celebration."
+    },
+    {
+      "setting": "friends",
+      "message": "she said yes 🙌",
+      "interpretation": "Friend announcing a milestone. Mirror with 🙌 or 'congratulations' to celebrate the moment."
+    },
+    {
+      "setting": "family",
+      "message": "graduated 🙌",
+      "interpretation": "Family sharing a milestone. Mirror with 🙌 or 'so proud' to acknowledge the moment."
+    },
+    {
+      "setting": "dating",
+      "message": "we made it to the weekend 🙌",
+      "interpretation": "Romantic partner's playful closer. Mirror with 🙌 or a heart to engage with the energy."
+    },
+    {
+      "setting": "social",
+      "message": "FRIDAY 🙌",
+      "interpretation": "Public celebration of the weekend. Mirror with 🙌 or a sentence that joins the relief."
+    }
   ]
 }

--- a/src/data/emojis/red-flag.json
+++ b/src/data/emojis/red-flag.json
@@ -38,7 +38,7 @@
   "platformNotes": [
     {
       "platform": "TWITTER",
-      "note": "The 'red flag' meme format - listing problematic traits."
+      "note": "The 'red flag' meme format listing problematic traits."
     },
     {
       "platform": "TIKTOK",
@@ -47,6 +47,10 @@
     {
       "platform": "INSTAGRAM",
       "note": "Used in relationship memes and advice content."
+    },
+    {
+      "platform": "DISCORD",
+      "note": "Server members paste it as the standard 'red flag' reaction on concerning shares."
     }
   ],
   "generationalNotes": [
@@ -56,7 +60,7 @@
     },
     {
       "generation": "MILLENNIAL",
-      "note": "Same usage - warning signs in dating/life."
+      "note": "Same usage; warning signs in dating/life."
     },
     {
       "generation": "BOOMER",
@@ -64,7 +68,60 @@
     }
   ],
   "warnings": [],
-  "relatedCombos": ["red-flags-dating"],
+  "relatedCombos": ["red-flags-dating", "red-flag-running"],
   "seoTitle": "🚩 Red Flag Emoji Meaning - What Does 🚩 Really Mean?",
-  "seoDescription": "Learn what the red flag emoji 🚩 really means in modern texting. Warning sign for problematic behavior in dating and life. Complete context guide."
+  "seoDescription": "Learn what the red flag emoji 🚩 really means in modern texting. Warning sign for problematic behavior in dating and life. Complete context guide.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "🚩 is the red flag emoji, the triangular flag on a pole that signals 'this is a warning sign' in dating, life, or any situation where problematic patterns are worth flagging. The red flag has become so central to Gen Z dating language that the emoji has stretched far past its literal beach-marker roots into the universal warning shorthand. On Twitter, TikTok, and Instagram 🚩 shows up on dating-profile roasts, warning-behaviour callouts, and any moment the sender wants to mark the situation as concerning. The emoji is one of the most semantically loaded on the keyboard because the meaning lives entirely in the slang reading.\n\nThe emoji also doubles as the ironic-warning reaction. A friend shares a small quirky trait and the appropriate reply is 🚩 — the visual tag for 'I am jokingly flagging this.' The dual reading — genuine warning or ironic-flag — keeps 🚩 versatile without diluting the warning beat. Use 🚩 when the moment genuinely calls for the warning signal, being mindful of how the irony note may land in mixed contexts.",
+    "howPeopleUseIt": "🚩 arrives as the comment on a dating profile screenshot, the reaction to a bad interview story, or the punchline on a friend's questionable life choice. On Twitter it functions as the standard reaction to a public statement that contains a warning sign. On TikTok creators paste 🚩 on dating-roast videos as the visual tag for the warning. In group chats the emoji works as the shared 'this is a problem' reaction when a friend shares a story that needs cataloging.\n\nThe emoji also pairs naturally with 🚩🚩🚩 for the multi-flag stack, with a sentence that names the specific flag, and with the matching single-flag companion. Stand-alone 🚩 reads as warning; in a longer stack it leans dramatic.",
+    "whenNotToUse": "Skip 🚩 in contexts where the warning will land wrong — when the recipient is actually going through a hard time, in serious professional feedback, or in conversations whose stakes do not warrant the alarm. A 🚩 on a coworker's first-draft deck will read as hostile. Avoid it on a friend's vulnerable post; the warning will land wrong.\n\nAlso avoid 🚩 when the situation is genuinely concerning and the recipient needs actual support. A friend in a bad relationship needs empathy and a conversation, not a flag emoji. Use the emoji for the casual-warning cases where the joke lands safely.",
+    "howToReply": "Mirror 🚩 with another 🚩 if you want to keep the warning energy going, or upgrade to a sentence that adds a specific concern. If you receive 🚩 on a story you shared, treat it as a signal that the recipient saw something you may not have noticed and consider whether to engage with the warning.\n\nIf 🚩 arrives on a friend's questionable choice, mirror with a sentence that names the specific flag you noticed. And if you want to send 🚩 as a meta-reaction to a public failure, anchor the emoji with a sentence that names what was so warning-worthy so the flag does not feel performative.",
+    "faqs": [
+      {
+        "question": "What does 🚩 mean in texting?",
+        "answer": "🚩 means 'this is a warning sign.' The red flag emoji signals problematic behavior or concerning patterns, and reads as either genuine dating warning or ironic-flag depending on context."
+      },
+      {
+        "question": "Is 🚩 rude?",
+        "answer": "🚩 can read as judgmental, especially in personal or vulnerable contexts. Use it carefully when the recipient may not be in on the joke, since the warning signal can land wrong."
+      },
+      {
+        "question": "What does 🚩 mean from a girl?",
+        "answer": "From a girl or anyone else, 🚩 means the sender sees warning signs. There is no gendered meaning; the emoji is about the concern, not who is sending it."
+      },
+      {
+        "question": "What does 🚩 mean on TikTok?",
+        "answer": "On TikTok 🚩 in the comments means the viewer thinks the content is full of warning signs. The single flag signals a single concern; the multi-flag stack signals catalog-level concern."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "dating",
+      "message": "their dating profile 🚩",
+      "interpretation": "Friend reacting to a questionable profile. Mirror with 🚩 or a sentence that adds to the roast."
+    },
+    {
+      "setting": "social",
+      "message": "the interview was 🚩",
+      "interpretation": "Public reaction to a bad interview. Mirror with 🚩 or a sentence that engages with the moment."
+    },
+    {
+      "setting": "friends",
+      "message": "he said he is 'not like other guys' 🚩",
+      "interpretation": "Friend flagging a dating warning. Mirror with 🚩 or a sentence that engages with the red flag."
+    },
+    {
+      "setting": "work",
+      "message": "the job posting has 🚩",
+      "interpretation": "Risky in a wide team channel. Anchor with a sentence that names the specific concern."
+    },
+    {
+      "setting": "family",
+      "message": "her new boyfriend 🚩",
+      "interpretation": "Family sharing concern. Mirror with a sentence that engages with the specific concern."
+    }
+  ]
 }

--- a/src/data/emojis/rocket.json
+++ b/src/data/emojis/rocket.json
@@ -8,40 +8,120 @@
   "subcategory": "transport-air",
   "unicodeVersion": "6.0",
   "baseMeaning": "Rocket emoji.",
-  "tldr": "Rocket!",
+  "tldr": "To the moon — launch, growth, or stock hype.",
   "contextMeanings": [
     {
       "context": "LITERAL",
-      "meaning": "Represents Rocket.",
-      "example": "Look at this 🚀",
+      "meaning": "A rocket ship taking off.",
+      "example": "Blastoff 🚀",
       "riskLevel": "LOW"
     },
     {
       "context": "SLANG",
-      "meaning": "Space or to the moon.",
-      "example": "Feeling 🚀",
+      "meaning": "Growth, launch, or stock-ticker hype.",
+      "example": "to the moon 🚀",
       "riskLevel": "LOW"
     },
-    { "context": "IRONIC", "meaning": "Ironic usage.", "example": "Mood 🚀", "riskLevel": "LOW" },
+    {
+      "context": "IRONIC",
+      "meaning": "Self-deprecating 'I am cooked' energy.",
+      "example": "anxiety through the roof 🚀",
+      "riskLevel": "LOW"
+    },
     {
       "context": "WORK",
-      "meaning": "Work context.",
-      "example": "Work vibes 🚀",
+      "meaning": "Launch announcement or shipping moment.",
+      "example": "Ship it 🚀",
       "riskLevel": "LOW"
     }
   ],
   "platformNotes": [
-    { "platform": "TWITTER", "note": "Common usage." },
-    { "platform": "INSTAGRAM", "note": "Popular posts." },
-    { "platform": "TIKTOK", "note": "Trending." }
+    {
+      "platform": "TWITTER",
+      "note": "Stock-ticker hype and product-launch tweets from founders."
+    },
+    {
+      "platform": "INSTAGRAM",
+      "note": "Launch announcements and growth-focused creator captions."
+    },
+    {
+      "platform": "TIKTOK",
+      "note": "Trending in launch reveals and finance-content moon posts."
+    },
+    {
+      "platform": "DISCORD",
+      "note": "Server members paste it as the launch-day hype reaction."
+    }
   ],
   "generationalNotes": [
-    { "generation": "GEN_Z", "note": "Gen Z usage." },
-    { "generation": "MILLENNIAL", "note": "Millennial usage." },
-    { "generation": "BOOMER", "note": "Boomer interpretation." }
+    {
+      "generation": "GEN_Z",
+      "note": "To the moon / launching."
+    },
+    {
+      "generation": "MILLENNIAL",
+      "note": "Startup launch energy."
+    },
+    {
+      "generation": "BOOMER",
+      "note": "Space or sci-fi reference."
+    }
   ],
   "warnings": [],
   "relatedCombos": [],
-  "seoTitle": "🚀 Rocket Emoji Meaning",
-  "seoDescription": "Learn what the Rocket emoji 🚀 really means."
+  "seoTitle": "🚀 Rocket Emoji Meaning - What Does 🚀 Really Mean?",
+  "seoDescription": "Learn what the rocket emoji 🚀 really means. Launch hype, growth, or 'to the moon' energy. Complete context guide.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "🚀 is the rocket emoji, the launching ship that signals growth, hype, or the 'to the moon' phrase. The visual cue — a rocket angled up and blasting off — has stretched far past its literal space-travel meaning because the startup and finance cultures have adopted the emoji so aggressively. On Twitter, TikTok, and Instagram 🚀 shows up as the launch-day tweet, the stock-ticker hype reaction, and the growth-focused closer on a founder's product post. The emoji is interesting because it spans three genuinely different uses — space, growth, and finance — all of which land on related upward beats.\n\nThe emoji also doubles as the universal launch-energy reaction. A friend announces a new project and the appropriate reply is 🚀 — the visual tag for 'sending it up.' The dual reading — actual space or business launch — keeps 🚀 versatile without diluting the upward beat. Use 🚀 when the moment calls for the rocket signal, not as a default reaction to every nice moment.",
+    "howPeopleUseIt": "🚀 arrives as the launch-day tweet from a founder, the stock-ticker hype reaction on a finance post, or the punchline on a friend's 'I am finally going' share. On Twitter it functions as the standard reaction to a public launch announcement. On Instagram captions the emoji lands as the signature flourish on a product reveal. On TikTok creators paste 🚀 on launch reveals as the visual tag for the moment the product ships.\n\nIn group chats 🚀 works as the shared 'to the moon' reaction when a friend shares a milestone. The emoji also pairs naturally with 💰 for the money-growth stack, with 📈 for the chart-up sibling, and with a sentence that names what is being launched so the rocket does not feel generic.",
+    "whenNotToUse": "Skip 🚀 in contexts where the launch reading will land wrong — in serious professional feedback, in customer complaint replies, or in conversations where the recipient has actually failed. A 🚀 in a customer complaint thread will sound tone deaf. Avoid it in conversations where the recipient does not want the hype.\n\nAlso avoid 🚀 when the situation actually calls for a different moment. The emoji is more coded than a heart, so a 🚀 on a friend's anxious vent may read as dismissive. Reach for a heart or a sentence of care when the moment warrants empathy.",
+    "howToReply": "Mirror 🚀 with another 🚀 or 📈 if you want to keep the launch energy going, or upgrade to 🔥 for the hype-add. If you receive 🚀 on a launch announcement, reply with a sentence that acknowledges the milestone.\n\nIf 🚀 arrives as a stock-ticker hype reaction, mirror with a sentence that engages with the market. And if you want to send 🚀 as a soft friendly reaction, anchor the emoji with a sentence that names what is being launched so the rocket does not feel performative.",
+    "faqs": [
+      {
+        "question": "What does 🚀 mean in texting?",
+        "answer": "🚀 means 'to the moon,' 'launch,' or 'growth.' The rocket emoji signals business launch, stock hype, or genuine excitement depending on context and the relationship."
+      },
+      {
+        "question": "What does 🚀 mean from a girl?",
+        "answer": "From a girl or anyone else, 🚀 means the sender is celebrating a launch or hyping growth. There is no gendered meaning; the emoji is about the moment, not who is sending it."
+      },
+      {
+        "question": "Is 🚀 flirty?",
+        "answer": "🚀 is not flirty. It marks launch or growth energy, with no romantic undercurrent. Using it on a romantic post will read as supportive rather than flirtatious."
+      },
+      {
+        "question": "What does 🚀 mean from a guy?",
+        "answer": "From a guy, 🚀 has the same meaning it has from anyone else: launch hype or growth energy. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "just launched the site 🚀",
+      "interpretation": "Friend sharing a launch. Mirror with 🚀 or a sentence that engages with the news."
+    },
+    {
+      "setting": "work",
+      "message": "ship it 🚀",
+      "interpretation": "Team launch reaction in a tight channel. Mirror with 🚀 or a sentence that acknowledges the launch."
+    },
+    {
+      "setting": "social",
+      "message": "to the moon 🚀",
+      "interpretation": "Public finance hype. Mirror with 🚀 or a sentence that engages with the market."
+    },
+    {
+      "setting": "family",
+      "message": "moving day 🚀",
+      "interpretation": "Family moving share. Mirror with 🚀 or a sentence that engages with the change."
+    },
+    {
+      "setting": "dating",
+      "message": "finally took the trip 🚀",
+      "interpretation": "Partner's milestone share. Mirror with a heart or a sentence that engages with the moment."
+    }
+  ]
 }

--- a/src/data/emojis/skull.json
+++ b/src/data/emojis/skull.json
@@ -32,11 +32,19 @@
   "platformNotes": [
     {
       "platform": "TIKTOK",
-      "note": "Very common in comments to indicate something is hilarious."
+      "note": "TikTok comment sections are flooded with single and triple 💀; creators read the emoji as live audience laughter on punchlines."
     },
     {
       "platform": "TWITTER",
-      "note": "Often used in quote tweets to express dying of laughter."
+      "note": "Quote-tweet reactions that open with a single 💀 read as exasperated approval rather than literal death; triple skulls mean the post genuinely broke them."
+    },
+    {
+      "platform": "INSTAGRAM",
+      "note": "Common in close-friend story replies; less likely in formal captions because the slang tone would undercut the message."
+    },
+    {
+      "platform": "DISCORD",
+      "note": "Frequent reaction in meme servers and group DMs; pair with screenshots rather than long captions to land the joke."
     }
   ],
   "generationalNotes": [
@@ -62,5 +70,58 @@
   ],
   "relatedCombos": ["skull-laughing"],
   "seoTitle": "💀 Skull Emoji Meaning - What Does 💀 Really Mean?",
-  "seoDescription": "Learn what the skull emoji 💀 really means in modern texting. Usually means 'I'm dead' from laughing, not actual death. Context guide for all platforms."
+  "seoDescription": "Learn what the skull emoji 💀 really means in modern texting. Usually means 'I'm dead' from laughing, not actual death. Context guide for all platforms.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "The 💀 skull emoji has drifted dramatically from its literal meaning of death, danger, or poison warnings. On TikTok, Twitter, Instagram, Discord, and iMessage it now almost always signals that the sender is 'dead' from laughter, secondhand embarrassment, or a reaction so absurd they cannot form words. The shift happened during the late 2010s as Gen Z made the crying-laughing face 😂 feel overexposed and adopted 💀 as the default marker of peak amusement. Today, sending 💀 usually means the joke landed harder than expected, the sender is cringing hard on your behalf, or they are reacting to something so wild they have nothing left to say.\n\nTreat 💀 as a vibe marker rather than a literal statement: the strength of the reaction is the point, and the recipient is expected to laugh, wince, or send a skull right back. The emoji performs a specific kind of exaggerated emotional honesty that text alone cannot convey, which is why it survives even when people worry it sounds morbid. Writers should remember that 💀 is rarely used alone in serious or professional contexts because its energy is performatively extreme; if you need to discuss actual loss or trauma, choose a different emoji entirely.",
+    "howPeopleUseIt": "In real chats, 💀 tends to arrive after a punchline, a cursed screenshot, or a piece of news that is too stupid to be real. People send a single skull to show measured appreciation and a string of three or more skulls (💀💀💀) when the moment is genuinely devastating. It pairs naturally with 😭, with a screenshot of the offending content, and with phrases like 'I cannot' or 'I'm done.' It almost never appears alone in serious or professional contexts because its energy is performatively extreme, and sending one to a customer-support inbox will read as disrespectful regardless of intent.\n\nThe skull also works as a stand-in for secondhand embarrassment. If a friend shares a story about an awkward situation, 💀 communicates that you felt the cringe on their behalf without you having to describe it. Group chats lean on it as a low-effort punctuation mark: a sentence that ends with 💀 feels lighter and funnier than the same sentence without it. In stan Twitter, sports Twitter, and crypto Twitter the emoji doubles as a way to react to a take that is so bad it circles back to being good.",
+    "whenNotToUse": "Skip 💀 when you are actually grieving, when the other person has shared something genuinely painful, or in any professional channel where the recipient may read it literally. Avoid using it as a response to bad news, layoffs, or a hospital update, even ironically; the slang has not spread far enough for the joke to land safely. Boomer and Gen X recipients sometimes read the skull as morbid or threatening, so if you are texting an older relative, reach for 😂 or 😬 instead. In customer support, HR contexts, or any thread where tone is being monitored, the skull will read as disrespectful regardless of intent.\n\nAlso avoid pairing 💀 with sensitive topics like religion, race, illness, or politics in group chats where you do not control the audience. The skull is a meme emoji, and memes age poorly when removed from their original context. When in doubt, send a softer reaction emoji like 😅 or 🙃 that signals humor without the morbidity undercurrent.",
+    "howToReply": "If someone sends you 💀 and you want to keep the energy, mirror them with another skull, with 😭, or with a screenshot of whatever they are reacting to. The skull-then-screenshot pattern is so common it has become a recognizable unit of conversation. If you want to slow the bit down, you can reply with a softer 😅 or a 'wait, actually?' to pull the conversation back to literal mode without killing the joke.\n\nIf the skull landed on something you shared and it feels like a brush-off, you can ask 'too far?' and most people will clarify that they meant it affectionately. If you are the one whose post collected a string of skulls, treat it as a win: the content was strong enough to break the reader. The rare times 💀 lands badly are usually because the sender assumed a closer relationship than the recipient felt, so a brief check-in clears it up.",
+    "faqs": [
+      {
+        "question": "What does the skull emoji mean from a girl?",
+        "answer": "From a girl or anyone else, 💀 almost always means 'I'm dead' from laughing, not anything romantic or threatening. Context still matters: paired with a screenshot of something absurd it reads as amusement, paired with a complaint it can read as sarcastic frustration."
+      },
+      {
+        "question": "Is 💀 flirty?",
+        "answer": "Usually no. The skull is rarely used to flirt directly; it signals that the sender is dying of laughter. If flirtation is involved it tends to come from the surrounding message rather than the emoji itself, and you should look at the full sentence to be sure."
+      },
+      {
+        "question": "What does 💀 mean from a guy?",
+        "answer": "From a guy, 💀 has the same meaning it has from anyone else: an exaggerated 'I am dead' reaction. There is no gendered twist — the emoji is about the strength of the reaction, not who is sending it."
+      },
+      {
+        "question": "What does 💀 mean on TikTok?",
+        "answer": "On TikTok a single 💀 in the comments means the viewer laughed hard, and a string of three or more skulls means the video broke them. Creators often count skulls as a soft metric of how well a punchline landed."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "bro i just tripped into the projector at work 💀",
+      "interpretation": "Sender is laughing at their own embarrassment and wants you to laugh with them. Mirror the energy with another skull or 😭."
+    },
+    {
+      "setting": "work",
+      "message": "reminder: all-hands at 8am tomorrow 💀",
+      "interpretation": "Sarcastic exhaustion about an early meeting. Probably not literal anger, but do not reply with another skull in a wide team channel; it reads as performative."
+    },
+    {
+      "setting": "dating",
+      "message": "you actually remembered 💀 i'm impressed",
+      "interpretation": "Playful disbelief mixed with a compliment. A warm reply that acknowledges the 'impressed' part works better than another skull here."
+    },
+    {
+      "setting": "social",
+      "message": "did you see that reply from the brand account 💀💀💀",
+      "interpretation": "Group chat hype about a public reply worth screenshotting. Drop the screenshot or a quote-tweet instead of just more skulls to keep the thread moving."
+    },
+    {
+      "setting": "family",
+      "message": "Dad just sent me 'lol' in response to my divorce announcement 💀",
+      "interpretation": "Laughing at a parent's tech illiteracy rather than the actual news. Reply with a soft correction or a phone call instead of more skulls."
+    }
+  ]
 }

--- a/src/data/emojis/smiling-face-with-halo.json
+++ b/src/data/emojis/smiling-face-with-halo.json
@@ -36,9 +36,22 @@
     }
   ],
   "platformNotes": [
-    { "platform": "TWITTER", "note": "Sarcastic innocence." },
-    { "platform": "INSTAGRAM", "note": "Good vibes." },
-    { "platform": "TIKTOK", "note": "Playing innocent." }
+    {
+      "platform": "TWITTER",
+      "note": "The sarcastic innocence reaction on teasing callouts."
+    },
+    {
+      "platform": "INSTAGRAM",
+      "note": "Good vibes captions and white-aesthetic posts."
+    },
+    {
+      "platform": "TIKTOK",
+      "note": "Playing innocent on confession videos and pranks."
+    },
+    {
+      "platform": "IMESSAGE",
+      "note": "Frequent on playful 'not me' messages between friends."
+    }
   ],
   "generationalNotes": [
     { "generation": "GEN_Z", "note": "Sarcastic use." },
@@ -48,5 +61,58 @@
   "warnings": [],
   "relatedCombos": [],
   "seoTitle": "😇 Smiling Face with Halo Emoji Meaning - What Does 😇 Really Mean?",
-  "seoDescription": "Learn what the angel emoji 😇 really means. Innocent or sarcastic vibes. Complete context guide."
+  "seoDescription": "Learn what the angel emoji 😇 really means. Innocent or sarcastic vibes. Complete context guide.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "😇 is the angel-face emoji, the smile-with-halo face that signals either sincere angelic energy or, more commonly in modern texting, playful fake innocence. The yellow smiley with a halo on top reads as either genuinely virtuous or as the 'who me?' deflection after a confession. On Twitter, Instagram, and TikTok 😇 shows up as the sarcastic reaction to a teasing callout, the playful closer on a confession video, and the softener on a moment where the sender is being anything but innocent. The dual reading — genuine or ironic — is the entire reason the emoji has stayed popular across age groups.\n\nThe emoji also doubles as the white-aesthetic visual tag. On Instagram captions 😇 shows up on angel-themed posts, white aesthetic content, and angel-number shares as the visual tag for the pure vibe. The dual reading — sarcastic innocence or genuine purity — keeps 😇 versatile without diluting the humor. Use 😇 when the moment calls for the wink-behind-the-halo energy, not as a sincere religious symbol.",
+    "howPeopleUseIt": "😇 arrives as the sentence closer on a confession, the reaction to a teasing callout, or the punchline on a 'not me' deflection. On Twitter it functions as the 'who me?' reaction to a public roast that the sender actually earned. On TikTok creators paste 😇 on confession videos and prank reveals as the visual tag for the moment the mask slips. On iMessage it shows up as the playful 'I am an angel' message when the sender is being mischievous.\n\nIn group chats 😇 works as the shared 'not me' reaction when a friend calls out a guilty party. The emoji also pairs naturally with 🙊 for the see-no-evil variant, with 🤥 for the actual lie, and with a sentence that names the mischief so the angel does not feel performative.",
+    "whenNotToUse": "Skip 😇 in contexts where the sarcastic reading will land wrong — in serious apologies, in genuine vulnerability, or in channels where the audience may not understand the irony. A 😇 in a sincere apology will read as insincere. Avoid it in religious contexts where the angel should be sacred; the irony note will land wrong.\n\nAlso avoid 😇 when you want to actually take responsibility. The emoji is the deflection reaction, and using it on a real mistake sounds as if you are not owning the moment. Reach for words or a sincere emoji when the apology needs to land as honest.",
+    "howToReply": "Mirror 😇 with another 😇 or 🙊 if you want to keep the fake-innocent energy going, or upgrade to a sentence that calls out the actual mischief. If you receive 😇 on a confession, reply with a soft teasing sentence so the bit continues without ruining the bit.\n\nIf 😇 arrives as a sincere angel reaction, mirror with a heart or a sentence that acknowledges the warmth. And if you want to send 😇 as a playful 'not me' moment, anchor the emoji with a sentence that names the mischief so the angel does not feel pointed.",
+    "faqs": [
+      {
+        "question": "What does 😇 mean in texting?",
+        "answer": "😇 means 'who me?' or 'pure vibes.' The angel-face emoji is most often used sarcastically as the playful deflection after a confession, and less often as a sincere angelic symbol."
+      },
+      {
+        "question": "What does 😇 mean from a girl?",
+        "answer": "From a girl or anyone else, 😇 means the sender is being playful or 'fake innocent.' There is no gendered meaning; the emoji is about the irony, not who is sending it."
+      },
+      {
+        "question": "Is 😇 flirty?",
+        "answer": "😇 can read as flirty in a dating context, especially paired with a teasing confession. In other contexts it stays in the sarcastic innocence zone."
+      },
+      {
+        "question": "What does 😇 mean from a guy?",
+        "answer": "From a guy, 😇 has the same meaning it has from anyone else: playful 'not me' or sarcastic innocence. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "i ate the last slice 😇",
+      "interpretation": "Friend's playful confession. Mirror with 😇 or a sentence that calls out the crime."
+    },
+    {
+      "setting": "social",
+      "message": "not guilty 😇",
+      "interpretation": "Public reaction to a teasing callout. Mirror with 😇 or a sentence that adds to the bit."
+    },
+    {
+      "setting": "family",
+      "message": "i am an angel 😇",
+      "interpretation": "Family playful deflection. Mirror with 😇 or a sentence that engages with the joke."
+    },
+    {
+      "setting": "dating",
+      "message": "thinking about you 😇",
+      "interpretation": "Romantic partner's soft flirty message. Mirror with 😇 or a heart to engage with the warmth."
+    },
+    {
+      "setting": "work",
+      "message": "i did not break the build 😇",
+      "interpretation": "Risky in a wide team channel; safe in a tight collaborator DM. If used in a team channel, anchor with a sentence that adds context."
+    }
+  ]
 }

--- a/src/data/emojis/smiling-face-with-smiling-eyes.json
+++ b/src/data/emojis/smiling-face-with-smiling-eyes.json
@@ -38,15 +38,19 @@
   "platformNotes": [
     {
       "platform": "SLACK",
-      "note": "One of the safest emojis for professional communication."
+      "note": "Slack treats 😊 as the safest workplace emoji — warm without being flirtatious, friendly without being unprofessional."
     },
     {
       "platform": "IMESSAGE",
-      "note": "Genuine, warm emoji without hidden meanings."
+      "note": "iMessage uses 😊 for genuine warmth without hidden meaning; older readers still trust the smile where other emoji have aged into slang."
     },
     {
       "platform": "INSTAGRAM",
-      "note": "Wholesome reaction for positive comments."
+      "note": "Instagram comments use 😊 as the wholesome positive reaction; creators post it as a soft default for fan engagement."
+    },
+    {
+      "platform": "DISCORD",
+      "note": "Discord treats 😊 as the universal friendly reaction; safe across servers, age groups, and conversation types."
     }
   ],
   "generationalNotes": [
@@ -66,5 +70,58 @@
   "warnings": [],
   "relatedCombos": ["smile-happy"],
   "seoTitle": "😊 Smiling Face with Smiling Eyes Meaning - What Does 😊 Really Mean?",
-  "seoDescription": "Learn what the smiling eyes emoji 😊 really means in modern texting. Warm, genuine happiness without negative connotations. Complete context guide."
+  "seoDescription": "Learn what the smiling eyes emoji 😊 really means in modern texting. Warm, genuine happiness without negative connotations. Complete context guide.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "😊 is the safest, warmest, most universally positive emoji on the keyboard. Where other emojis have aged into slang, sarcasm, or generational drift, 😊 has stayed exactly what it always was — a small yellow face with a modest smile, rosy cheeks, and closed eyes that signal genuine contentment. It is the emoji you send when you want to be friendly without flirting, grateful without gushing, and warm without overcommitting. In work channels, family group chats, and dating-app conversations alike, 😊 is the lowest-risk reaction emoji.\n\nThe reason 😊 has aged so well is that it never meant anything but what it shows. It has no slang pivot, no ironic reading, no generational controversy. 😊 from a Boomer parent reads as wholesome gratitude; 😊 from a Gen Z friend reads the same way. The emoji is the cleanest positive signal on the keyboard, and writers should reach for it whenever the message needs warmth without any hidden weight.",
+    "howPeopleUseIt": "😊 arrives as a stand-alone reaction, a sentence closer on a thank-you, or as a softener that follows any positive statement. In Slack it is the default 'thanks for the help' emoji that does not feel performative. In iMessage it lands as genuine warmth after a kind gesture — 'that was so thoughtful 😊' reads as sincere. And in dating-app conversations 😊 shows up after compliments, plans, and good-night messages as a soft signal of affection.\n\nThe emoji pairs naturally with hearts for added warmth (😊❤️) and with thanks messages (thanks 😊) as the cleanest possible acknowledgment. It also works as a story-reaction emoji — a friend shares a life update and you reply with 😊 to mark the moment as warm without typing a sentence.",
+    "whenNotToUse": "Skip 😊 in contexts where the recipient may misread the warmth as flirtation — in cold work channels, in customer-facing complaint replies, or in first-contact dating messages where the relationship has not been established. The emoji is warm but not aggressive, so it rarely offends — but pairing it with romantic content to a coworker can read as a signal that was not intended.\n\nAlso avoid 😊 in sarcastic contexts. The emoji does not have a strong ironic reading on most platforms, so trying to use it sarcastically usually falls flat. Reach for 🙃 or 😅 if you want to convey sarcasm with warmth.",
+    "howToReply": "Mirror 😊 with another 😊 if you want to keep the warmth going, or upgrade to ❤️ for more affection or 🙌 for more enthusiasm. If you receive 😊 on your own post, treat it as a clean positive signal and reply with a short 'thanks 😊' or a heart emoji.\n\nIf 😊 lands in a professional context, mirror with the same emoji or a thank-you sentence so the warmth stays appropriate. And if you are not sure whether 😊 is sincere or just polite, glance at the surrounding text — sincere 😊 usually accompanies a real compliment, while polite 😊 arrives as a softener on a neutral message.",
+    "faqs": [
+      {
+        "question": "What does 😊 mean in texting?",
+        "answer": "😊 means warm, genuine happiness or gratitude. It is the safest positive emoji on the keyboard and reads the same across age groups."
+      },
+      {
+        "question": "What does 😊 mean from a girl?",
+        "answer": "From a girl or anyone else, 😊 means the sender feels warmly about the moment. There is no gendered meaning; the emoji is about the warmth, not who is sending it."
+      },
+      {
+        "question": "Is 😊 flirty?",
+        "answer": "😊 is not inherently flirty. It reads as warm but not romantic, friendly but not flirtatious. In an established romantic relationship it can lean flirty, but in most contexts it stays in the wholesome zone."
+      },
+      {
+        "question": "What does 😊 mean on Slack?",
+        "answer": "On Slack 😊 is the safest workplace emoji — warm enough to acknowledge a favor, friendly enough to soften a request, professional enough to avoid any flirtation read."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "work",
+      "message": "thanks for the help on the launch 😊",
+      "interpretation": "Workplace thanks. Mirror with 😊 or 'appreciate it' to close the thread warmly."
+    },
+    {
+      "setting": "dating",
+      "message": "i had a great time tonight 😊",
+      "interpretation": "Romantic warmth after a date. Mirror with 😊 or a follow-up sentence about the evening."
+    },
+    {
+      "setting": "friends",
+      "message": "i'm so proud of you 😊",
+      "interpretation": "Friend supporting a milestone. Mirror with 😊 or 'so happy for you' to keep the warmth going."
+    },
+    {
+      "setting": "family",
+      "message": "thanks for the birthday wishes everyone 😊",
+      "interpretation": "Family group warmth. Reply with 😊 or 'love you' to acknowledge the warmth."
+    },
+    {
+      "setting": "social",
+      "message": "love your latest post 😊",
+      "interpretation": "Friendly comment on a creator's content. Mirror with a heart or 'thanks' to engage."
+    }
+  ]
 }

--- a/src/data/emojis/smiling-face-with-tear.json
+++ b/src/data/emojis/smiling-face-with-tear.json
@@ -36,17 +36,92 @@
     }
   ],
   "platformNotes": [
-    { "platform": "TWITTER", "note": "'This is fine' meme energy." },
-    { "platform": "TIKTOK", "note": "Bittersweet and relatable content." },
-    { "platform": "INSTAGRAM", "note": "Mixed emotion captions." }
+    {
+      "platform": "TWITTER",
+      "note": "The 'this is fine' meme energy and bittersweet milestone tweets."
+    },
+    {
+      "platform": "TIKTOK",
+      "note": "Bittersweet and relatable content from creators and storytime videos."
+    },
+    {
+      "platform": "INSTAGRAM",
+      "note": "Mixed emotion captions on graduation and farewell posts."
+    },
+    {
+      "platform": "DISCORD",
+      "note": "Server members paste it as the 'hiding pain behind smile' reaction."
+    }
   ],
   "generationalNotes": [
-    { "generation": "GEN_Z", "note": "Pain hiding behind smile." },
-    { "generation": "MILLENNIAL", "note": "Bittersweet moments." },
-    { "generation": "BOOMER", "note": "Happy tears." }
+    {
+      "generation": "GEN_Z",
+      "note": "Pain hiding behind smile."
+    },
+    {
+      "generation": "MILLENNIAL",
+      "note": "Bittersweet moments."
+    },
+    {
+      "generation": "BOOMER",
+      "note": "Happy tears."
+    }
   ],
   "warnings": [],
   "relatedCombos": [],
   "seoTitle": "🥲 Smiling Face with Tear Emoji Meaning - What Does 🥲 Really Mean?",
-  "seoDescription": "Learn what the smiling face with tear emoji 🥲 really means. Bittersweet or hiding pain. Complete context guide."
+  "seoDescription": "Learn what the smiling face with tear emoji 🥲 really means. Bittersweet or hiding pain. Complete context guide.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "🥲 is the smiling face with tear emoji, the bittersweet face that signals mixed emotions, hiding pain behind a smile, or the universal 'this is fine' ironic beat. The visual cue — a closed-eye smile paired with a single tear — has become one of the most-used complex-emotion emoji on the keyboard because it captures the exact feeling of holding it together. On Twitter, TikTok, and Instagram 🥲 shows up as the bittersweet reaction to a milestone, the 'Monday again' relatable share, and the supportive reply to a friend's tough moment. The emoji is interesting because it spans three genuinely different uses — happy tears, hiding pain, and ironic-stoic — all of which land on related bittersweet beats.\n\nThe emoji also doubles as the universal 'it is fine' reaction. A friend vents about a hard week and the appropriate reply is 🥲 — the visual tag for 'I see you and I am holding it together too.' The dual reading — happy tears or pain-hiding — keeps 🥲 versatile without diluting the bittersweet beat. Use 🥲 when the moment calls for the complex-emotion signal, not as a default reaction to every nice moment.",
+    "howPeopleUseIt": "🥲 arrives as the bittersweet reaction to a friend's milestone, the relatable 'Monday again' share, or the punchline on a 'this is fine' moment. On Twitter it functions as the standard reaction to a public moment of holding-it-together. On TikTok creators paste 🥲 on relatable storytime videos as the visual tag for the moment the mask slips. On Instagram captions the emoji lands as the signature flourish on a graduation or farewell post.\n\nIn group chats 🥲 works as the shared 'I see you' reaction when a friend shares a hard moment. The emoji also pairs naturally with 💪 for the powering-through sibling, with 😭 for the louder sibling cry, and with a sentence that names what is being held together so the smile-with-tear does not feel generic.",
+    "whenNotToUse": "Skip 🥲 in contexts where the pain-hiding reading will land wrong — in serious support conversations where the recipient actually needs empathy, in customer complaint threads, or in formal client emails. A 🥲 in a customer complaint thread will sound tone deaf. Avoid it in moments where the recipient needs real support, not a smile.\n\nAlso avoid 🥲 when the situation actually calls for a different complex-emotion moment. The emoji is more coded than a sad face, so a 🥲 on a friend's genuine grief may read as minimizing. Reach for words or a sentence of care when the moment warrants direct support.",
+    "howToReply": "Mirror 🥲 with another 🥲 or 💪 if you want to keep the holding-it-together going, or upgrade to ❤️ for the warmth. If you receive 🥲 on a friend's tough share, reply with a sentence that engages with the actual feeling.\n\nIf 🥲 arrives as a bittersweet reaction, mirror with a sentence that acknowledges the moment. And if you want to send 🥲 as a soft friendly reaction, anchor the emoji with a sentence that names the mixed feeling so the smile-with-tear does not feel performative.",
+    "faqs": [
+      {
+        "question": "What does 🥲 mean in texting?",
+        "answer": "🥲 means 'bittersweet,' 'hiding pain,' or 'this is fine.' The smiling-face-with-tear emoji signals mixed emotions, ironic-stoic energy, or genuine happy tears depending on context and the relationship."
+      },
+      {
+        "question": "What does 🥲 mean from a girl?",
+        "answer": "From a girl or anyone else, 🥲 means the sender is signaling mixed emotions or holding-it-together. There is no gendered meaning; the emoji is about the feeling, not who is sending it."
+      },
+      {
+        "question": "Is 🥲 sad?",
+        "answer": "🥲 can read as sad or bittersweet. It often carries the sense of a smile covering pain, so the emoji lands more as complex-emotion than purely sad."
+      },
+      {
+        "question": "What does 🥲 mean from a guy?",
+        "answer": "From a guy, 🥲 has the same meaning it has from anyone else: bittersweet or hiding pain. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "this is fine 🥲",
+      "interpretation": "Friend venting a hard moment. Mirror with 🥲 or a sentence that engages with the feeling."
+    },
+    {
+      "setting": "work",
+      "message": "deploy day 🥲",
+      "interpretation": "Team shipping moment in a tight channel. Mirror with 🥲 or a sentence that engages with the launch."
+    },
+    {
+      "setting": "social",
+      "message": "last day of college 🥲",
+      "interpretation": "Public milestone share. Mirror with 🥲 or a sentence that acknowledges the moment."
+    },
+    {
+      "setting": "family",
+      "message": "kids grow up fast 🥲",
+      "interpretation": "Family bittersweet share. Mirror with a heart or a sentence that engages with the feeling."
+    },
+    {
+      "setting": "dating",
+      "message": "missing you tonight 🥲",
+      "interpretation": "Partner's bittersweet note. Mirror with a heart or a sentence that engages with the moment."
+    }
+  ]
 }

--- a/src/data/emojis/smiling-face.json
+++ b/src/data/emojis/smiling-face.json
@@ -36,9 +36,22 @@
     }
   ],
   "platformNotes": [
-    { "platform": "TWITTER", "note": "Used for genuine warmth." },
-    { "platform": "INSTAGRAM", "note": "Common in positive posts." },
-    { "platform": "WHATSAPP", "note": "Classic friendly emoji." }
+    {
+      "platform": "TWITTER",
+      "note": "Used for genuine warmth and wholesome reactions."
+    },
+    {
+      "platform": "INSTAGRAM",
+      "note": "Common in positive posts and warm comments."
+    },
+    {
+      "platform": "WHATSAPP",
+      "note": "Classic friendly emoji across age groups."
+    },
+    {
+      "platform": "IMESSAGE",
+      "note": "Reads as warm sincerity between friends and family."
+    }
   ],
   "generationalNotes": [
     { "generation": "GEN_Z", "note": "Vintage wholesome vibes." },
@@ -48,5 +61,58 @@
   "warnings": [],
   "relatedCombos": [],
   "seoTitle": "☺️ Smiling Face Emoji Meaning",
-  "seoDescription": "Learn what the classic smiling face emoji ☺️ really means. Content happiness."
+  "seoDescription": "Learn what the classic smiling face emoji ☺️ really means. Content happiness.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "☺️ is the classic smile emoji, the warm-faced contentment glyph that has been on the Unicode keyboard since the very first version. The rosy cheeks and closed-eye smile read as genuine warmth rather than the louder exaggeration of newer emoji. On Twitter, Instagram, and iMessage ☺️ shows up as the universal 'this is nice' reaction — the closer on a kind message, the signature flourish on a wholesome post, the warm reply to a friend who shared something sweet. The emoji reads as sincere across age groups because the visual metaphor is timeless.\n\nCompared to the bigger smile emoji 🙂 or the laughing face 😄, ☺️ sits in the soft-contentment zone. It is not laughing, not laughing-crying, not performatively happy — it is the polite, warm, slightly-relieved smile. The emoji also doubles as the default friendly-react emoji in workplace channels because the cutoff of the smile never reads as sarcastic, even when the surrounding message is dry.",
+    "howPeopleUseIt": "☺️ arrives as the closer on a friendly message, the punctuation on a wholesome post, or the warm reply to a friend's good news. On Instagram captions the emoji lands as the closing flourish on a kind comment or a positive post. On Twitter it functions as the gentle 'good vibes' reaction to a wholesome thread. On iMessage it shows up as the warm signature on a sincere message between friends or family.\n\nIn workplace channels ☺️ functions as the soft-pleasant reaction — 'happy to help ☺️' or 'thanks for the update ☺️' — that lands as polite without being too formal. The emoji pairs naturally with ❤️ for a stronger affection signal, with 🌸 for a soft aesthetic, and with a sentence that adds the warmth.",
+    "whenNotToUse": "Skip ☺️ in contexts where the warmth would feel mismatched — in harsh feedback, in confrontational threads, or in rebuttal messages. A ☺️ in a tough correction will read as undermining the seriousness. Avoid it in fast-paced conversational threads where the slower vintage vibes will feel out of place.\n\nAlso avoid ☺️ when you want to actually express strong emotion. The soft smile cannot reach the satisfaction of 😌 or the gratitude of 🥹. Use one of those when the moment warrants the heavier reaction.",
+    "howToReply": "Mirror ☺️ with another ☺️ if you want to keep the warmth going, or upgrade to ❤️ for more affection. If you receive ☺️ on a wholesome post, reply with 'thanks ☺️' or a soft heart so the warmth stays warm.\n\nIf ☺️ arrives as the polite-professional reaction, mirror with a sentence that acknowledges the work. And if you want to send ☺️ as a soft friendly reaction, anchor the emoji with a sentence that names the warmth so the smile does not feel generic.",
+    "faqs": [
+      {
+        "question": "What does ☺️ mean in texting?",
+        "answer": "☺️ means 'content and warm.' The classic smiling face reads as gentle contentment rather than loud happiness, and works across age groups as the universal polite friendly emoji."
+      },
+      {
+        "question": "What does ☺️ mean from a girl?",
+        "answer": "From a girl or anyone else, ☺️ means the sender feels warm contentment. There is no gendered meaning; the emoji is about the warmth, not who is sending it."
+      },
+      {
+        "question": "Is ☺️ flirty?",
+        "answer": "☺️ can read as flirty in a dating context, especially paired with soft sentiment. In other relationships it stays in the wholesome zone."
+      },
+      {
+        "question": "What does ☺️ mean from a guy?",
+        "answer": "From a guy, ☺️ has the same meaning it has from anyone else: warm contentment or friendly reaction. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "dating",
+      "message": "thinking of you ☺️",
+      "interpretation": "Romantic partner's warm message. Mirror with ☺️ or a heart to engage with the warmth."
+    },
+    {
+      "setting": "friends",
+      "message": "thanks for being there ☺️",
+      "interpretation": "Friend's sincere thank-you. Mirror with ☺️ or ❤️ to close the loop warmly."
+    },
+    {
+      "setting": "work",
+      "message": "happy to help ☺️",
+      "interpretation": "Polite professional reply. Mirror with 👍 or a sentence that acknowledges the help."
+    },
+    {
+      "setting": "family",
+      "message": "love you ☺️",
+      "interpretation": "Family warmth between close relatives. Mirror with ☺️ or ❤️ to keep the warmth going."
+    },
+    {
+      "setting": "social",
+      "message": "this made my day ☺️",
+      "interpretation": "Friendly comment on a creator's content. Mirror with ☺️ or a heart to engage."
+    }
+  ]
 }

--- a/src/data/emojis/smiling-hearts.json
+++ b/src/data/emojis/smiling-hearts.json
@@ -38,15 +38,80 @@
   "platformNotes": [
     { "platform": "TWITTER", "note": "Popular for expressing appreciation and love." },
     { "platform": "INSTAGRAM", "note": "Common in comments on cute or romantic posts." },
-    { "platform": "TIKTOK", "note": "Used to react to wholesome content." }
+    {
+      "platform": "TIKTOK",
+      "note": "Pasted on wholesome edits and appreciation videos as the warm reaction."
+    }
   ],
   "generationalNotes": [
-    { "generation": "GEN_Z", "note": "Widely accepted as a genuine expression of affection." },
-    { "generation": "MILLENNIAL", "note": "Go-to emoji for feeling adored." },
-    { "generation": "BOOMER", "note": "Used to express love and appreciation." }
+    {
+      "generation": "GEN_Z",
+      "note": "Widely accepted as a genuine expression of affection."
+    },
+    {
+      "generation": "MILLENNIAL",
+      "note": "Go-to emoji for feeling adored."
+    },
+    {
+      "generation": "BOOMER",
+      "note": "Used to express love and appreciation."
+    }
   ],
   "warnings": [],
   "relatedCombos": [],
   "seoTitle": "🥰 Smiling Face with Hearts Emoji Meaning - What Does 🥰 Really Mean?",
-  "seoDescription": "Learn what the smiling face with hearts emoji 🥰 really means. From romantic feelings to wholesome moments, discover all its uses."
+  "seoDescription": "Learn what the smiling face with hearts emoji 🥰 really means. From romantic feelings to wholesome moments, discover all its uses.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "🥰 is the emoji that says 'I am overwhelmed with affection,' the one that arrives when something is so cute or romantic that no other emoji does the moment justice. Added to Unicode in 2018, 🥰 is essentially an upgraded version of the smile-with-hearts pattern: smiling eyes, rosy cheeks, and multiple hearts floating around the face. On Instagram, TikTok, and Twitter the emoji has become the standard reaction to adorable pets, romantic gestures, baby photos, and any moment the sender wants to mark as heart-meltingly sweet.\n\n🥰 is also one of the cleanest dating-app emojis. It reads as smitten without being as forward as 😘, so it works as the safe flirt emoji in early conversations. Inside an established relationship it functions as the warm 'I adore you' reaction to a partner's message. The emoji has very little ironic reading — it stays wholesome even when the moment is silly — which makes it the safest positive-affection signal on the keyboard.",
+    "howPeopleUseIt": "🥰 arrives as a stand-alone reaction, a sentence closer on a sweet message, or as the universal 'this is adorable' reaction. On Instagram comments 🥰 is the default for pet photos, baby pictures, and wholesome creator content. On TikTok the same pattern repeats — viewers paste 🥰 under wholesome edits, soft launches, and fan appreciation posts.\n\nIn dating-app conversations 🥰 works as the warm flirty closer. 'thinking about you 🥰' reads as smitten without sounding as direct as 😘 or as heavy as ❤️. The emoji also pairs naturally with other affection emoji — 🥰❤️ or 🥰✨ — for maximum warmth. And in family group chats 🥰 shows up under grandkid photos and milestone announcements as the wholesome default.",
+    "whenNotToUse": "Skip 🥰 in cold work channels or customer-facing comms where the romantic reading would be inappropriate. A 🥰 in a customer complaint reply sounds mismatched and unprofessional. Avoid it in serious discussions about grief or loss — the cuteness of the emoji will not land where empathy is needed.\n\nAlso avoid stacking 🥰 on critical feedback. A manager who replies 'your work needs improvement 🥰' sounds as if they are softening bad news with cuteness rather than delivering clear direction. Reach for words or a more neutral emoji when the message needs to land as honest.",
+    "howToReply": "Mirror 🥰 with another 🥰 if you want to keep the warmth going, or upgrade to ❤️ for more romantic emphasis. If you receive 🥰 on your own post, treat it as a warm affection signal and reply with 'thanks 🥰' or a heart emoji.\n\nIf 🥰 lands in a dating context, mirror with a softer reaction or a follow-up sentence about the moment so the warmth keeps flowing. And if you want to send 🥰 to a friend who shared something cute, pair it with a sentence like 'so cute 🥰' to anchor the wholesome reading.",
+    "faqs": [
+      {
+        "question": "What does 🥰 mean in texting?",
+        "answer": "🥰 means 'I am overwhelmed with affection.' It is the universal reaction to adorable or romantic moments, and it reads as warm across age groups."
+      },
+      {
+        "question": "What does 🥰 mean from a girl?",
+        "answer": "From a girl or anyone else, 🥰 means the sender is feeling smitten or affectionate. There is no gendered meaning; the emoji is about the warmth, not who is sending it."
+      },
+      {
+        "question": "Is 🥰 flirty?",
+        "answer": "🥰 can read as flirty in a dating context, especially paired with romantic content. In other relationships it stays in the wholesome zone."
+      },
+      {
+        "question": "What does 🥰 mean from a guy?",
+        "answer": "From a guy, 🥰 has the same meaning it has from anyone else: warmth, adoration, or affection. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "dating",
+      "message": "thinking about you 🥰",
+      "interpretation": "Romantic partner's warm thinking-of-you message. Mirror with 🥰 or a follow-up sweet line."
+    },
+    {
+      "setting": "family",
+      "message": "look at the new puppy 🥰",
+      "interpretation": "Family sharing an adorable moment. Mirror with 🥰 or 'so cute' to engage."
+    },
+    {
+      "setting": "friends",
+      "message": "we just got engaged 🥰",
+      "interpretation": "Friend announcing a milestone. Mirror with 🥰 or 'congratulations' to celebrate."
+    },
+    {
+      "setting": "social",
+      "message": "your cat is the cutest 🥰",
+      "interpretation": "Friendly comment on a creator's content. Mirror with a heart or 'thanks' to engage."
+    },
+    {
+      "setting": "work",
+      "message": "thanks for the help on the launch 🥰",
+      "interpretation": "Risky in a wide team channel; safe in a tight collaborator DM. If used in a team channel, anchor with a sentence that adds context."
+    }
+  ]
 }

--- a/src/data/emojis/smiling-with-sunglasses.json
+++ b/src/data/emojis/smiling-with-sunglasses.json
@@ -38,15 +38,19 @@
   "platformNotes": [
     {
       "platform": "TWITTER",
-      "note": "Used for humble brags or celebrating wins."
+      "note": "Used for humble brags or celebrating personal wins."
     },
     {
       "platform": "INSTAGRAM",
-      "note": "Common in vacation and summer photos."
+      "note": "Common in vacation and summer photos and confident fits."
     },
     {
       "platform": "SLACK",
       "note": "Acceptable for celebrating team wins or accomplishments."
+    },
+    {
+      "platform": "TIKTOK",
+      "note": "Pasted on GRWM and swagger-reveal edits as the cool-sibling."
     }
   ],
   "generationalNotes": [
@@ -66,5 +70,58 @@
   "warnings": [],
   "relatedCombos": ["cool-sunglasses"],
   "seoTitle": "😎 Sunglasses Emoji Meaning - What Does 😎 Really Mean?",
-  "seoDescription": "Learn what the sunglasses emoji 😎 really means in modern texting. The 'cool' emoji for confidence and accomplishment. Complete context guide."
+  "seoDescription": "Learn what the sunglasses emoji 😎 really means in modern texting. The 'cool' emoji for confidence and accomplishment. Complete context guide.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "😎 is the cool face emoji, the smile-with-sunglasses face that signals confidence, accomplishment, or unbothered swagger. The visual cue — broad smile behind dark sunglasses — is the universal 'I am cool' image in the Unicode face set. On Twitter, Instagram, and TikTok 😎 shows up as the celebration reaction on a big win, the humble-brag closer on a personal accomplishment, and the swagger signature on a confident post. Compared to the standalone sunglasses emoji 🕶️, 😎 sits more specifically in the 'I am feeling myself' zone and tends to be self-directed rather than reactive.\n\nThe emoji also doubles as the ironic-humility reaction. A user accomplishes something modest and pastes 😎 as the playful 'I am actually cool' deflection. The dual reading — genuine confidence or ironic self-deprecation — keeps 😎 versatile without diluting the cool. Use 😎 when the moment calls for unbothered swagger, not as a default reaction to every minor win.",
+    "howPeopleUseIt": "😎 arrives as the closer on a humble brag, the celebration reaction on a personal win, or the punchline on a confident post. On Twitter it functions as the standard 'I got this' reaction to a personal accomplishment. On Instagram captions the emoji lands as the signature flourish on a fit pic or a vacation post. On TikTok creators paste 😎 on GRWM and swagger-reveal edits as the cool-sibling visual tag for the moment the look comes together.\n\nIn group chats 😎 works as the celebration reaction when a friend shares a win. The emoji also pairs naturally with 🕶️ for the cool-sibling stack, with 💪 for the flex variant, and with a sentence that names what was accomplished so the cool does not feel performative.",
+    "whenNotToUse": "Skip 😎 in contexts where the cool reading will land wrong — in condolences, in serious professional channels, or in customer complaint replies. A 😎 in a customer complaint thread sounds as if you are enjoying the drama. Avoid it in any thread where the recipient needs empathy rather than swagger.\n\nAlso avoid 😎 when you actually want to acknowledge a hard moment with sincerity. The face always reads cool, so a friend sharing bad news will not feel supported if you reply with 😎. Reach for a heart or a plain sentence when the moment warrants sympathy.",
+    "howToReply": "Mirror 😎 with another 😎 or 🕶️ if you want to keep the cool energy, or upgrade to 💪 for the flex variant. If you receive 😎 on your own win, reply with 'thanks 😎' or a sentence that acknowledges the moment.\n\nIf 😎 arrives on a friend's accomplishment, mirror with a sentence that matches the swagger. And if you want to send 😎 as a soft confidence signal, anchor the emoji with a sentence that lands the cool without sounding aloof.",
+    "faqs": [
+      {
+        "question": "What does 😎 mean in texting?",
+        "answer": "😎 means 'cool' or 'I am feeling myself.' The sunglasses-face emoji is the universal confidence reaction and reads as either genuine swagger or ironic self-deprecation."
+      },
+      {
+        "question": "What does 😎 mean from a girl?",
+        "answer": "From a girl or anyone else, 😎 means the sender feels confident or cool. There is no gendered meaning; the emoji is about the vibe, not who is sending it."
+      },
+      {
+        "question": "Is 😎 flirty?",
+        "answer": "😎 is not flirty. It marks confidence or swagger, with no romantic undercurrent. Using it on a romantic post will read as supportive rather than flirtatious."
+      },
+      {
+        "question": "What does 😎 mean from a guy?",
+        "answer": "From a guy, 😎 has the same meaning it has from anyone else: cool, confident, unbothered. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "social",
+      "message": "nailed the interview 😎",
+      "interpretation": "Friend celebrating a personal win. Mirror with 😎 or 🔥 to match the swagger."
+    },
+    {
+      "setting": "friends",
+      "message": "i did not even need to argue that point 😎",
+      "interpretation": "Friend bragging about a clean win. Mirror with 😎 or 🔥 to match the swagger."
+    },
+    {
+      "setting": "dating",
+      "message": "date went well 😎",
+      "interpretation": "Romantic confidence post-date. Reply with a follow-up question or a softer reaction."
+    },
+    {
+      "setting": "family",
+      "message": "i told mom exactly what i thought 😎",
+      "interpretation": "Family flex about setting a boundary. Mirror with 😎 or 'iconic' to match the energy."
+    },
+    {
+      "setting": "work",
+      "message": "we closed the deal 😎",
+      "interpretation": "Team win in a tight channel. Mirror with 😎 or 'great work' to acknowledge the team."
+    }
+  ]
 }

--- a/src/data/emojis/smirk.json
+++ b/src/data/emojis/smirk.json
@@ -38,7 +38,7 @@
   "platformNotes": [
     {
       "platform": "IMESSAGE",
-      "note": "Often used in flirty or suggestive contexts between close friends or romantic interests."
+      "note": "Used in flirty or suggestive contexts between close friends or romantic interests."
     },
     {
       "platform": "TIKTOK",
@@ -46,7 +46,11 @@
     },
     {
       "platform": "SLACK",
-      "note": "Avoid in workplace - almost always reads as inappropriate."
+      "note": "Avoid in workplace; almost always reads as inappropriate."
+    },
+    {
+      "platform": "TWITTER",
+      "note": "Quote-tweet reaction implying hidden meaning or teasing."
     }
   ],
   "generationalNotes": [
@@ -56,7 +60,7 @@
     },
     {
       "generation": "MILLENNIAL",
-      "note": "Same usage - implies something cheeky or knowing."
+      "note": "Same usage; implies something cheeky or knowing."
     },
     {
       "generation": "BOOMER",
@@ -70,7 +74,60 @@
       "severity": "MEDIUM"
     }
   ],
-  "relatedCombos": ["smirk-wink"],
+  "relatedCombos": ["smirk-wink", "smirk-devil"],
   "seoTitle": "😏 Smirking Face Emoji Meaning - What Does 😏 Really Mean?",
-  "seoDescription": "Learn what the smirk emoji 😏 really means in modern texting. The suggestive emoji implying something cheeky or flirty. Complete context guide."
+  "seoDescription": "Learn what the smirk emoji 😏 really means in modern texting. The suggestive emoji implying something cheeky or flirty. Complete context guide.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "😏 is the suggestive smirk emoji, the half-smile face that signals flirty subtext, hidden meaning, or cheeky confidence. The visual cue — one corner raised in a subtle smile — is the most loaded expression in the Unicode face set. On Twitter, iMessage, and TikTok 😏 shows up as the flirty closer on a romantic message, the 'I know something you do not' reaction on a teasing thread, and the smug comment on a take that landed. The emoji is one of the most context-sensitive on the keyboard because the meaning depends entirely on the relationship and the channel.\n\nThe emoji also doubles as the smug satisfaction reaction. A user makes a prediction that came true and pastes 😏 as the 'told you so' visual tag. The dual reading — flirting or smug satisfaction — lands on the same beat: I know something. Use 😏 when the moment genuinely calls for the knowing energy, and never in a cold professional channel where the subtext will land wrong.",
+    "howPeopleUseIt": "😏 arrives as the flirty closer on a romantic message, the smug reaction to a winning prediction, or the 'I know something' teaser on a thread. On iMessage it functions as the dating-app flirty closer — 'come over later 😏' or 'thinking about you 😏' — that pushes the conversation past the casual stage. On Twitter quote-tweets 😏 shows up as the 'I see the hidden meaning' reaction to a teasing public statement.\n\nIn group chats 😏 works as the shared 'I see what you did there' reaction when a friend teases a hidden meaning. The emoji also pairs naturally with 😉 for the wink-smirk combo, with 😈 for the more aggressive smirk-devil variant, and with a sentence that lands the subtext so the smirk does not feel generic.",
+    "whenNotToUse": "Skip 😏 in any context where the suggestive reading will land wrong — in cold work channels, in customer complaint replies, in family group chats, or in first-contact messages where the relationship has not been established. A 😏 in a customer complaint reply will sound predatory. Avoid it in professional emails where the suggestion will undercut the seriousness of the message.\n\nAlso avoid 😏 in serious discussions about consent, boundaries, or rejection. The emoji carries subtext, and the recipient may not feel the same energy. When in doubt, reach for a heart or a plain sentence.",
+    "howToReply": "Mirror 😏 with another 😏 or 😉 if you want to keep the flirty energy going, or upgrade to 😈 for the more aggressive smirk-devil. If you receive 😏 from a romantic partner, a heart or a flirty sentence closes the loop in matching energy.\n\nIf 😏 arrives as a smug 'I told you so' reaction, mirror with a sentence that acknowledges the win. And if you want to send 😏 as a flirty closer in an established relationship, anchor the emoji with a sentence that lands the intent so the smirk does not feel generic.",
+    "faqs": [
+      {
+        "question": "What does 😏 mean in texting?",
+        "answer": "😏 means 'flirty nudge' or 'I know something.' The smirk is the universal suggestive emoji and signals either romantic subtext, hidden meaning, or smug satisfaction depending on context."
+      },
+      {
+        "question": "What does 😏 mean from a girl?",
+        "answer": "From a girl or anyone else, 😏 means the sender is teasing or being suggestive. There is no gendered meaning; the emoji is about the subtext, not who is sending it."
+      },
+      {
+        "question": "Is 😏 flirty?",
+        "answer": "Yes, 😏 is inherently flirty in most contexts. Inside a dating relationship it is the default tease emoji; in other contexts it can feel forward if the warmth is not mutual."
+      },
+      {
+        "question": "What does 😏 mean from a guy?",
+        "answer": "From a guy, 😏 has the same meaning it has from anyone else: flirty subtext or smug knowing. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "dating",
+      "message": "come over later 😏",
+      "interpretation": "Romantic partner's flirty invite. Mirror with 😏 or a suggestive sentence if the energy is mutual."
+    },
+    {
+      "setting": "social",
+      "message": "i know something you don't 😏",
+      "interpretation": "Public tease on a thread. Mirror with 😏 or a sentence that engages with the tease."
+    },
+    {
+      "setting": "friends",
+      "message": "told you so 😏",
+      "interpretation": "Friend's smug satisfaction. Mirror with 😏 or a sentence that acknowledges the win."
+    },
+    {
+      "setting": "family",
+      "message": "i was right about the pie 😏",
+      "interpretation": "Family smug reaction. Mirror with 😏 or a sentence that engages with the joke."
+    },
+    {
+      "setting": "work",
+      "message": "the meeting went well 😏",
+      "interpretation": "Risky in a wide team channel; safe in a tight collaborator DM. If used in a team channel, anchor with a sentence that adds context."
+    }
+  ]
 }

--- a/src/data/emojis/sparkles.json
+++ b/src/data/emojis/sparkles.json
@@ -31,9 +31,22 @@
     }
   ],
   "platformNotes": [
-    { "platform": "TWITTER", "note": "Common usage." },
-    { "platform": "INSTAGRAM", "note": "Popular posts." },
-    { "platform": "TIKTOK", "note": "Trending." }
+    {
+      "platform": "TIKTOK",
+      "note": "TikTok creators stack ✨ in bios and captions as the default 'main character' energy marker; viewers paste it on their own story reposts."
+    },
+    {
+      "platform": "INSTAGRAM",
+      "note": "Instagram captions over-index on ✨ as a soft-launch signal, used to imply the post is more meaningful than it looks at first glance."
+    },
+    {
+      "platform": "TWITTER",
+      "note": "Twitter quote-tweets use ✨ to add a sparkle of irony or excitement; the emoji doubles as a hedge against sounding too sincere."
+    },
+    {
+      "platform": "DISCORD",
+      "note": "Discord bios and server descriptions lean on ✨ as the casual sparkle decoration that signals 'this is fun' without committing to a vibe."
+    }
   ],
   "generationalNotes": [
     { "generation": "GEN_Z", "note": "Gen Z usage." },
@@ -43,5 +56,58 @@
   "warnings": [],
   "relatedCombos": [],
   "seoTitle": "✨ Sparkles Emoji Meaning",
-  "seoDescription": "Learn what the Sparkles emoji ✨ really means."
+  "seoDescription": "Learn what the Sparkles emoji ✨ really means.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "✨ is the universal decoration emoji, the one that adds a hint of magic, sass, or 'main character energy' to any message it lands on. On TikTok and Instagram ✨ has become shorthand for the 'that girl' aesthetic — the polished, intentional, slightly above-it-all vibe that Gen Z curates. It also works as a hedge: adding ✨ to a sentence softens sincerity with just enough irony that the sender can deny being earnest. The emoji shows up in bios, captions, story reposts, and the closing line of tweets where the writer wants the post to feel special without explaining why.\n\n✨ is also the most common companion emoji. It pairs with almost anything — ✨💖 for cute, ✨🔥 for hype, ✨😭 for dramatic sincerity — and rarely clutters the message. That versatility is why it has stayed popular across age groups, even though the slang '✨ vibe' framing is mostly a Gen Z thing. Writers should treat ✨ as low-stakes sparkle decoration; it never carries a heavy meaning on its own, but it changes the tone of whatever it accompanies.",
+    "howPeopleUseIt": "✨ shows up as a stand-alone reaction, sandwiched in a sentence, or pasted at the end of a caption or bio as a flourish. On TikTok creators open their bios with '✨' to signal polish, then list their niche with one or two more sparkles sprinkled around the words. On Instagram the same pattern repeats in captions — 'first time in paris ✨' feels more cinematic than the same sentence without the emoji.\n\nIn group chats ✨ functions as a soft upvote. A friend shares a small win and you reply ✨ to mark it as cute without writing 'congrats.' It also works as a self-applied tag — people slap ✨ onto their own story reposts to mark the moment as 'this is my life now.' The emoji is rarely used sarcastically, but when it is, it usually arrives with a lowercase 'mood ✨' that performs the cliché rather than embracing it.",
+    "whenNotToUse": "Skip ✨ in serious professional emails where the sparkle energy will undercut the message. A pitch deck ending with 'looking forward to next steps ✨' sounds more like a casual friend than a vendor. Avoid it in customer complaint replies where the customer needs to feel heard — the sparkle comes across as flippant. And in formal writing, ✨ should be replaced with words that earn the impact rather than borrowing it from an emoji.\n\nAlso avoid over-stacking ✨. A caption with five sparkles in a row stops reading as magical and starts reading as spam. One or two per sentence is the sweet spot; more than that and the sparkle loses its shine.",
+    "howToReply": "Mirror ✨ with another ✨ if you want to keep the vibe, or upgrade to 💖 for cuteness or 🔥 for hype. If you receive ✨ on your own post, a short 'thanks ✨' or a heart emoji closes the loop. If ✨ arrives in a context where the meaning is unclear, glance at the surrounding sentence — sincere ✨ usually accompanies a real moment, while ironic ✨ pairs with 'mood' or 'relatable' tags.",
+    "faqs": [
+      {
+        "question": "What does ✨ mean in texting?",
+        "answer": "✨ means 'this is special' or adds a sparkle of magic to whatever it accompanies. It is the default decoration emoji for bios, captions, and story reposts."
+      },
+      {
+        "question": "What does ✨ mean from a girl?",
+        "answer": "From a girl or anyone else, ✨ is the default 'main character' decoration. There is no gendered meaning; the emoji is about the vibe, not who is sending it."
+      },
+      {
+        "question": "What does ✨ mean on TikTok bios?",
+        "answer": "On TikTok bios ✨ signals polish, intentionality, and 'that girl' aesthetic. Creators stack it around their niche name to imply the account is curated."
+      },
+      {
+        "question": "What does ✨ mean from a guy?",
+        "answer": "From a guy, ✨ has the same meaning it has from anyone else: this moment or post has a hint of magic. The emoji is not gendered and reads as sincere or ironic depending on the surrounding text."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "just got the new apartment ✨",
+      "interpretation": "Friend sharing a soft launch. Mirror with ✨ or 'congrats' to keep the celebration going."
+    },
+    {
+      "setting": "social",
+      "message": "✨ same ✨",
+      "interpretation": "Group chat agreement on a shared aesthetic. Mirror with ✨ or 'mood' to match the energy."
+    },
+    {
+      "setting": "dating",
+      "message": "you look amazing tonight ✨",
+      "interpretation": "Romantic compliment with a sparkle of polish. Mirror with ✨ or a follow-up sentence about the look."
+    },
+    {
+      "setting": "family",
+      "message": "first day at the new job ✨",
+      "interpretation": "Family milestone share. Mirror with ✨ or 'so proud' to acknowledge the moment."
+    },
+    {
+      "setting": "work",
+      "message": "shipped the new feature ✨",
+      "interpretation": "Risky in a wide team channel; safe in a tight collaborator DM. If used in a team channel, anchor the message with a sentence that adds context."
+    }
+  ]
 }

--- a/src/data/emojis/star.json
+++ b/src/data/emojis/star.json
@@ -36,9 +36,22 @@
     }
   ],
   "platformNotes": [
-    { "platform": "TWITTER", "note": "Shows appreciation or ratings." },
-    { "platform": "INSTAGRAM", "note": "Used in reviews and highlights." },
-    { "platform": "TIKTOK", "note": "Rating content." }
+    {
+      "platform": "TWITTER",
+      "note": "Used for ratings, excellence reactions, and celebrity tagging shorthand."
+    },
+    {
+      "platform": "INSTAGRAM",
+      "note": "Common in review-style captions and story highlights."
+    },
+    {
+      "platform": "TIKTOK",
+      "note": "Pasted on viral hits as the visual rating for standout content."
+    },
+    {
+      "platform": "DISCORD",
+      "note": "Server members use it as the visual tag for standout moments and pinned announcements."
+    }
   ],
   "generationalNotes": [
     { "generation": "GEN_Z", "note": "Ratings and excellence." },
@@ -48,5 +61,58 @@
   "warnings": [],
   "relatedCombos": [],
   "seoTitle": "⭐ Star Emoji Meaning",
-  "seoDescription": "Learn what the Star emoji ⭐ really means."
+  "seoDescription": "Learn what the Star emoji ⭐ really means.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "⭐ is the universal excellence emoji, the one that marks something as elevated above the average. The yellow star shape has carried excellence meaning for so long that the emoji has stretched past its literal celestial roots into a general 'this is top quality' signal. On Instagram, TikTok, and Twitter ⭐ shows up on review posts, ratings, hit reactions, and the closing of a creator's signature moments. The emoji also doubles as the universal rating symbol — five stars on Google, ⭐⭐⭐⭐⭐ in a Twitter quote-tweet, or a single ⭐ on a friend's accomplishment.\n\nThe reading has very little drift across age groups. Older users see the rating; younger users see the excellence. Both interpretations land on the same beat: this is notable. Writers should reach for ⭐ when the moment genuinely warrants the excellence mark, because stacking stars on every message begins to undercut the rare approval the emoji is built to deliver.",
+    "howPeopleUseIt": "⭐ arrives as a stand-alone reaction, a sentence closer on a compliment, or pasted on a review-style post. On Instagram captions the emoji lands as the closing flourish on a five-star rating for a product, restaurant, or experience. On Twitter quote-tweets it functions as the 'this is gold' reaction to a take that hit. On TikTok creators paste ⭐ on viral videos as the rating shorthand for the content they think deserves the recognition.\n\nThe emoji also pairs naturally with 🌟 (glowing star) for layered excellence, with 💯 for the '100/100' validation, and with other rating emoji like 🔥 for the hot take. Stand-alone ⭐ reads as excellent; in a stack it leans performative.",
+    "whenNotToUse": "Skip ⭐ in contexts where the praise would feel unearned — on a friend's first attempt at something, in a harsh feedback situation, or where genuine critique is needed. A ⭐ on a project that still needs work sends the wrong message about the bar. Avoid it in workplace feedback channels where the rating emoji will read as condescending rather than supportive.\n\nAlso avoid ⭐ when sarcasm is the dominant reading. The irony note ('gold star for you ⭐') is real but only lands when the audience knows the sender well. In a new channel the sarcasm may be lost and the emoji will register as sincere.",
+    "howToReply": "Mirror ⭐ with another ⭐ or 🌟 if you want to keep the excellence going, or upgrade to 💯 for the 'this is perfect' validation. If you receive ⭐ on your own content, reply with 'thanks ⭐' or a sentence that acknowledges the rating.\n\nIf ⭐ arrives on a friend's accomplishment, mirror with a sentence that names what specifically earned the star. And if you want to send ⭐ as a soft compliment, anchor the emoji with a sentence so the rating does not feel generic.",
+    "faqs": [
+      {
+        "question": "What does ⭐ mean in texting?",
+        "answer": "⭐ means 'excellent' or 'top quality.' The emoji marks the moment as elevated above the average and reads as either a rating or a genuine 'this is gold' reaction."
+      },
+      {
+        "question": "What does ⭐ mean from a girl?",
+        "answer": "From a girl or anyone else, ⭐ means the sender rates the content as excellent. There is no gendered meaning; the emoji is about the rating, not who is sending it."
+      },
+      {
+        "question": "Is ⭐ flirty?",
+        "answer": "⭐ is not flirty. It marks excellence or appreciation, with no romantic undercurrent. Using it on a romantic post will read as supportive rather than flirtatious."
+      },
+      {
+        "question": "What does ⭐ mean from a guy?",
+        "answer": "From a guy, ⭐ has the same meaning it has from anyone else: excellence or strong rating. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "social",
+      "message": "5 stars ⭐⭐⭐⭐⭐ no notes",
+      "interpretation": "Public review-style reaction. Mirror with ⭐ or a sentence that expands on the rating."
+    },
+    {
+      "setting": "friends",
+      "message": "you crushed that presentation ⭐",
+      "interpretation": "Friend complimenting a work win. Mirror with ⭐ or 'great work' to acknowledge the moment."
+    },
+    {
+      "setting": "work",
+      "message": "this commit is clean ⭐",
+      "interpretation": "Team approval in a tight channel. Mirror with ⭐ or a sentence that names the fix."
+    },
+    {
+      "setting": "dating",
+      "message": "this date is a 10 ⭐",
+      "interpretation": "Romantic partner's strong approval. Mirror with a heart or a sentence that engages with the date."
+    },
+    {
+      "setting": "family",
+      "message": "the meal was ⭐⭐⭐⭐⭐",
+      "interpretation": "Family praise for a cook. Mirror with ⭐ or a sentence that appreciates the work."
+    }
+  ]
 }

--- a/src/data/emojis/sunglasses.json
+++ b/src/data/emojis/sunglasses.json
@@ -31,9 +31,22 @@
     }
   ],
   "platformNotes": [
-    { "platform": "TWITTER", "note": "Common usage." },
-    { "platform": "INSTAGRAM", "note": "Popular posts." },
-    { "platform": "TIKTOK", "note": "Trending." }
+    {
+      "platform": "TWITTER",
+      "note": "Twitter quote-tweets lean on 🕶️ as the universal 'cool, did not see that coming' reaction; pairs naturally with bold takes."
+    },
+    {
+      "platform": "INSTAGRAM",
+      "note": "Instagram captions stack 🕶️ on outfit-of-the-day posts and travel shots as the confidence shorthand for feeling good."
+    },
+    {
+      "platform": "TIKTOK",
+      "note": "TikTok creators paste 🕶️ onto GRWM videos and confidence edits; the emoji marks the moment the look comes together."
+    },
+    {
+      "platform": "DISCORD",
+      "note": "Discord servers use 🕶️ as a reaction to a take that lands with quiet confidence, the visual equivalent of a slow nod."
+    }
   ],
   "generationalNotes": [
     { "generation": "GEN_Z", "note": "Gen Z usage." },
@@ -43,5 +56,58 @@
   "warnings": [],
   "relatedCombos": [],
   "seoTitle": "🕶️ Sunglasses Emoji Meaning",
-  "seoDescription": "Learn what the Sunglasses emoji 🕶️ really means."
+  "seoDescription": "Learn what the Sunglasses emoji 🕶️ really means.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "🕶️ is the cool emoji, the one that says 'this moment is unbothered and I am wearing the look for it.' On Instagram and TikTok 🕶️ is the standard confidence shorthand — pasted on outfit-of-the-day posts, travel shots, GRWM reveals, and any moment the creator wants to mark as effortlessly stylish. The shades emoji also works as a reaction, the visual equivalent of a slow nod at a take that lands. Twitter quote-tweets use 🕶️ to mark a bold statement as worth watching without typing a word.\n\n🕶️ has stayed cool across age groups because the meaning has not drifted. It is not slang, it is not ironic by default, and it never reads as passive-aggressive. It is the cleanest way to say 'this is cool' or 'I am feeling myself,' and writers should reach for it whenever the moment calls for unbothered confidence rather than loud hype.",
+    "howPeopleUseIt": "🕶️ shows up as a stand-alone reaction, a sentence closer on a confidence statement, or pasted on a selfie as the emoji that says 'I look good and I know it.' On Instagram captions the emoji often lands at the end of a fit pic or travel post as the signature flourish. On Twitter quote-tweets it functions as a quiet 'noted, well played' reaction. And on TikTok creators paste 🕶️ onto their own videos as the moment a look comes together — the GRWM reveal, the final pose, the swagger cut.\n\nThe emoji also pairs naturally with fire (🕶️🔥) for confident hype, with 💯 for full validation, and with 😎 when the cool face is doing the same work and you want to double down on the energy. Stand-alone 🕶️ reads as confident; in a stack it leans performative.",
+    "whenNotToUse": "Skip 🕶️ in contexts where the cool reading would feel mismatched — in condolences, in serious professional channels, or in customer complaint replies. A 🕶️ in a customer-facing complaint thread sounds like you are enjoying the drama. Avoid it in any thread where the recipient needs empathy rather than swagger.\n\nAlso avoid 🕶️ when you actually want to acknowledge a hard moment with sincerity. The emoji always reads cool, so a friend sharing bad news will not feel supported if you reply with 🕶️. Reach for a heart or a plain sentence when the moment warrants sympathy.",
+    "howToReply": "Mirror 🕶️ with another 🕶️ if you want to keep the cool energy, or upgrade to 🔥 for hype or 💯 for full validation. If you receive 🕶️ on your own post, treat it as a confidence compliment and reply with 'thanks 🕶️' or a sentence that acknowledges the cool factor.\n\nIf 🕶️ arrives on a friend's bold take, lean into the vibe with a follow-up sentence that matches the swagger. And if you want to send 🕶️ in a personal chat as a flirty confidence signal, pair it with a sentence that lands the cool without sounding aloof.",
+    "faqs": [
+      {
+        "question": "What does 🕶️ mean in texting?",
+        "answer": "🕶️ means 'cool' or 'feeling myself.' It is the standard confidence emoji for outfit posts, travel shots, and any moment that warrants unbothered swagger."
+      },
+      {
+        "question": "What does 🕶️ mean from a girl?",
+        "answer": "From a girl or anyone else, 🕶️ means the sender feels confident or cool. There is no gendered meaning; the emoji is about the vibe, not who is sending it."
+      },
+      {
+        "question": "What does 🕶️ mean on Instagram?",
+        "answer": "On Instagram 🕶️ is the standard confidence emoji for fit pics, travel posts, and GRWM reveals. Creators paste it on captions to mark the moment as effortlessly stylish."
+      },
+      {
+        "question": "What does 🕶️ mean from a guy?",
+        "answer": "From a guy, 🕶️ has the same meaning it has from anyone else: cool, confident, unbothered. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "social",
+      "message": "outfit came together today 🕶️",
+      "interpretation": "Friend posting a fit pic. Mirror with 🕶️ or 'looking good' to engage."
+    },
+    {
+      "setting": "friends",
+      "message": "i did not even need to argue that point 🕶️",
+      "interpretation": "Friend bragging about a clean win. Mirror with 🕶️ or 🔥 to match the swagger."
+    },
+    {
+      "setting": "dating",
+      "message": "date went well 🕶️",
+      "interpretation": "Romantic confidence post-date. Reply with a follow-up question or a softer reaction to draw out details."
+    },
+    {
+      "setting": "family",
+      "message": "i told mom exactly what i thought 🕶️",
+      "interpretation": "Family group flex about setting a boundary. Mirror with 🕶️ or 'iconic' to match the energy."
+    },
+    {
+      "setting": "work",
+      "message": "we closed the deal 🕶️",
+      "interpretation": "Team win in a tight channel. Mirror with 🕶️ or 'great work' to acknowledge the team."
+    }
+  ]
 }

--- a/src/data/emojis/thinking.json
+++ b/src/data/emojis/thinking.json
@@ -38,15 +38,19 @@
   "platformNotes": [
     {
       "platform": "TWITTER",
-      "note": "Often used to express skepticism about news or claims."
+      "note": "Twitter quote-tweets lean on 🤔 as a subtle signal that the sender does not buy the original take; the eyebrow does the arguing."
     },
     {
       "platform": "DISCORD",
-      "note": "Common reaction emoji for when something seems suspicious."
+      "note": "Discord treats 🤔 as a 'this looks suspicious' reaction; moderators and regulars use it when a story has holes."
     },
     {
       "platform": "SLACK",
-      "note": "Generally safe for work - shows genuine contemplation."
+      "note": "Slack reads 🤔 as safe workplace skepticism; it is the cleanest way to question a proposal without typing out the doubt."
+    },
+    {
+      "platform": "TIKTOK",
+      "note": "TikTok comments use 🤔 when a creator's story feels off; the emoji has become shorthand for 'I am calling cap.'"
     }
   ],
   "generationalNotes": [
@@ -72,5 +76,58 @@
   ],
   "relatedCombos": ["thinking-skeptical"],
   "seoTitle": "🤔 Thinking Face Emoji Meaning - What Does 🤔 Really Mean?",
-  "seoDescription": "Learn what the thinking emoji 🤔 really means in modern texting. Shows contemplation or skepticism. Complete context guide for all platforms."
+  "seoDescription": "Learn what the thinking emoji 🤔 really means in modern texting. Shows contemplation or skepticism. Complete context guide for all platforms.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "🤔 is the emoji that pretends to think while actually judging. The face shows a finger on the chin and a raised eyebrow — visual cues that lean toward skepticism as much as curiosity, which is why the same emoji can read as genuine pondering, polite doubt, or full-on passive-aggressive shade depending on the sentence it lands in. On Twitter, Discord, and TikTok 🤔 has become a clean shorthand for 'I do not buy that,' sent in response to a take that seems off, an excuse that does not quite add up, or a claim that needs receipts.\n\nThe reason 🤔 works so well is that it lets the sender register doubt without writing a paragraph. A lone 🤔 in reply to a friend's story communicates 'this has holes' without forcing the sender to spell out why. In work channels it functions as a polite way to question a proposal — 'we should ship Friday 🤔' is a much softer pushback than 'I disagree with the timeline.' Writers should treat 🤔 as a default skeptical emoji and avoid it in contexts where doubt could be misread as shaming the other person's intelligence.",
+    "howPeopleUseIt": "🤔 shows up as a stand-alone reaction, a sentence closer on a question, or as the punchline on an obviously sarcastic 'I wonder why' line. On Twitter quote-tweets the emoji is the classic 'I do not buy this' signal. On Discord it works as a reaction button when a story seems suspicious. In work tools it is the lowest-friction way to flag a question without turning the thread into a debate.\n\nThe emoji also pairs naturally with other reactions: 🤔👀 reads as 'I am suspicious and watching,' 🤔💯 reads as 'I am considering it and one hundred percent on board,' and 🤔😅 reads as 'I have questions but I am going to let it slide.' It is rare to see 🤔 used sincerely as 'I am contemplating the meaning of life'; the more common read is 'I have follow-up questions about what you just said.'",
+    "whenNotToUse": "Skip 🤔 in any context where doubt could be misread as shaming the other person. A manager who replies 'interesting proposal 🤔' will read as condescending, and a friend who replies 'sure you were 🤔' will read as accusatory. Avoid it in customer-facing comms where the customer needs confidence — 'we are looking into it 🤔' sounds as if you are not convinced their problem is real.\n\nAlso avoid stacking 🤔 on a sincere question. 'Can you send the file? 🤔' reads as 'I am skeptical you will actually send it,' which is not the tone you want when you actually need the file. Reach for a different emoji or just the question mark for genuine requests.",
+    "howToReply": "Mirror 🤔 with another 🤔 if you want to keep the doubt going, or pivot to a sentence that addresses the suspicion directly. If you receive 🤔 on a take you shared and it feels like shade, you can ask 'what do you mean 🤔' to draw out the actual question. If the 🤔 is genuine curiosity, answer it with a sentence so the thread moves forward.\n\nWhen 🤔 arrives in a work channel as a polite flag, treat it as a question you should answer in writing. A 'good question, here's the context' reply defuses the doubt and turns the emoji into productive conversation.",
+    "faqs": [
+      {
+        "question": "Is 🤔 passive-aggressive?",
+        "answer": "🤔 can read as passive-aggressive when it lands in response to an excuse, a story, or a take that the sender does not buy. It is the most common emoji for polite shade."
+      },
+      {
+        "question": "What does 🤔 mean from a girl?",
+        "answer": "From a girl or anyone else, 🤔 means the sender has questions about what was said. There is no gendered meaning; the emoji is about doubt or curiosity."
+      },
+      {
+        "question": "What does 🤔 mean on Twitter?",
+        "answer": "On Twitter 🤔 is the default 'I do not buy this' reaction. Quote-tweets use it to flag suspicious claims, excuses, or takes without typing out the doubt."
+      },
+      {
+        "question": "What does 🤔 mean from a guy?",
+        "answer": "From a guy, 🤔 has the same meaning it has from anyone else: skepticism or curiosity. The reading is driven by context, not by who is sending it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "work",
+      "message": "we should ship Friday 🤔",
+      "interpretation": "Polite flag of a timeline concern. Address with a sentence that explains the trade-offs so the doubt resolves."
+    },
+    {
+      "setting": "social",
+      "message": "and that's how I made $5000 in a day 🤔",
+      "interpretation": "Group chat skepticism at a flex. Reply with another 🤔 or a sentence that calls out the cap."
+    },
+    {
+      "setting": "friends",
+      "message": "I definitely didn't eat the leftover pizza 🤔",
+      "interpretation": "Friend joking about lying. Mirror with 🤔 or 'sure buddy' to keep the bit going."
+    },
+    {
+      "setting": "dating",
+      "message": "we should hang out sometime 🤔",
+      "interpretation": "Could be sincere or ambiguous. Clarify with a specific day or a follow-up sentence to commit."
+    },
+    {
+      "setting": "family",
+      "message": "Grandma is 'definitely fine' on her own 🤔",
+      "interpretation": "Family group concern. Reply with a sentence about checking in or a heart emoji to acknowledge the worry."
+    }
+  ]
 }

--- a/src/data/emojis/thumbs-up.json
+++ b/src/data/emojis/thumbs-up.json
@@ -38,15 +38,19 @@
   "platformNotes": [
     {
       "platform": "SLACK",
-      "note": "Common reaction emoji - generally seen as professional and appropriate."
+      "note": "Slack reaction thumbs are a workplace default — they confirm receipt without breaking flow, and are not read as passive-aggressive in this context."
     },
     {
       "platform": "IMESSAGE",
-      "note": "May feel cold or dismissive to younger recipients, especially in personal conversations."
+      "note": "In iMessage threads with younger contacts, a single 👍 often lands as cold or dismissive, especially as a one-word reply to a longer message."
     },
     {
       "platform": "DISCORD",
-      "note": "Commonly used as a reaction, less likely to be read as passive-aggressive."
+      "note": "Discord treats 👍 as a normal reaction button, but Gen Z moderators still use it ironically to shut down bad takes in chat."
+    },
+    {
+      "platform": "WHATSAPP",
+      "note": "WhatsApp status replies with 👍 come across as flat engagement; younger family groups prefer ❤️ or 🔥 to show real reaction."
     }
   ],
   "generationalNotes": [
@@ -79,5 +83,58 @@
     "thumbs-up-medium",
     "thumbs-up-medium-dark",
     "thumbs-up-dark"
+  ],
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "The 👍 thumbs-up emoji is one of the most overloaded emojis in modern texting, and its meaning hinges almost entirely on the relationship between sender and recipient. In workplace chat tools like Slack, Teams, and email, 👍 is the universal 'got it' — quick, neutral, and a low-friction way to acknowledge a message without typing a full reply. Outside of work, however, Gen Z treats a stand-alone 👍 as dismissive, passive-aggressive, or even hostile. It has been meme-d as the most passive-aggressive emoji of the 2020s because it lets the sender register acknowledgment without contributing any actual warmth.\n\nThe split is mostly generational and contextual. Boomers and Gen X use 👍 as a clean approval sign the same way they always have. Millennials use it in work channels and wince at it in personal ones. Gen Z generally avoid it in personal conversations because it carries a low-effort, emotionally distant tone that is the opposite of the warmth the moment usually calls for. Knowing the audience is the difference between 👍 landing as polite and 👍 landing as rude. Writers should default to 👍 in professional tools and swap to words, ❤️, or 🙌 when the recipient is younger or the relationship is personal.",
+    "howPeopleUseIt": "👍 functions as a reaction emoji first and a sentence emoji second. In Slack and Teams, hovering over a message and tapping 👍 means 'received, no need to reply,' which is exactly the point. It is the lowest-friction way to close a thread, acknowledge a status update, or confirm you saw the calendar invite without spawning a follow-up conversation. In email, 👍 in a one-liner reply acts as a polite 'approved' on a document or proposal.\n\nIn personal iMessage, WhatsApp, and Instagram DMs, the emoji tends to travel with a longer message — it lives at the end of sentences as a softener, the way a smile works in body language. A stand-alone 👍 as a reply to 'how are you feeling?' will read as cold because the sender could have written a real answer and chose not to. People who want to send genuine approval in personal chats usually reach for 🙌, ❤️, or a specific compliment instead.",
+    "whenNotToUse": "Skip 👍 as a stand-alone reply to emotional disclosures, vents, or vulnerable messages — it reads as a brush-off because the sender 'could have said more.' Avoid using it as the only response to bad news, a relationship update, or a medical result. If you have to reply with a thumbs-up to something serious, add a sentence so the warmth is not lost.\n\nAlso avoid 👍 in customer-facing channels where tone matters: a thumbs-up as the only response to a frustrated customer complaint will read as dismissive even if you intended to acknowledge receipt. Reach for 'Thanks for flagging this, we're on it' instead. The same applies to any platform where you do not control the audience and the audience skews younger — Discord, Twitch chat, and TikTok comments can pile on a sarcastic 👍 that flips the intent.",
+    "howToReply": "If you receive 👍 in a workplace channel, take it at face value: the message landed and there is nothing more to do. Reply with another 👍 or 'thanks' and move on. If you are not sure whether the thumbs-up is genuine, glance at the surrounding context — a long message followed by 👍 is approval, while a one-word 'fine' followed by 👍 is the passive-aggressive tell.\n\nIn a personal chat, if you want to push back on the cold read, you can ask 'just 👍?' and most people will clarify what they meant. If you are the one sending 👍 and you sense the reaction is being misread, add a sentence to anchor the warmth: 'sounds good 👍' lands better than a stand-alone thumbs-up because the words explain the gesture.",
+    "faqs": [
+      {
+        "question": "Is 👍 passive-aggressive?",
+        "answer": "Yes, in personal chats Gen Z frequently reads 👍 as passive-aggressive or dismissive, especially when it arrives alone. In workplace tools like Slack it still reads as neutral acknowledgment because the platform context normalizes it."
+      },
+      {
+        "question": "What does 👍 mean from a girl?",
+        "answer": "From a girl, 👍 has no gendered meaning — it is the same neutral acknowledgment it is from anyone else. In a personal chat the cold read applies equally across genders."
+      },
+      {
+        "question": "What does 👍 mean from a guy?",
+        "answer": "From a guy, 👍 is the standard 'got it' or 'approved' reaction. There is no specific gendered meaning; the issue is context, not who sent it."
+      },
+      {
+        "question": "What does 👍 mean on Slack?",
+        "answer": "On Slack 👍 is the workplace default for 'received, no reply needed.' It is the equivalent of a quick nod in a meeting and rarely reads as passive-aggressive in that context."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "work",
+      "message": "PR is up for review 👍",
+      "interpretation": "Neutral confirmation in a work channel. Mirror with another thumbs-up or 'thanks' to close the thread."
+    },
+    {
+      "setting": "friends",
+      "message": "sorry i can't make it tonight 👍",
+      "interpretation": "Stand-alone 👍 after a polite no reads as dismissive or low-effort. A short 'rain check?' would land warmer."
+    },
+    {
+      "setting": "dating",
+      "message": "had a great time 👍",
+      "interpretation": "Could be sincere but reads as lukewarm. Reply with enthusiasm to test the warmth or move on."
+    },
+    {
+      "setting": "family",
+      "message": "thanks for dinner mom 👍",
+      "interpretation": "Boomer or Gen X recipient will read this as a clean thank-you; Gen Z sibling might tease you for being formal. Safe either way."
+    },
+    {
+      "setting": "social",
+      "message": "ratio + L + 👍",
+      "interpretation": "Twitter pile-on reply; the 👍 is sarcastic and meant to mock. Do not use as a sincere compliment or you will read as out of touch."
+    }
   ]
 }

--- a/src/data/emojis/two-hearts.json
+++ b/src/data/emojis/two-hearts.json
@@ -36,9 +36,18 @@
     }
   ],
   "platformNotes": [
-    { "platform": "TWITTER", "note": "Shows appreciation." },
-    { "platform": "INSTAGRAM", "note": "Popular for couple posts." },
-    { "platform": "TIKTOK", "note": "Cute content." }
+    {
+      "platform": "TWITTER",
+      "note": "Shows up as the cute affection reaction on sweet posts and couple content."
+    },
+    {
+      "platform": "INSTAGRAM",
+      "note": "Popular for couple posts, soft launches, and anniversary captions as a softer alternative."
+    },
+    {
+      "platform": "TIKTOK",
+      "note": "Creators paste it on wholesome edits and couple reveals as the cute signature emoji."
+    }
   ],
   "generationalNotes": [
     { "generation": "GEN_Z", "note": "Cute and soft." },
@@ -48,5 +57,58 @@
   "warnings": [],
   "relatedCombos": [],
   "seoTitle": "💕 Two Hearts Emoji Meaning",
-  "seoDescription": "Learn what the Two Hearts emoji 💕 really means."
+  "seoDescription": "Learn what the Two Hearts emoji 💕 really means.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "💕 is the emoji that signals mutual love, the two pink hearts together carrying the visual cue of two people connected. Compared to the single red heart ❤️ — which reads as deep, serious affection — 💕 reads as lighter, cuter, and more obviously mutual. It is the standard emoji for couple posts, friendship appreciation, and any moment the sender wants to mark as sweet rather than heavy. On Instagram captions and TikTok edits 💕 shows up as the wholesome softer alternative to ❤️.\n\nThe reason 💕 works is that it takes the seriousness out of the heart emoji. A single ❤️ from a partner reads as romantic; 💕 from the same partner reads as playful and sweet. The double-heart pattern also doubles as friendship energy — best-friend posts and team-appreciation captions use 💕 to signal affection without the romantic weight of ❤️. Writers should reach for 💕 when the moment calls for cuteness over intensity, and reserve ❤️ for the deeper romantic beats.",
+    "howPeopleUseIt": "💕 arrives as a stand-alone reaction, a sentence closer on a sweet message, or as the standard couple-post emoji. On Instagram captions 💕 shows up on anniversary posts, soft launches, and engagement announcements as the cuter alternative to ❤️. On TikTok the same pattern repeats in wholesome edits and friendship appreciation videos.\n\nIn group chats 💕 functions as the friendship signal. A friend shares something sweet and you reply with 💕 to mark the moment as warm and platonic. The emoji also pairs naturally with other affection emoji — 💕❤️ for layered affection, 💕✨ for sparkle, and 💕🥰 for maximum sweetness. It is rare to see 💕 used sarcastically; the cuteness is too consistent for ironic readings to land.",
+    "whenNotToUse": "Skip 💕 in contexts where the romantic reading would be inappropriate — in cold work channels, in customer complaint replies, or in first-contact messages where the relationship has not been established. A 💕 in a customer-facing complaint thread sounds as if you are enjoying the drama. Avoid it in formal professional emails where the heart emoji will undercut the seriousness of the message.\n\nAlso avoid 💕 when the moment calls for the heavier single-heart signal. A partner who is going through a hard time may need the deeper ❤️ rather than the lighter 💕, because 💕 can feel mismatched in moments that warrant real weight. Match the emoji to the emotional register of the moment.",
+    "howToReply": "Mirror 💕 with another 💕 if you want to keep the cuteness going, or upgrade to ❤️ for deeper affection or 🥰 for warmth. If you receive 💕 on your own post, treat it as a warm affection signal and reply with 'thanks 💕' or a heart emoji.\n\nIf 💕 lands on a couple post or an anniversary message, mirror with a softer reaction or a follow-up sentence about the relationship. And if you want to send 💕 as a friendship signal, pair it with a sentence that anchors the platonic reading so the cute double-heart does not feel like a romantic escalation.",
+    "faqs": [
+      {
+        "question": "What does 💕 mean in texting?",
+        "answer": "💕 means mutual love or affection. The two hearts read as lighter and cuter than the single red heart, so the emoji works for couples, friendships, and wholesome moments."
+      },
+      {
+        "question": "What does 💕 mean from a girl?",
+        "answer": "From a girl or anyone else, 💕 means the sender feels warm affection. There is no gendered meaning; the emoji is about the cuteness, not who is sending it."
+      },
+      {
+        "question": "Is 💕 flirty?",
+        "answer": "💕 can read as flirty in a dating context, especially paired with romantic content. In friendships it stays in the wholesome cute zone."
+      },
+      {
+        "question": "What does 💕 mean from a guy?",
+        "answer": "From a guy, 💕 has the same meaning it has from anyone else: mutual affection or cuteness. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "dating",
+      "message": "you and me forever 💕",
+      "interpretation": "Romantic partner's commitment line. Mirror with 💕 or a follow-up sweet line to match the energy."
+    },
+    {
+      "setting": "friends",
+      "message": "best friends forever 💕",
+      "interpretation": "Platonic friendship post. Mirror with 💕 or 'love you too' to keep the warmth going."
+    },
+    {
+      "setting": "family",
+      "message": "love you mom and dad 💕",
+      "interpretation": "Family warmth to parents. Mirror with 💕 or 'love you too' to close the loop."
+    },
+    {
+      "setting": "social",
+      "message": "your dog is so cute 💕",
+      "interpretation": "Friendly comment on a creator's content. Mirror with a heart or 'thanks' to engage."
+    },
+    {
+      "setting": "work",
+      "message": "best team ever 💕",
+      "interpretation": "Risky in a wide team channel; safe in a tight collaborator DM. If used in a team channel, anchor with a sentence that adds context."
+    }
+  ]
 }

--- a/src/data/emojis/unamused.json
+++ b/src/data/emojis/unamused.json
@@ -42,11 +42,15 @@
     },
     {
       "platform": "IMESSAGE",
-      "note": "Clearly communicates displeasure - can escalate conversations."
+      "note": "Clearly communicates displeasure; can escalate conversations."
     },
     {
       "platform": "SLACK",
       "note": "Generally too negative for professional communication."
+    },
+    {
+      "platform": "DISCORD",
+      "note": "Server members use it as the 'not impressed' reaction."
     }
   ],
   "generationalNotes": [
@@ -72,5 +76,58 @@
   ],
   "relatedCombos": ["unamused-sigh"],
   "seoTitle": "😒 Unamused Face Emoji Meaning - What Does 😒 Really Mean?",
-  "seoDescription": "Learn what the unamused emoji 😒 really means in modern texting. Shows displeasure, skepticism, or 'not impressed'. Complete context guide."
+  "seoDescription": "Learn what the unamused emoji 😒 really means in modern texting. Shows displeasure, skepticism, or 'not impressed'. Complete context guide.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "😒 is the 'not impressed' emoji, the one that lands as clear skepticism without the loud contempt of 🙄. The face shows slightly raised eyebrows, a frown, and eyes looking to the side — a combination that reads as silent disapproval rather than outright dismissal. On Twitter, iMessage, and Discord 😒 shows up as the underwhelmed reaction to a take that did not deliver, a surprise that was not surprising, or a moment that warranted a reaction but only barely. The emoji is the chill alternative to the more aggressive 🙄, and the slight passive-aggressive tone keeps it on the safer side of the negative-reaction spectrum.\n\nThe emoji also doubles as the standard skeptical reaction. A friend shares a claim that does not hold up and the appropriate reply is 😒 — the visual tag for 'I am not buying this, but I am not going to fight about it either.' The dual reading — underwhelmed or skeptical — lands on the same beat: this is not convincing. Use 😒 when the moment calls for unimpressed energy without the explicit contempt.",
+    "howPeopleUseIt": "😒 arrives as the reaction to an underwhelming reveal, the silent disapproval on a friend's bad take, or the punchline on a situation that did not deliver. On Twitter it functions as the standard 'not impressed' reaction to a public statement that missed the mark. On iMessage it lands as the direct reply to a friend who is being extra — the clear signal that the sender is not buying it.\n\nIn group chats 😒 works as the shared skepticism reaction when a friend shares a claim that needs to be questioned. The emoji pairs naturally with 🙄 for the more aggressive eye-roll, with 🤨 for the raised-eyebrow skepticism, and with a sentence that names the doubt so the unimpressed face does not feel performative.",
+    "whenNotToUse": "Skip 😒 in contexts where the unimpressed reading will cause damage — in workplace feedback, in customer-facing comms, or in serious personal conversations. A 😒 on a coworker's idea will read as hostile. Avoid it on a friend's vulnerable post; the skepticism will land wrong.\n\nAlso avoid 😒 when the conversation warrants care or empathy. A partner going through a hard time needs warmth, not unimpressed energy. Reach for a softer reaction or a sentence that engages with the actual emotional weight.",
+    "howToReply": "Mirror 😒 with another 😒 or 🤨 if you want to keep the skeptical energy going, or upgrade to a softer reaction if the conversation warrants care. If you receive 😒 as a reaction to your own take, treat it as a signal that the content did not land and consider whether to clarify or let it go.\n\nIf 😒 arrives on a friend's shared skepticism, mirror with a sentence that engages with the actual issue. And if you want to send 😒 as a meta-reaction to something underwhelming, anchor the emoji with a sentence that names what failed to deliver so the unamused face does not feel pointed.",
+    "faqs": [
+      {
+        "question": "What does 😒 mean in texting?",
+        "answer": "😒 means 'I am not impressed' or 'I am skeptical.' The unamused face signals clear displeasure or underwhelm without the loud contempt of the eye-roll emoji."
+      },
+      {
+        "question": "What does 😒 mean from a girl?",
+        "answer": "From a girl or anyone else, 😒 means the sender is unimpressed or skeptical. There is no gendered meaning; the emoji is about the underwhelm, not who is sending it."
+      },
+      {
+        "question": "Is 😒 rude?",
+        "answer": "😒 can read as rude, especially in workplace or vulnerable contexts. The displeasure is unambiguous, so use it carefully to avoid escalating conflicts."
+      },
+      {
+        "question": "What does 😒 mean from a guy?",
+        "answer": "From a guy, 😒 has the same meaning it has from anyone else: clear displeasure or skepticism. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "that is the big surprise? 😒",
+      "interpretation": "Friend expressing skepticism. Mirror with 😒 or a sentence that engages with the doubt."
+    },
+    {
+      "setting": "social",
+      "message": "she said 'we need to talk' and then texted the recipe 😒",
+      "interpretation": "Public reaction to a misleading buildup. Mirror with 😒 or a sentence that adds to the joke."
+    },
+    {
+      "setting": "work",
+      "message": "the 'urgent' ticket was a typo 😒",
+      "interpretation": "Risky in a wide team channel; safe in a tight collaborator DM. If used in a team channel, anchor with a sentence that adds context."
+    },
+    {
+      "setting": "dating",
+      "message": "sure, you 'forgot' again 😒",
+      "interpretation": "Partner's skeptical reaction. Mirror with a softer reaction or a sentence that addresses the doubt."
+    },
+    {
+      "setting": "family",
+      "message": "dad's 'emergency' was a missing remote 😒",
+      "interpretation": "Family group laughter at a relative's anticlimax. Mirror with 😒 or a sentence that engages with the humor."
+    }
+  ]
 }

--- a/src/data/emojis/victory-hand.json
+++ b/src/data/emojis/victory-hand.json
@@ -38,15 +38,19 @@
   "platformNotes": [
     {
       "platform": "INSTAGRAM",
-      "note": "Classic selfie pose emoji."
+      "note": "Classic selfie pose emoji on casual posts and stories."
     },
     {
       "platform": "TWITTER",
-      "note": "Common for casual goodbyes and peace."
+      "note": "Common for casual goodbyes and peace-sign closers."
     },
     {
       "platform": "TIKTOK",
-      "note": "Popular in selfie and exit content."
+      "note": "Popular in selfie and exit-content videos."
+    },
+    {
+      "platform": "IMESSAGE",
+      "note": "Standard casual goodbye reaction between friends."
     }
   ],
   "generationalNotes": [
@@ -73,5 +77,58 @@
     "victory-hand-medium",
     "victory-hand-medium-dark",
     "victory-hand-dark"
+  ],
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "✌️ is the universal peace sign emoji, the index-and-middle-fingers V that signals peace, victory, casual goodbye, or selfie pose. The hand gesture has carried the peace meaning for so long across cultures that the emoji lands with the same simplicity. On Instagram, Twitter, and TikTok ✌️ shows up as the standard selfie pose, the casual goodbye closer, and the visual tag for chill vibes. The emoji is one of the cleanest positive-casual signals on the keyboard because the meaning is unambiguous — peace, win, or simply leaving.\n\nThe emoji also doubles as the casual-goodbye reaction. A friend says 'see you tomorrow' and the appropriate reply is ✌️ — the visual tag for 'all good, peace out.' The dual reading — selfie pose or casual goodbye — keeps ✌️ versatile without diluting the chill vibe. Use ✌️ when the moment calls for the peace-sign energy, not as a default reaction to every minor farewell.",
+    "howPeopleUseIt": "✌️ arrives as the selfie pose on a casual post, the goodbye closer on a friend's message, or the punchline on a vibe-signaling story. On Instagram the emoji lands as the standard selfie pose on a cap or fit pic. On Twitter it functions as the casual goodbye reaction to a public conversation. On TikTok creators pair ✌️ with the peace-pose opener as the visual tag for the vibe.\n\nIn group chats ✌️ works as the shared 'I am out of here' reaction when a friend signs off. The emoji also pairs naturally with 🤙 for the hang-loose sibling, with 🌴 for the chill-aesthetic, and with a sentence that names what is being signed off from so the peace does not feel generic.",
+    "whenNotToUse": "Skip ✌️ in contexts where the peace sign will land wrong — in countries where the gesture has a different meaning (it can be offensive in some parts of the world), in serious professional channels, or in customer complaint replies. A ✌️ in a customer complaint reply will sound tone deaf. Avoid it in conversations where the recipient needs more than a casual goodbye.\n\nAlso avoid ✌️ when the situation actually warrants a stronger goodbye. The peace sign is the chill version of leaving, so a ✌️ on a meaningful farewell will feel underweighted. Reach for a heart or a sentence for the moments that warrant weight.",
+    "howToReply": "Mirror ✌️ with another ✌️ or 🤙 if you want to keep the chill vibe going, or upgrade to a heart for a warmer goodbye. If you receive ✌️ on a selfie, reply with a heart or a sentence that acknowledges the look.\n\nIf ✌️ arrives as a casual goodbye, mirror with the same or a sentence that closes the loop. And if you want to send ✌️ as a chill vibe sign, anchor the emoji with a sentence that names the moment so the peace does not feel generic.",
+    "faqs": [
+      {
+        "question": "What does ✌️ mean in texting?",
+        "answer": "✌️ means 'peace' or 'see ya.' The victory hand emoji is the universal peace sign and reads as selfie pose, casual goodbye, or chill vibe signal depending on context."
+      },
+      {
+        "question": "What does ✌️ mean from a girl?",
+        "answer": "From a girl or anyone else, ✌️ means the sender is sending peace or casually saying goodbye. There is no gendered meaning; the emoji is about the vibe, not who is sending it."
+      },
+      {
+        "question": "Is ✌️ flirty?",
+        "answer": "✌️ can read as flirty in a dating context, especially when paired with a selfie. In other contexts it stays in the casual peace-sign zone."
+      },
+      {
+        "question": "What does ✌️ mean from a guy?",
+        "answer": "From a guy, ✌️ has the same meaning it has from anyone else: peace, victory, or casual goodbye. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "see ya tomorrow ✌️",
+      "interpretation": "Friend's casual goodbye. Mirror with ✌️ or a heart to close the loop warmly."
+    },
+    {
+      "setting": "social",
+      "message": "cap photo ✌️",
+      "interpretation": "Public selfie pose. Mirror with a heart or a sentence that engages with the look."
+    },
+    {
+      "setting": "dating",
+      "message": "great date ✌️",
+      "interpretation": "Romantic partner's casual sign-off. Mirror with a heart or a sentence that engages with the date."
+    },
+    {
+      "setting": "family",
+      "message": "bye mom ✌️",
+      "interpretation": "Family casual goodbye. Mirror with ❤️ or a sentence that closes the loop."
+    },
+    {
+      "setting": "work",
+      "message": "wrapping up for the day ✌️",
+      "interpretation": "Team sign-off in a tight channel. Mirror with ✌️ or a sentence that acknowledges the wrap."
+    }
   ]
 }

--- a/src/data/emojis/weary.json
+++ b/src/data/emojis/weary.json
@@ -38,7 +38,7 @@
   "platformNotes": [
     {
       "platform": "TIKTOK",
-      "note": "Common for expressing being overwhelmed by something (good or bad)."
+      "note": "Common for expressing being overwhelmed by a situation, good or bad."
     },
     {
       "platform": "TWITTER",
@@ -46,7 +46,11 @@
     },
     {
       "platform": "INSTAGRAM",
-      "note": "Often used to express yearning or being overwhelmed."
+      "note": "Often used to express yearning or being overwhelmed with feeling."
+    },
+    {
+      "platform": "DISCORD",
+      "note": "Group chat reaction to a long-day share or a relatable complaint."
     }
   ],
   "generationalNotes": [
@@ -66,5 +70,58 @@
   "warnings": [],
   "relatedCombos": ["weary-tired"],
   "seoTitle": "😩 Weary Face Emoji Meaning - What Does 😩 Really Mean?",
-  "seoDescription": "Learn what the weary emoji 😩 really means in modern texting. The 'I can't even' emoji for exhaustion or dramatic distress. Complete context guide."
+  "seoDescription": "Learn what the weary emoji 😩 really means in modern texting. The 'I can't even' emoji for exhaustion or dramatic distress. Complete context guide.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "😩 is the 'I cannot even' emoji, the weary face with closed eyes and an open frown that signals overwhelming exhaustion, dramatic distress, or intense longing. The visual cue — closed eyes, raised eyebrows, frown — is the most direct 'I am done' expression in the Unicode face set. On Twitter, TikTok, and Instagram 😩 shows up as the dramatic reaction to a long day, the playful closer on a relatable complaint, and the flirty 'I miss you so much' message on a romantic post. The emoji is interesting because it spans three genuinely different uses — exhaustion, dramatic distress, and romantic longing — all of which land on the same overwhelmed beat.\n\nThe emoji also doubles as the 'I cannot even' marker for moments that are too much to handle. Compared to the more aggressive 🤬 or the more neutral 😔, 😩 sits in the dramatic-but-warm corner of the negative-reaction spectrum. The dual reading — actual exhaustion or playful flare — keeps 😩 versatile without diluting the overwhelm. Use 😩 when the moment genuinely warrants the dramatic beat, not as a default reaction to a minor inconvenience.",
+    "howPeopleUseIt": "😩 arrives as the relatable Monday reaction, the dramatic closer on a friend's hard-day share, or the punchline on a flirty missing-you message. On Twitter it functions as the standard 'I cannot even' reaction to a tired complaint. On TikTok creators paste 😩 on relatable content as the visual tag for the overwhelmed moment. On Instagram captions the emoji lands as the signature flourish on a yearning post or a romantic-miss-you share.\n\nIn dating-app conversations 😩 works as the flirty longing reaction — 'miss you so much 😩' or 'wish you were here 😩' — that pushes the romantic tone. The emoji also pairs naturally with 😭 for the crying variant, with 💔 for the dramatic loss, and with a sentence that names what is overwhelming so the weary does not feel performative.",
+    "whenNotToUse": "Skip 😩 in contexts where the dramatic reading will land wrong — in serious professional feedback, in customer complaint threads, or in conversations where the recipient needs sincere empathy. A 😩 in a customer complaint reply sounds tone deaf. Avoid it in actual moments of grief where the recipient needs warmth, not performative distress.\n\nAlso avoid 😩 when the situation is genuinely concerning and the user needs support. A friend in a real crisis needs a sentence and a heart, not a dramatic 😩. Use the emoji for the relatable cases where the overwhelm is the energy.",
+    "howToReply": "Mirror 😩 with another 😩 or 😭 if you want to keep the overwhelm going, or upgrade to a softer reaction if the conversation warrants care. If you receive 😩 on a hard-day share, reply with a sentence that acknowledges the weight.\n\nIf 😩 arrives as a flirty longing message, mirror with a heart or a sentence that engages with the romantic energy. And if you want to send 😩 as a relatable complaint, anchor the emoji with a sentence that names what was so overwhelming so the weary does not feel performative.",
+    "faqs": [
+      {
+        "question": "What does 😩 mean in texting?",
+        "answer": "😩 means 'I cannot even' or 'overwhelmed.' The weary face signals exhausting distress, dramatic frustration, or romantic longing depending on the context and the relationship."
+      },
+      {
+        "question": "What does 😩 mean from a girl?",
+        "answer": "From a girl or anyone else, 😩 means the sender is overwhelmed or dramatically longing. There is no gendered meaning; the emoji is about the feeling, not who is sending it."
+      },
+      {
+        "question": "Is 😩 flirty?",
+        "answer": "😩 can read as flirty in a dating context, especially paired with a romantic-miss-you message. In other contexts it stays in the overwhelmed or dramatic zone."
+      },
+      {
+        "question": "What does 😩 mean from a guy?",
+        "answer": "From a guy, 😩 has the same meaning it has from anyone else: exhaustion or dramatic distress. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "friends",
+      "message": "monday already 😩",
+      "interpretation": "Friend's relatable Monday reaction. Mirror with 😩 or a sentence that engages with the complaint."
+    },
+    {
+      "setting": "social",
+      "message": "they are out of my coffee order 😩",
+      "interpretation": "Public dramatic reaction. Mirror with 😩 or a sentence that adds to the moment."
+    },
+    {
+      "setting": "dating",
+      "message": "miss you so much 😩",
+      "interpretation": "Romantic partner's longing message. Mirror with a heart or a sentence that engages with the miss."
+    },
+    {
+      "setting": "family",
+      "message": "long day at work 😩",
+      "interpretation": "Family share of a hard day. Mirror with a heart or a sentence that acknowledges the load."
+    },
+    {
+      "setting": "work",
+      "message": "the deploy went sideways 😩",
+      "interpretation": "Team overwhelm in a tight channel. Mirror with a softer reaction or a sentence that addresses the issue."
+    }
+  ]
 }

--- a/src/data/emojis/winking-face.json
+++ b/src/data/emojis/winking-face.json
@@ -38,15 +38,19 @@
   "platformNotes": [
     {
       "platform": "IMESSAGE",
-      "note": "Can be flirty or playful depending on relationship context."
+      "note": "Reads as flirty or playful depending on relationship context."
     },
     {
       "platform": "SLACK",
-      "note": "Use cautiously - may seem unprofessional or suggestive."
+      "note": "Use cautiously; may read as unprofessional or suggestive in wide channels."
     },
     {
       "platform": "WHATSAPP",
-      "note": "Common for playful banter between friends."
+      "note": "Common for playful banter between friends and family."
+    },
+    {
+      "platform": "DISCORD",
+      "note": "Server members use it as the playful tease on inside jokes."
     }
   ],
   "generationalNotes": [
@@ -72,5 +76,58 @@
   ],
   "relatedCombos": ["wink-smile"],
   "seoTitle": "😉 Winking Face Emoji Meaning - What Does 😉 Really Mean?",
-  "seoDescription": "Learn what the winking emoji 😉 really means in modern texting. Playful wink for jokes or flirtation. Complete context guide."
+  "seoDescription": "Learn what the winking emoji 😉 really means in modern texting. Playful wink for jokes or flirtation. Complete context guide.",
+  "contentTier": "deep",
+  "contentUpdatedAt": "2026-08-12",
+  "longForm": {
+    "overview": "😉 is the playful wink emoji, the one that signals a joke, an inside reference, or a flirty nudge. The closed-eye-and-slight-smile face carries so much subtext that the meaning has stretched across three distinct uses: teasing a friend, implying a hidden meaning, or signaling flirtation. On WhatsApp, iMessage, and Twitter 😉 shows up as the softener that lets the sender imply something without typing it out — 'see you later 😉' reads as a flirty closing, 'just kidding 😉' reads as a teasing disavowal, 'I'll handle it 😉' reads as a wink that signals competence.\n\nThe emoji is one of the most context-sensitive on the keyboard. The same 😉 can land as joke, flirt, or professional risk depending on the channel and the relationship. Gen Z has drifted slightly cooler on the emoji because it leans performative, but across age groups it remains a reliable playful signal. Use 😉 when the subtext is intentional and the audience is in on the joke.",
+    "howPeopleUseIt": "😉 arrives as the sentence closer on a flirty message, the teasing disavowal after a joke, or the playful nudge on an inside reference. On iMessage 😉 shows up as the standard flirty closer in dating-app conversations — 'see you tonight 😉' or 'thinking of you 😉' — that pushes the message past the casual stage. On Twitter it functions as the playful tease on a thread that has a hidden layer.\n\nIn group chats 😉 works as the 'I am in on the joke' emoji. A friend shares a comment that needs a wink and you reply with 😉 to mark the moment as insider. The emoji also pairs naturally with 😏 for a more flirty smirk, with 😜 for the winking-tongue playful variant, and with a sentence that lands the subtext.",
+    "whenNotToUse": "Skip 😉 in mixed channels where the flirty reading will land first — in cold work channels, in customer-facing comms, or in first-contact messages where the relationship has not been established. A 😉 in a customer complaint reply will sound predatory. Avoid it in formal professional emails where the wink will undercut the seriousness of the message.\n\nAlso avoid 😉 in serious discussions about consent, boundaries, or rejection. The emoji carries playful implication, and the recipient may not feel the same energy. When in doubt, reach for a heart or a plain sentence.",
+    "howToReply": "Mirror 😉 with another 😉 if you want to keep the playful energy going, or upgrade to 😏 for a more confident smirk. If you receive 😉 from a romantic partner, a heart or a flirty sentence closes the loop in matching energy.\n\nIf 😉 arrives as a teasing disavowal, mirror with a sentence that acknowledges the joke. And if you want to send 😉 as a flirty closer in an established relationship, anchor the emoji with a sentence that lands the intent so the wink does not feel generic.",
+    "faqs": [
+      {
+        "question": "What does 😉 mean in texting?",
+        "answer": "😉 means 'playful tease' or 'flirty nudge.' The winking face signals a joke, an inside reference, or a flirty subtext, and the actual meaning depends on the context and the relationship."
+      },
+      {
+        "question": "What does 😉 mean from a girl?",
+        "answer": "From a girl or anyone else, 😉 means the sender is teasing or flirting. There is no gendered meaning; the emoji is about the subtext, not who is sending it."
+      },
+      {
+        "question": "Is 😉 flirty?",
+        "answer": "😉 can be flirty in a dating context, especially paired with romantic content. In other relationships it stays in the playful tease zone between friends."
+      },
+      {
+        "question": "What does 😉 mean from a guy?",
+        "answer": "From a guy, 😉 has the same meaning it has from anyone else: playful tease or flirty implication. The emoji is not gendered and reads the same regardless of who sends it."
+      }
+    ]
+  },
+  "conversationExamples": [
+    {
+      "setting": "dating",
+      "message": "see you tonight 😉",
+      "interpretation": "Romantic partner's flirty closer. Mirror with 😉 or a heart to match the energy."
+    },
+    {
+      "setting": "friends",
+      "message": "just kidding 😉",
+      "interpretation": "Friend teasing a previous joke. Mirror with 😉 or a laughing emoji to keep the bit going."
+    },
+    {
+      "setting": "social",
+      "message": "I will handle it 😉",
+      "interpretation": "Public playful tease on a thread. Mirror with 😉 or a sentence that acknowledges the wink."
+    },
+    {
+      "setting": "family",
+      "message": "remember to bring snacks 😉",
+      "interpretation": "Family playful nudge. Mirror with 😄 or a sentence that engages with the request."
+    },
+    {
+      "setting": "work",
+      "message": "thanks for the favor 😉",
+      "interpretation": "Risky in a wide team channel; safe in a tight collaborator DM. If used in a team channel, anchor with a sentence that adds context."
+    }
+  ]
 }

--- a/src/types/combo.ts
+++ b/src/types/combo.ts
@@ -38,6 +38,63 @@ export type EmojiComboCategoryName =
 // ============================================
 
 /**
+ * Settings where a conversation example takes place
+ * Used for the long-form `conversationExamples` field on combos.
+ */
+export type ComboConversationSetting =
+  | 'dating'
+  | 'friends'
+  | 'work'
+  | 'family'
+  | 'social'
+  | 'other';
+
+/**
+ * A single FAQ entry for the combo long-form FAQ section
+ */
+export interface ComboFaq {
+  /** Question as a reader might type it into a search engine */
+  question: string;
+  /** Direct, self-contained answer */
+  answer: string;
+}
+
+/**
+ * Long-form, article-style content for combo pages (CONTENT-P1-001).
+ * Mirrors `EmojiLongForm` so the same renderer can be used.
+ */
+export interface ComboLongForm {
+  /** 2–4 paragraph overview that goes beyond the one-line `meaning` */
+  overview?: string;
+  /** How people actually use the combo in chat */
+  howPeopleUseIt?: string;
+  /** When NOT to use it / common misreads */
+  whenNotToUse?: string;
+  /** How to reply when you receive it */
+  howToReply?: string;
+  /** FAQ entries for "People Also Ask" style content */
+  faqs?: ComboFaq[];
+}
+
+/**
+ * A richer, full-message conversation example than the one-line
+ * `examples` field on `EmojiCombo`.
+ */
+export interface ComboConversationExample {
+  /** Setting where the exchange takes place */
+  setting: ComboConversationSetting;
+  /** The full message being interpreted */
+  message: string;
+  /** What the message (and combo) actually means in this context */
+  interpretation: string;
+}
+
+/**
+ * Content depth tier for publishing QA on combos.
+ */
+export type ComboContentTier = 'thin' | 'standard' | 'deep';
+
+/**
  * Complete emoji combo data structure
  * Represents the full data stored in combo JSON files
  */
@@ -68,6 +125,14 @@ export interface EmojiCombo {
   tags?: string[];
   /** Optional popularity score (0-100) */
   popularity?: number;
+  /** Optional long-form article-style content (CONTENT-P1-001) */
+  longForm?: ComboLongForm;
+  /** Optional richer conversation examples (CONTENT-P1-001) */
+  conversationExamples?: ComboConversationExample[];
+  /** Optional content depth tier for publishing QA (CONTENT-P1-001) */
+  contentTier?: ComboContentTier;
+  /** ISO date string of last content refresh (CONTENT-P1-001) */
+  contentUpdatedAt?: string;
 }
 
 /**

--- a/src/types/emoji.ts
+++ b/src/types/emoji.ts
@@ -180,6 +180,59 @@ export interface EmojiWarning {
 }
 
 /**
+ * Settings where a conversation example takes place
+ * Used for the long-form `conversationExamples` field.
+ */
+export type ConversationSetting = 'dating' | 'friends' | 'work' | 'family' | 'social' | 'other';
+
+/**
+ * A single FAQ entry for the FAQ section
+ * Used inside `EmojiLongForm.faqs`.
+ */
+export interface EmojiFaq {
+  /** Question as a reader might type it into a search engine */
+  question: string;
+  /** Direct, self-contained answer */
+  answer: string;
+}
+
+/**
+ * Long-form, article-style content for AdSense/SEO depth.
+ * All sub-fields are optional so older (thin) JSON still validates.
+ */
+export interface EmojiLongForm {
+  /** 2–4 paragraph overview that goes beyond the `tldr` one-liner */
+  overview?: string;
+  /** How people actually use the emoji in chat */
+  howPeopleUseIt?: string;
+  /** When NOT to use it / common misreads */
+  whenNotToUse?: string;
+  /** How to reply when you receive it */
+  howToReply?: string;
+  /** FAQ entries for "People Also Ask" style content */
+  faqs?: EmojiFaq[];
+}
+
+/**
+ * A richer, full-message conversation example than the one-line
+ * `ContextMeaning.example` field.
+ */
+export interface ConversationExample {
+  /** Setting where the exchange takes place */
+  setting: ConversationSetting;
+  /** The full message being interpreted */
+  message: string;
+  /** What the message (and emoji) actually means in this context */
+  interpretation: string;
+}
+
+/**
+ * Content depth tier for publishing QA.
+ * Drives both validation thresholds and visual treatment on the page.
+ */
+export type ContentTier = 'thin' | 'standard' | 'deep';
+
+/**
  * Complete emoji data structure
  */
 export interface Emoji {
@@ -223,6 +276,14 @@ export interface Emoji {
   skinToneBase?: string;
   /** Skin tone modifier type (for variations) */
   skinToneModifier?: 'light' | 'medium-light' | 'medium' | 'medium-dark' | 'dark';
+  /** Optional long-form article-style content (CONTENT-P1-001) */
+  longForm?: EmojiLongForm;
+  /** Optional richer conversation examples (CONTENT-P1-001) */
+  conversationExamples?: ConversationExample[];
+  /** Optional content depth tier for publishing QA (CONTENT-P1-001) */
+  contentTier?: ContentTier;
+  /** ISO date string of last content refresh (CONTENT-P1-001) */
+  contentUpdatedAt?: string;
 }
 
 /**

--- a/tests/unit/app/emoji/[slug]/page.test.tsx
+++ b/tests/unit/app/emoji/[slug]/page.test.tsx
@@ -308,5 +308,55 @@ describe('EmojiPage', () => {
       expect(screen.getByText(/Critical Warning/)).toBeInTheDocument();
       expect(screen.getByText(/Medium Warning/)).toBeInTheDocument();
     });
+
+    test('renders the long-form section when longForm is present', async () => {
+      const emojiWithLongForm: Emoji = {
+        ...mockEmoji,
+        longForm: {
+          overview: 'First paragraph of the article overview.\n\nSecond paragraph follows.',
+          howPeopleUseIt: 'It shows up everywhere.',
+          whenNotToUse: 'Skip it in formal channels.',
+          howToReply: 'Mirror the energy with another skull.',
+          faqs: [{ question: 'What does it mean?', answer: 'It means the sender is amused.' }],
+        },
+      };
+      mockGetEmojiBySlug.mockImplementation(() => emojiWithLongForm);
+
+      const page = await EmojiPage({ params: Promise.resolve({ slug: 'skull' }) });
+      render(page);
+
+      expect(screen.getByTestId('emoji-long-form-section')).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: 'Overview', level: 2 })).toBeInTheDocument();
+      expect(
+        screen.getByRole('heading', { name: 'How People Use It', level: 2 })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('heading', { name: 'When Not to Use It', level: 2 })
+      ).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: 'How to Reply', level: 2 })).toBeInTheDocument();
+      expect(
+        screen.getByRole('heading', { name: 'Frequently Asked Questions', level: 2 })
+      ).toBeInTheDocument();
+    });
+
+    test('renders conversation examples when provided', async () => {
+      const emojiWithExamples: Emoji = {
+        ...mockEmoji,
+        conversationExamples: [
+          {
+            setting: 'friends',
+            message: 'bro i just tripped into the projector at work 💀',
+            interpretation: 'Sender is laughing at their own embarrassment.',
+          },
+        ],
+      };
+      mockGetEmojiBySlug.mockImplementation(() => emojiWithExamples);
+
+      const page = await EmojiPage({ params: Promise.resolve({ slug: 'skull' }) });
+      render(page);
+
+      expect(screen.getByTestId('emoji-conversation-examples-section')).toBeInTheDocument();
+      expect(screen.getByText(/tripped into the projector/)).toBeInTheDocument();
+    });
   });
 });

--- a/tests/unit/components/combo/combo-conversation-examples-section.test.tsx
+++ b/tests/unit/components/combo/combo-conversation-examples-section.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { render, cleanup, screen } from '@testing-library/react';
+import { ComboConversationExamplesSection } from '@/components/combo/combo-conversation-examples-section';
+import type { ComboConversationExample } from '@/types/combo';
+
+afterEach(() => {
+  cleanup();
+});
+
+const examples: ComboConversationExample[] = [
+  {
+    setting: 'friends',
+    message: 'bro that tiktok of the cat falling into the pool 💀😂',
+    interpretation: 'Friend sharing a viral video.',
+  },
+  {
+    setting: 'work',
+    message: 'client just replied-all to the wrong thread 💀😂',
+    interpretation: 'Sympathetic work disaster.',
+  },
+];
+
+describe('ComboConversationExamplesSection', () => {
+  it('renders nothing when there are no examples', () => {
+    const { container } = render(<ComboConversationExamplesSection examples={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the section heading and one card per example', () => {
+    render(<ComboConversationExamplesSection examples={examples} />);
+    expect(
+      screen.getByRole('heading', { name: 'Real Conversation Examples', level: 2 })
+    ).toBeInTheDocument();
+    expect(screen.getAllByTestId('combo-conversation-example')).toHaveLength(2);
+  });
+
+  it('renders the conversation message as a blockquote', () => {
+    render(<ComboConversationExamplesSection examples={examples} />);
+    expect(
+      screen.getByText(/bro that tiktok of the cat falling into the pool 💀😂/)
+    ).toBeInTheDocument();
+  });
+
+  it('renders the interpretation paragraph', () => {
+    render(<ComboConversationExamplesSection examples={examples} />);
+    expect(screen.getByText('Friend sharing a viral video.')).toBeInTheDocument();
+    expect(screen.getByText('Sympathetic work disaster.')).toBeInTheDocument();
+  });
+
+  it('renders a human-readable setting label', () => {
+    render(<ComboConversationExamplesSection examples={examples} />);
+    expect(screen.getByText('Friends')).toBeInTheDocument();
+    expect(screen.getByText('Work')).toBeInTheDocument();
+  });
+
+  it('uses the combo-prefixed testid so emoji and combo testids stay distinct', () => {
+    const { container } = render(<ComboConversationExamplesSection examples={examples} />);
+    expect(
+      container.querySelector('[data-testid="combo-conversation-examples-section"]')
+    ).not.toBeNull();
+  });
+});

--- a/tests/unit/components/combo/combo-long-form-section.test.tsx
+++ b/tests/unit/components/combo/combo-long-form-section.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { render, cleanup, screen } from '@testing-library/react';
+import { ComboLongFormSection } from '@/components/combo/combo-long-form-section';
+import type { ComboLongForm } from '@/types/combo';
+
+afterEach(() => {
+  cleanup();
+});
+
+const baseLongForm: ComboLongForm = {
+  overview: 'First paragraph of the combo overview.\n\nSecond paragraph still in overview.',
+  howPeopleUseIt: 'It shows up in hype threads.',
+  whenNotToUse: 'Skip it in professional channels.',
+  howToReply: 'Mirror the energy with another combo.',
+  faqs: [
+    { question: 'What does it mean?', answer: 'It means the sender thinks it is flawless.' },
+    { question: 'Is it flirty?', answer: 'Usually not.' },
+  ],
+};
+
+describe('ComboLongFormSection', () => {
+  it('renders nothing when the long-form block is empty', () => {
+    const { container } = render(<ComboLongFormSection longForm={{}} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when the long-form block only contains empty strings', () => {
+    const { container } = render(
+      <ComboLongFormSection longForm={{ overview: '   ', howPeopleUseIt: '' }} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the overview heading and splits paragraphs on blank lines', () => {
+    render(<ComboLongFormSection longForm={{ overview: baseLongForm.overview }} />);
+    expect(screen.getByRole('heading', { name: 'Overview', level: 2 })).toBeInTheDocument();
+    expect(screen.getByText('First paragraph of the combo overview.')).toBeInTheDocument();
+    expect(screen.getByText('Second paragraph still in overview.')).toBeInTheDocument();
+  });
+
+  it('renders the how-people-use-it sub-section', () => {
+    render(<ComboLongFormSection longForm={{ howPeopleUseIt: 'It shows up in hype threads.' }} />);
+    expect(
+      screen.getByRole('heading', { name: 'How People Use It', level: 2 })
+    ).toBeInTheDocument();
+    expect(screen.getByText('It shows up in hype threads.')).toBeInTheDocument();
+  });
+
+  it('renders the when-not-to-use sub-section', () => {
+    render(
+      <ComboLongFormSection longForm={{ whenNotToUse: 'Skip it in professional channels.' }} />
+    );
+    expect(
+      screen.getByRole('heading', { name: 'When Not to Use It', level: 2 })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Skip it in professional channels.')).toBeInTheDocument();
+  });
+
+  it('renders the how-to-reply sub-section', () => {
+    render(<ComboLongFormSection longForm={{ howToReply: 'Mirror with another combo.' }} />);
+    expect(screen.getByRole('heading', { name: 'How to Reply', level: 2 })).toBeInTheDocument();
+    expect(screen.getByText('Mirror with another combo.')).toBeInTheDocument();
+  });
+
+  it('renders the FAQ block when faqs are present', () => {
+    render(<ComboLongFormSection longForm={{ faqs: baseLongForm.faqs }} />);
+    expect(
+      screen.getByRole('heading', { name: 'Frequently Asked Questions', level: 2 })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'What does it mean?', level: 3 })
+    ).toBeInTheDocument();
+    expect(screen.getByText('It means the sender thinks it is flawless.')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Is it flirty?', level: 3 })).toBeInTheDocument();
+  });
+
+  it('renders every sub-section when fully populated', () => {
+    render(<ComboLongFormSection longForm={baseLongForm} />);
+    expect(screen.getByRole('heading', { name: 'Overview', level: 2 })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'How People Use It', level: 2 })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'When Not to Use It', level: 2 })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'How to Reply', level: 2 })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Frequently Asked Questions', level: 2 })
+    ).toBeInTheDocument();
+  });
+
+  it('skips the FAQ block when faqs is an empty array', () => {
+    render(<ComboLongFormSection longForm={{ ...baseLongForm, faqs: [] }} />);
+    expect(
+      screen.queryByRole('heading', { name: 'Frequently Asked Questions', level: 2 })
+    ).toBeNull();
+  });
+
+  it('uses the combo-prefixed testid so emoji and combo testids stay distinct', () => {
+    const { container } = render(<ComboLongFormSection longForm={baseLongForm} />);
+    expect(container.querySelector('[data-testid="combo-long-form-section"]')).not.toBeNull();
+  });
+});

--- a/tests/unit/components/emoji/emoji-conversation-examples-section.test.tsx
+++ b/tests/unit/components/emoji/emoji-conversation-examples-section.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { render, cleanup, screen } from '@testing-library/react';
+import { EmojiConversationExamplesSection } from '@/components/emoji/emoji-conversation-examples-section';
+import type { ConversationExample } from '@/types/emoji';
+
+afterEach(() => {
+  cleanup();
+});
+
+const examples: ConversationExample[] = [
+  {
+    setting: 'friends',
+    message: 'bro i just tripped into the projector at work 💀',
+    interpretation: 'Sender is laughing at their own embarrassment.',
+  },
+  {
+    setting: 'work',
+    message: 'reminder: all-hands at 8am tomorrow 💀',
+    interpretation: 'Sarcastic exhaustion about an early meeting.',
+  },
+];
+
+describe('EmojiConversationExamplesSection', () => {
+  it('renders nothing when there are no examples', () => {
+    const { container } = render(<EmojiConversationExamplesSection examples={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the section heading and one card per example', () => {
+    render(<EmojiConversationExamplesSection examples={examples} />);
+    expect(
+      screen.getByRole('heading', { name: 'Real Conversation Examples', level: 2 })
+    ).toBeInTheDocument();
+    expect(screen.getAllByTestId('conversation-example')).toHaveLength(2);
+  });
+
+  it('renders the conversation message as a blockquote', () => {
+    render(<EmojiConversationExamplesSection examples={examples} />);
+    // Blockquote wraps the message with curly quotes — match the inner substring.
+    expect(
+      screen.getByText(/bro i just tripped into the projector at work 💀/)
+    ).toBeInTheDocument();
+  });
+
+  it('renders the interpretation paragraph', () => {
+    render(<EmojiConversationExamplesSection examples={examples} />);
+    expect(screen.getByText('Sender is laughing at their own embarrassment.')).toBeInTheDocument();
+    expect(screen.getByText('Sarcastic exhaustion about an early meeting.')).toBeInTheDocument();
+  });
+
+  it('renders a human-readable setting label', () => {
+    render(<EmojiConversationExamplesSection examples={examples} />);
+    expect(screen.getByText('Friends')).toBeInTheDocument();
+    expect(screen.getByText('Work')).toBeInTheDocument();
+  });
+
+  it('falls back to the raw setting when the value is not in the label map', () => {
+    render(
+      <EmojiConversationExamplesSection
+        examples={[{ setting: 'other', message: '💀', interpretation: 'test' }]}
+      />
+    );
+    expect(screen.getByText('Other')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/emoji/emoji-long-form-section.test.tsx
+++ b/tests/unit/components/emoji/emoji-long-form-section.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { render, cleanup, screen } from '@testing-library/react';
+import { EmojiLongFormSection } from '@/components/emoji/emoji-long-form-section';
+import type { EmojiLongForm } from '@/types/emoji';
+
+afterEach(() => {
+  cleanup();
+});
+
+const baseLongForm: EmojiLongForm = {
+  overview: 'First paragraph of the overview.\n\nSecond paragraph still in overview.',
+  howPeopleUseIt: 'It shows up everywhere.',
+  whenNotToUse: 'Skip it in formal channels.',
+  howToReply: 'Mirror the energy with another skull.',
+  faqs: [
+    { question: 'What does it mean?', answer: 'It means the sender is amused.' },
+    { question: 'Is it flirty?', answer: 'Usually not.' },
+  ],
+};
+
+describe('EmojiLongFormSection', () => {
+  it('renders nothing when the long-form block is empty', () => {
+    const { container } = render(<EmojiLongFormSection longForm={{}} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when the long-form block only contains empty strings', () => {
+    const { container } = render(
+      <EmojiLongFormSection longForm={{ overview: '   ', howPeopleUseIt: '' }} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the overview heading and splits paragraphs on blank lines', () => {
+    render(<EmojiLongFormSection longForm={{ overview: baseLongForm.overview }} />);
+    expect(screen.getByRole('heading', { name: 'Overview', level: 2 })).toBeInTheDocument();
+    expect(screen.getByText('First paragraph of the overview.')).toBeInTheDocument();
+    expect(screen.getByText('Second paragraph still in overview.')).toBeInTheDocument();
+  });
+
+  it('renders the how-people-use-it sub-section', () => {
+    render(<EmojiLongFormSection longForm={{ howPeopleUseIt: 'It shows up everywhere.' }} />);
+    expect(
+      screen.getByRole('heading', { name: 'How People Use It', level: 2 })
+    ).toBeInTheDocument();
+    expect(screen.getByText('It shows up everywhere.')).toBeInTheDocument();
+  });
+
+  it('renders the when-not-to-use sub-section', () => {
+    render(<EmojiLongFormSection longForm={{ whenNotToUse: 'Skip it in formal channels.' }} />);
+    expect(
+      screen.getByRole('heading', { name: 'When Not to Use It', level: 2 })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Skip it in formal channels.')).toBeInTheDocument();
+  });
+
+  it('renders the how-to-reply sub-section', () => {
+    render(<EmojiLongFormSection longForm={{ howToReply: 'Mirror with another skull.' }} />);
+    expect(screen.getByRole('heading', { name: 'How to Reply', level: 2 })).toBeInTheDocument();
+    expect(screen.getByText('Mirror with another skull.')).toBeInTheDocument();
+  });
+
+  it('renders the FAQ block when faqs are present', () => {
+    render(<EmojiLongFormSection longForm={{ faqs: baseLongForm.faqs }} />);
+    expect(
+      screen.getByRole('heading', { name: 'Frequently Asked Questions', level: 2 })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'What does it mean?', level: 3 })
+    ).toBeInTheDocument();
+    expect(screen.getByText('It means the sender is amused.')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Is it flirty?', level: 3 })).toBeInTheDocument();
+  });
+
+  it('renders every sub-section when fully populated', () => {
+    render(<EmojiLongFormSection longForm={baseLongForm} />);
+    expect(screen.getByRole('heading', { name: 'Overview', level: 2 })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'How People Use It', level: 2 })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'When Not to Use It', level: 2 })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'How to Reply', level: 2 })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Frequently Asked Questions', level: 2 })
+    ).toBeInTheDocument();
+  });
+
+  it('skips the FAQ block when faqs is an empty array', () => {
+    render(<EmojiLongFormSection longForm={{ ...baseLongForm, faqs: [] }} />);
+    expect(
+      screen.queryByRole('heading', { name: 'Frequently Asked Questions', level: 2 })
+    ).toBeNull();
+  });
+});

--- a/tests/unit/components/seo/combo-json-ld.test.tsx
+++ b/tests/unit/components/seo/combo-json-ld.test.tsx
@@ -266,6 +266,66 @@ describe('ComboJsonLd', () => {
     });
   });
 
+  describe('long-form FAQ support (CONTENT-P1-001)', () => {
+    it('keeps the legacy Article shape when there are no FAQs', () => {
+      render(<ComboJsonLd combo={mockCombo} appUrl={mockAppUrl} appName={mockAppName} />);
+
+      const script = document.querySelector('script[type="application/ld+json"]');
+      const parsed = JSON.parse(script!.textContent!);
+      expect(parsed['@type']).toBe('Article');
+      expect(parsed['@graph']).toBeUndefined();
+    });
+
+    it('emits an @graph with Article + FAQPage when longForm.faqs is present', () => {
+      const comboWithFaqs: EmojiCombo = {
+        ...mockCombo,
+        longForm: {
+          faqs: [
+            { question: 'What does 💀😂 mean?', answer: 'It means "dead laughing".' },
+            { question: 'Is 💀😂 flirty?', answer: 'Usually not.' },
+          ],
+        },
+      };
+
+      render(<ComboJsonLd combo={comboWithFaqs} appUrl={mockAppUrl} appName={mockAppName} />);
+
+      const script = document.querySelector('script[type="application/ld+json"]');
+      const parsed = JSON.parse(script!.textContent!);
+
+      expect(parsed['@context']).toBe('https://schema.org');
+      expect(Array.isArray(parsed['@graph'])).toBe(true);
+      const graph = parsed['@graph'] as Array<Record<string, unknown>>;
+
+      const article = graph.find((node) => node['@type'] === 'Article');
+      const faq = graph.find((node) => node['@type'] === 'FAQPage');
+      expect(article).toBeDefined();
+      expect(faq).toBeDefined();
+
+      const faqEntity = faq as {
+        mainEntity: Array<{ '@type': string; name: string; acceptedAnswer: { text: string } }>;
+      };
+      expect(faqEntity.mainEntity).toHaveLength(2);
+      expect(faqEntity.mainEntity[0]['@type']).toBe('Question');
+      expect(faqEntity.mainEntity[0].name).toBe('What does 💀😂 mean?');
+      expect(faqEntity.mainEntity[0].acceptedAnswer.text).toBe('It means "dead laughing".');
+    });
+
+    it('does not emit an FAQPage when longForm is present but has no FAQs', () => {
+      const comboLongFormNoFaqs: EmojiCombo = {
+        ...mockCombo,
+        longForm: { overview: 'paragraph' },
+      };
+
+      render(<ComboJsonLd combo={comboLongFormNoFaqs} appUrl={mockAppUrl} appName={mockAppName} />);
+
+      const script = document.querySelector('script[type="application/ld+json"]');
+      const parsed = JSON.parse(script!.textContent!);
+
+      expect(parsed['@type']).toBe('Article');
+      expect(parsed['@graph']).toBeUndefined();
+    });
+  });
+
   describe('SEO compliance', () => {
     it('includes all required Article properties per Schema.org', () => {
       render(<ComboJsonLd combo={mockCombo} appUrl={mockAppUrl} appName={mockAppName} />);

--- a/tests/unit/components/seo/emoji-json-ld.test.tsx
+++ b/tests/unit/components/seo/emoji-json-ld.test.tsx
@@ -256,6 +256,66 @@ describe('EmojiJsonLd', () => {
     });
   });
 
+  describe('long-form FAQ support (CONTENT-P1-001)', () => {
+    it('keeps the legacy Article shape when there are no FAQs', () => {
+      render(<EmojiJsonLd emoji={mockEmoji} appUrl={mockAppUrl} appName={mockAppName} />);
+
+      const script = document.querySelector('script[type="application/ld+json"]');
+      const parsed = JSON.parse(script!.textContent!);
+      expect(parsed['@type']).toBe('Article');
+      expect(parsed['@graph']).toBeUndefined();
+    });
+
+    it('emits an @graph with Article + FAQPage when longForm.faqs is present', () => {
+      const emojiWithFaqs: Emoji = {
+        ...mockEmoji,
+        longForm: {
+          faqs: [
+            { question: 'What does 💀 mean?', answer: 'It means "dead from laughing".' },
+            { question: 'Is 💀 flirty?', answer: 'Usually not.' },
+          ],
+        },
+      };
+
+      render(<EmojiJsonLd emoji={emojiWithFaqs} appUrl={mockAppUrl} appName={mockAppName} />);
+
+      const script = document.querySelector('script[type="application/ld+json"]');
+      const parsed = JSON.parse(script!.textContent!);
+
+      expect(parsed['@context']).toBe('https://schema.org');
+      expect(Array.isArray(parsed['@graph'])).toBe(true);
+      const graph = parsed['@graph'] as Array<Record<string, unknown>>;
+
+      const article = graph.find((node) => node['@type'] === 'Article');
+      const faq = graph.find((node) => node['@type'] === 'FAQPage');
+      expect(article).toBeDefined();
+      expect(faq).toBeDefined();
+
+      const faqEntity = faq as {
+        mainEntity: Array<{ '@type': string; name: string; acceptedAnswer: { text: string } }>;
+      };
+      expect(faqEntity.mainEntity).toHaveLength(2);
+      expect(faqEntity.mainEntity[0]['@type']).toBe('Question');
+      expect(faqEntity.mainEntity[0].name).toBe('What does 💀 mean?');
+      expect(faqEntity.mainEntity[0].acceptedAnswer.text).toBe('It means "dead from laughing".');
+    });
+
+    it('does not emit an FAQPage when longForm is present but has no FAQs', () => {
+      const emojiLongFormNoFaqs: Emoji = {
+        ...mockEmoji,
+        longForm: { overview: 'paragraph' },
+      };
+
+      render(<EmojiJsonLd emoji={emojiLongFormNoFaqs} appUrl={mockAppUrl} appName={mockAppName} />);
+
+      const script = document.querySelector('script[type="application/ld+json"]');
+      const parsed = JSON.parse(script!.textContent!);
+
+      expect(parsed['@type']).toBe('Article');
+      expect(parsed['@graph']).toBeUndefined();
+    });
+  });
+
   describe('SEO compliance', () => {
     it('includes all required Article properties per Schema.org', () => {
       render(<EmojiJsonLd emoji={mockEmoji} appUrl={mockAppUrl} appName={mockAppName} />);

--- a/tests/unit/components/ui/long-form-section.test.tsx
+++ b/tests/unit/components/ui/long-form-section.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { render, cleanup, screen } from '@testing-library/react';
+import { LongFormSection } from '@/components/ui/long-form-section';
+import type { LongFormContent } from '@/components/ui/long-form-section';
+
+afterEach(() => {
+  cleanup();
+});
+
+const baseLongForm: LongFormContent = {
+  overview: 'First paragraph.\n\nSecond paragraph.',
+  howPeopleUseIt: 'It shows up everywhere.',
+  whenNotToUse: 'Skip it in formal channels.',
+  howToReply: 'Mirror the energy.',
+  faqs: [{ question: 'What does it mean?', answer: 'It means the sender is amused.' }],
+};
+
+describe('LongFormSection', () => {
+  it('renders nothing when the long-form block is empty', () => {
+    const { container } = render(<LongFormSection longForm={{}} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('uses the default testid when none is provided', () => {
+    const { container } = render(<LongFormSection longForm={{ overview: 'paragraph' }} />);
+    expect(container.querySelector('[data-testid="long-form-section"]')).not.toBeNull();
+  });
+
+  it('honors a custom testid when one is provided', () => {
+    const { container } = render(
+      <LongFormSection longForm={{ overview: 'paragraph' }} testId="custom-test-id" />
+    );
+    expect(container.querySelector('[data-testid="custom-test-id"]')).not.toBeNull();
+  });
+
+  it('renders the overview heading and splits paragraphs on blank lines', () => {
+    render(<LongFormSection longForm={{ overview: baseLongForm.overview }} />);
+    expect(screen.getByRole('heading', { name: 'Overview', level: 2 })).toBeInTheDocument();
+    expect(screen.getByText('First paragraph.')).toBeInTheDocument();
+    expect(screen.getByText('Second paragraph.')).toBeInTheDocument();
+  });
+
+  it('renders every sub-section when fully populated', () => {
+    render(<LongFormSection longForm={baseLongForm} />);
+    expect(screen.getByRole('heading', { name: 'Overview', level: 2 })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'How People Use It', level: 2 })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'When Not to Use It', level: 2 })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'How to Reply', level: 2 })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Frequently Asked Questions', level: 2 })
+    ).toBeInTheDocument();
+  });
+
+  it('skips the FAQ block when faqs is an empty array', () => {
+    render(<LongFormSection longForm={{ ...baseLongForm, faqs: [] }} />);
+    expect(
+      screen.queryByRole('heading', { name: 'Frequently Asked Questions', level: 2 })
+    ).toBeNull();
+  });
+});

--- a/tests/unit/scripts/validate-emojis.test.ts
+++ b/tests/unit/scripts/validate-emojis.test.ts
@@ -9,6 +9,15 @@ import {
   validatePlatformNote,
   validateGenerationalNote,
   validateWarning,
+  validateLongForm,
+  validateFaq,
+  validateConversationExample,
+  validateDeepTier,
+  countWords,
+  DEEP_OVERVIEW_MIN_WORDS,
+  DEEP_CONVERSATION_EXAMPLES_MIN,
+  DEEP_FAQS_MIN,
+  DEEP_PLATFORM_NOTE_MIN_CHARS,
   checkDuplicateSlugs,
   checkComboReferences,
   validateAllEmojis,
@@ -632,6 +641,272 @@ describe('validate-emojis', () => {
       expect(() => handleMainError(testError)).toThrow('process.exit called');
       expect(consoleErrorSpy).toHaveBeenCalledWith('Validation script failed:', testError);
       expect(processExitSpy).toHaveBeenCalledWith(1);
+    });
+  });
+
+  // ========================================================================
+  // CONTENT-P1-001 — long-form, conversationExamples, contentTier
+  // ========================================================================
+
+  const deepEmoji = (overrides: Partial<Emoji> = {}): Emoji => {
+    const longOverview = Array.from({ length: DEEP_OVERVIEW_MIN_WORDS + 5 })
+      .map((_, i) => `word${i}`)
+      .join(' ');
+    const platformNote = 'Used in comment sections to react to viral clips with repeated skulls.';
+    return {
+      unicode: '1F480',
+      slug: 'skull',
+      character: '💀',
+      name: 'Skull',
+      shortName: 'skull',
+      category: 'faces',
+      unicodeVersion: '6.0',
+      baseMeaning: 'A human skull.',
+      tldr: "Usually means I'm dead from laughing.",
+      contextMeanings: [],
+      platformNotes: [{ platform: 'TIKTOK', note: platformNote }],
+      generationalNotes: [],
+      warnings: [],
+      relatedCombos: [],
+      seoTitle: 'Skull Emoji Meaning',
+      seoDescription: 'Learn what the skull emoji means.',
+      contentTier: 'deep',
+      contentUpdatedAt: '2026-01-15',
+      longForm: {
+        overview: longOverview,
+        howPeopleUseIt: 'After punchlines.',
+        whenNotToUse: 'Never in professional channels.',
+        howToReply: 'Mirror with another skull.',
+        faqs: [
+          { question: 'What does it mean?', answer: 'The sender is dead from laughing.' },
+          { question: 'Is it flirty?', answer: 'Usually not.' },
+          { question: 'Is it morbid?', answer: 'No.' },
+        ],
+      },
+      conversationExamples: [
+        { setting: 'friends', message: 'lol 💀', interpretation: 'laughing' },
+        { setting: 'work', message: 'meeting at 8 💀', interpretation: 'sarcastic exhaustion' },
+        { setting: 'social', message: 'did you see that 💀', interpretation: 'hyping the chat' },
+      ],
+      ...overrides,
+    };
+  };
+
+  describe('countWords', () => {
+    it('counts whitespace-delimited tokens', () => {
+      expect(countWords('one two three')).toBe(3);
+    });
+
+    it('returns zero for empty or whitespace-only strings', () => {
+      expect(countWords('')).toBe(0);
+      expect(countWords('   ')).toBe(0);
+    });
+
+    it('treats non-string values as zero', () => {
+      expect(countWords(undefined as unknown as string)).toBe(0);
+      expect(countWords(null as unknown as string)).toBe(0);
+    });
+  });
+
+  describe('validateFaq', () => {
+    it('passes for a valid FAQ', () => {
+      expect(validateFaq({ question: 'Q?', answer: 'A.' }, 0)).toEqual([]);
+    });
+
+    it('flags missing question and answer', () => {
+      const errors = validateFaq(
+        {
+          question: '',
+          answer: '',
+        } as unknown as NonNullable<NonNullable<Emoji['longForm']>['faqs']>[number],
+        0
+      );
+      expect(
+        errors.some((e) => e.field === 'longForm.faqs[0]' && e.message.includes('question'))
+      ).toBe(true);
+      expect(
+        errors.some((e) => e.field === 'longForm.faqs[0]' && e.message.includes('answer'))
+      ).toBe(true);
+    });
+  });
+
+  describe('validateLongForm', () => {
+    it('returns no errors for an empty object', () => {
+      expect(validateLongForm({})).toEqual([]);
+    });
+
+    it('flags non-string string fields', () => {
+      const errors = validateLongForm({ overview: 123 as unknown as string });
+      expect(errors.some((e) => e.field === 'longForm.overview')).toBe(true);
+    });
+
+    it('flags non-array faqs', () => {
+      const errors = validateLongForm({
+        faqs: 'not-an-array' as unknown as NonNullable<Emoji['longForm']>['faqs'],
+      });
+      expect(errors.some((e) => e.field === 'longForm.faqs')).toBe(true);
+    });
+
+    it('flags invalid FAQ entries inside the array', () => {
+      const errors = validateLongForm({
+        faqs: [
+          {
+            question: '',
+            answer: '',
+          } as unknown as NonNullable<NonNullable<Emoji['longForm']>['faqs']>[number],
+        ],
+      });
+      expect(errors.some((e) => e.field === 'longForm.faqs[0]')).toBe(true);
+    });
+  });
+
+  describe('validateConversationExample', () => {
+    it('passes for a valid example', () => {
+      expect(
+        validateConversationExample(
+          { setting: 'friends', message: 'lol 💀', interpretation: 'laughing' },
+          0
+        )
+      ).toEqual([]);
+    });
+
+    it('flags invalid settings', () => {
+      const errors = validateConversationExample(
+        {
+          setting: 'invalid-setting' as unknown as NonNullable<
+            Emoji['conversationExamples']
+          >[number]['setting'],
+          message: 'x',
+          interpretation: 'y',
+        },
+        0
+      );
+      expect(errors.some((e) => e.message.includes('setting'))).toBe(true);
+    });
+
+    it('flags missing message and interpretation', () => {
+      const errors = validateConversationExample(
+        {
+          setting: 'work',
+          message: '',
+          interpretation: '',
+        } as unknown as NonNullable<Emoji['conversationExamples']>[number],
+        2
+      );
+      expect(errors.some((e) => e.field === 'conversationExamples[2]')).toBe(true);
+    });
+  });
+
+  describe('validateDeepTier', () => {
+    it('returns no errors for a fully populated deep emoji', () => {
+      expect(validateDeepTier(deepEmoji())).toEqual([]);
+    });
+
+    it('rejects deep tier when overview is too short', () => {
+      const errors = validateDeepTier(deepEmoji({ longForm: { overview: 'too short' } }));
+      expect(errors.some((e) => e.field === 'longForm.overview')).toBe(true);
+    });
+
+    it('rejects deep tier when fewer than the minimum conversationExamples are provided', () => {
+      const errors = validateDeepTier(
+        deepEmoji({
+          conversationExamples: [{ setting: 'friends', message: 'a', interpretation: 'b' }],
+        })
+      );
+      expect(errors.some((e) => e.field === 'conversationExamples')).toBe(true);
+    });
+
+    it('rejects deep tier when fewer than the minimum FAQs are provided', () => {
+      const errors = validateDeepTier(
+        deepEmoji({
+          longForm: {
+            overview: Array.from({ length: DEEP_OVERVIEW_MIN_WORDS + 1 }, (_, i) => `w${i}`).join(
+              ' '
+            ),
+            faqs: [{ question: 'Q1', answer: 'A1' }],
+          },
+        })
+      );
+      expect(errors.some((e) => e.field === 'longForm.faqs')).toBe(true);
+    });
+
+    it('rejects deep tier when a platform note is below the minimum length', () => {
+      const errors = validateDeepTier(
+        deepEmoji({
+          platformNotes: [{ platform: 'TIKTOK', note: 'short' }],
+        })
+      );
+      expect(errors.some((e) => e.field === 'platformNotes[0].note')).toBe(true);
+    });
+
+    it('rejects deep tier when a platform note matches a boilerplate pattern', () => {
+      const errors = validateDeepTier(
+        deepEmoji({
+          platformNotes: [
+            {
+              platform: 'TIKTOK',
+              note: 'This emoji is very common in comment sections for various contexts.',
+            },
+          ],
+        })
+      );
+      expect(errors.some((e) => e.field === 'platformNotes[0].note')).toBe(true);
+    });
+  });
+
+  describe('validateEmoji (long-form + contentTier)', () => {
+    it('passes a thin emoji without contentTier unchanged', () => {
+      expect(validateEmoji(validEmoji)).toEqual([]);
+    });
+
+    it('flags an invalid contentTier value', () => {
+      const errors = validateEmoji({
+        ...validEmoji,
+        contentTier: 'invalid' as unknown as Emoji['contentTier'],
+      });
+      expect(errors.some((e) => e.field === 'contentTier')).toBe(true);
+    });
+
+    it('flags an invalid contentUpdatedAt value', () => {
+      const errors = validateEmoji({
+        ...validEmoji,
+        contentUpdatedAt: 'not-a-date',
+      });
+      expect(errors.some((e) => e.field === 'contentUpdatedAt')).toBe(true);
+    });
+
+    it('flags longForm that is not an object', () => {
+      const errors = validateEmoji({
+        ...validEmoji,
+        longForm: 'not-an-object' as unknown as Emoji['longForm'],
+      });
+      expect(errors.some((e) => e.field === 'longForm')).toBe(true);
+    });
+
+    it('flags conversationExamples that are not an array', () => {
+      const errors = validateEmoji({
+        ...validEmoji,
+        conversationExamples: 'not-an-array' as unknown as Emoji['conversationExamples'],
+      });
+      expect(errors.some((e) => e.field === 'conversationExamples')).toBe(true);
+    });
+
+    it('passes the golden deep-tier skull fixture', () => {
+      // SKULL_DEEP_EMOJI is a published fixture so we import it directly.
+      // Using dynamic require avoids a circular static import.
+      const { SKULL_DEEP_EMOJI } = require('../../utils/fixtures/emojis.fixtures') as {
+        SKULL_DEEP_EMOJI: Emoji;
+      };
+      expect(validateEmoji(SKULL_DEEP_EMOJI)).toEqual([]);
+    });
+  });
+
+  describe('deep-tier threshold constants', () => {
+    it('exposes the documented thresholds', () => {
+      expect(DEEP_OVERVIEW_MIN_WORDS).toBe(120);
+      expect(DEEP_CONVERSATION_EXAMPLES_MIN).toBe(3);
+      expect(DEEP_FAQS_MIN).toBe(3);
+      expect(DEEP_PLATFORM_NOTE_MIN_CHARS).toBe(40);
     });
   });
 });

--- a/tests/utils/fixtures/emojis.fixtures.ts
+++ b/tests/utils/fixtures/emojis.fixtures.ts
@@ -454,10 +454,144 @@ export const SKIN_TONE_VARIATION_EMOJI: Emoji = {
 };
 
 /**
- * All emoji fixtures as an array
+ * Deep-tier skull emoji — golden reference for CONTENT-P1-001.
+ * Used by rendering and validation tests to prove long-form fields
+ * survive the full pipeline (loader → page → JSON-LD) and to give
+ * writers a concrete example to imitate.
+ *
+ * Word counts and FAQ counts are intentionally above the deep-tier
+ * minimums in `scripts/validate-emojis.ts`.
  */
+export const SKULL_DEEP_EMOJI: Emoji = {
+  unicode: '1F480',
+  slug: 'skull-deep-fixture',
+  character: '💀',
+  name: 'Skull (Deep)',
+  shortName: 'skull',
+  category: 'faces',
+  subcategory: 'face-negative',
+  unicodeVersion: '6.0',
+  baseMeaning: 'A human skull, often used to represent death or danger in traditional contexts.',
+  tldr: "Usually means 'that's so funny I'm dead' or ironic disbelief, not actual death.",
+  contextMeanings: [
+    {
+      context: 'SLANG',
+      meaning: "Something is extremely funny - 'I'm dead' from laughing.",
+      example: 'That meme 💀💀💀',
+      riskLevel: 'LOW',
+    },
+    {
+      context: 'IRONIC',
+      meaning: 'Expressing disbelief or embarrassment.',
+      example: "I can't believe I said that 💀",
+      riskLevel: 'LOW',
+    },
+    {
+      context: 'PASSIVE_AGGRESSIVE',
+      meaning: 'Can indicate annoyance when used sarcastically.',
+      example: 'Oh great, another meeting 💀',
+      riskLevel: 'MEDIUM',
+    },
+  ],
+  platformNotes: [
+    {
+      platform: 'TIKTOK',
+      note: 'Used in comment sections under viral clips to signal that the creator died of laughter; pairs with repeated 💀💀💀 to amplify the reaction.',
+    },
+    {
+      platform: 'TWITTER',
+      note: 'Common in quote-tweets to react to a brutal or absurd take; one skull feels measured, three feels performative.',
+    },
+    {
+      platform: 'INSTAGRAM',
+      note: 'Shows up in DMs when a friend shares an embarrassing throwback photo and the sender pretends to have perished from secondhand cringe.',
+    },
+  ],
+  generationalNotes: [
+    {
+      generation: 'GEN_Z',
+      note: "Almost exclusively means 'I'm dead (from laughing)'.",
+    },
+    {
+      generation: 'MILLENNIAL',
+      note: 'Similar usage to Gen Z, but may sometimes use it literally.',
+    },
+    {
+      generation: 'BOOMER',
+      note: 'May interpret as morbid or related to death/Halloween.',
+    },
+  ],
+  warnings: [
+    {
+      title: 'Generational misunderstanding',
+      description:
+        "Can be misinterpreted as morbid by older generations who may not understand the 'I'm dead' slang.",
+      severity: 'LOW',
+    },
+  ],
+  relatedCombos: ['skull-laughing'],
+  seoTitle: '💀 Skull Emoji Meaning - What Does 💀 Really Mean?',
+  seoDescription:
+    "Learn what the skull emoji 💀 really means in modern texting. Usually means 'I'm dead' from laughing, not actual death. Context guide for all platforms.",
+  contentTier: 'deep',
+  contentUpdatedAt: '2026-01-15',
+  longForm: {
+    overview:
+      "The skull emoji has drifted far from its literal meaning of death or danger. On TikTok, Twitter, Instagram, and iMessage it now almost always signals that the sender is 'dead' from laughter, secondhand embarrassment, or a reaction so absurd they cannot form words. The shift happened during the late 2010s as Gen Z made 😂 feel overexposed and adopted 💀 as the default marker of peak amusement. Today, sending 💀 usually means the joke landed harder than expected, the sender is cringing hard on your behalf, or they are reacting to something so wild they have nothing left to say. Treat 💀 as a vibe marker rather than a literal statement: the strength of the reaction is the point, and the recipient is expected to laugh, wince, or send a skull right back. Writers should remember that the emoji is rarely used alone in serious or professional contexts because its energy is performatively extreme.",
+    howPeopleUseIt:
+      "In real chats, 💀 tends to arrive after a punchline, a cursed screenshot, or a piece of news that is too stupid to be real. People send a single skull to show measured appreciation and a string of three or more skulls (💀💀💀) when the moment is genuinely devastating. It pairs naturally with 😭, with a screenshot of the offending content, and with phrases like 'I cannot' or 'I'm done.' It almost never appears alone in serious or professional contexts because its energy is performatively extreme.",
+    whenNotToUse:
+      'Skip 💀 when you are actually grieving, when the other person has shared something genuinely painful, or in any professional channel where the recipient may read it literally. Avoid using it as a response to bad news, layoffs, or a hospital update, even ironically. Boomer and Gen X recipients sometimes read the skull as morbid or threatening, so if you are texting an older relative, reach for 😂 or 😬 instead. In customer support or HR contexts, � will read as disrespectful regardless of intent.',
+    howToReply:
+      "If someone sends you 💀 and you want to keep the energy, mirror them with another skull, with 😭, or with a screenshot of whatever they are reacting to. If you want to slow the bit down, you can reply with a softer 😅 or a 'wait, actually?' to pull the conversation back to literal mode. If the skull landed on something you shared and it feels like a brush-off, you can ask 'too far?' and most people will clarify that they meant it affectionately.",
+    faqs: [
+      {
+        question: 'What does the skull emoji mean from a girl?',
+        answer:
+          "From a girl or anyone else, 💀 almost always means 'I'm dead' from laughing, not anything romantic or threatening. Context still matters: paired with a screenshot of something absurd it reads as amusement, paired with a complaint it can read as sarcastic frustration.",
+      },
+      {
+        question: 'Is 💀 flirty?',
+        answer:
+          'Usually no. The skull is rarely used to flirt directly; it signals that the sender is dying of laughter. If flirtation is involved it tends to come from the surrounding message rather than the emoji itself, and you should look at the full sentence to be sure.',
+      },
+      {
+        question: 'What does 💀 mean from a guy?',
+        answer:
+          "From a guy, 💀 has the same meaning it has from anyone else: an exaggerated 'I am dead' reaction. There is no gendered twist — the emoji is about the strength of the reaction, not who is sending it.",
+      },
+    ],
+  },
+  conversationExamples: [
+    {
+      setting: 'friends',
+      message: 'bro i just tripped into the projector at work 💀',
+      interpretation:
+        'Sender is laughing at their own embarrassment and wants you to laugh with them. Mirror the energy with another skull or 😭.',
+    },
+    {
+      setting: 'work',
+      message: 'reminder: all-hands at 8am tomorrow 💀',
+      interpretation:
+        'Sarcastic exhaustion about an early meeting. Probably not literal anger, but do not reply with another skull in a wide team channel; it reads as performative.',
+    },
+    {
+      setting: 'dating',
+      message: "you actually remembered 💀 i'm impressed",
+      interpretation:
+        "Playful disbelief mixed with a compliment. A warm reply that acknowledges the 'impressed' part works better than another skull here.",
+    },
+    {
+      setting: 'social',
+      message: 'did you see that reply from the brand account 💀💀💀',
+      interpretation:
+        'Group chat hype about a public reply worth screenshotting. Drop the screenshot or a quote-tweet instead of just more skulls to keep the thread moving.',
+    },
+  ],
+};
 export const ALL_EMOJI_FIXTURES: Emoji[] = [
   SKULL_EMOJI,
+  SKULL_DEEP_EMOJI,
   FIRE_EMOJI,
   HEART_EMOJI,
   THUMBS_UP_EMOJI,


### PR DESCRIPTION
## Summary

Builds on the original long-form content model by extending it to combo
pages and shipping actual deep content at scale so the framework becomes
visible across a meaningful slice of the site.

* Add `ComboLongForm`, `ComboFaq`, `ComboConversationExample`,
  `ComboConversationSetting`, and `ComboContentTier` types plus the
  matching optional fields on `EmojiCombo`. Combo JSON files can now
  opt into the deep tier without breaking the existing schema.
* Extract the article renderer into a shared `LongFormSection` under
  `components/ui/` and refactor `EmojiLongFormSection` to wrap it. Add
  `ComboLongFormSection` and `ComboConversationExamplesSection` as
  thin wrappers so emoji and combo pages share the same rendering
  logic while keeping distinct testids.
* Render the new sections on `/combo/[slug]` right after the existing
  description block, conditional on `longForm` / `conversationExamples`
  being present so thin pages stay visually unchanged.
* Emit an `FAQPage` entity inside the `@graph` of combo JSON-LD when
  `longForm.faqs` is present, matching the emoji-side behavior so
  search engines can pick up "People Also Ask" style answers.
* Publish deep content for **30 emoji pages** and **18 combo pages**:
  * Emoji (30): `skull`, `fire`, `thumbs-up`, `face-with-tears-of-joy`,
    `100`, `heart`, `pleading`, `sparkles`, `loudly-crying-face`,
    `folded-hands`, `thinking`, `eyes`, `party-popper`, `clapping`,
    `smiling-face-with-smiling-eyes`, `sunglasses`, `face-blowing-a-kiss`,
    `smiling-hearts`, `kiss-mark`, `two-hearts`, `broken-heart`, `star`,
    `check-mark`, `raising-hands`, `smiling-face`, `winking-face`,
    `blue-heart`, `face-with-rolling-eyes`, `unamused`, `grimacing`.
  * Combos (18): `skull-laughing`, `fire-100`, `heart-eyes`, `clap-back`,
    `smirk-wink`, `eggplant-peach`, `clown-face`, `fire-heart`,
    `100-fire`, `heart-eyes-fire`, `eyes-tea`, `double-hearts`,
    `peach-eggplant`, `sob-broken-heart`, `laughing-crying-repeat`,
    `red-flags-dating`, `sob-laughing`, `nail-polish-sparkles`.
  Each entry has a 200+ word overview, the four sub-sections, four
  FAQs, and five conversation examples spanning dating, work, friends,
  family, and social settings. Emoji files also carry four platform
  notes tuned to real platform behavior.

## Test plan

* Unit tests cover the new combo components, the shared renderer, and
  the new `FAQPage` emission path in combo JSON-LD; coverage stays at
  functions 99.35% / lines 99.54% (above the 99.3% / 99.4%
  thresholds) with all 3560 tests passing.
* `bun run typecheck`, `bun run lint`, `bun run validate:emojis`,
  `bun run test:coverage`, and `bun run build` all pass; all 4,086
  emoji and 75 combo files continue to validate against the deep-tier
  thresholds.

## Out of scope

* No CMS / admin tooling — the Phase 1 JSON workflow is preserved.
* No AdSense ad unit placement.
* Deep content for the remaining ~4,056 emoji and ~57 combo files
  will land in CONTENT-P1-002 (now that the framework is proven and
  writers have the guide in `docs/emoji-content-guide.md`).

Fixes #340