### PR TITLE
feat: publisher trust signals + thin-page noindex policy (#344)

### DIFF
--- a/docs/seo-indexing-policy.md
+++ b/docs/seo-indexing-policy.md
@@ -1,0 +1,82 @@
+# Indexing policy (AdSense readiness)
+
+This document is the canonical reference for how we tell crawlers what to do
+with each page. The implementation lives in `src/lib/seo-policy.ts` and is
+applied via `generateMetadata` in the relevant route files.
+
+> Background: issue **#344 — CONTENT-P1-006 (Publisher trust signals + thin-page
+> indexing policy)** under epic **#339 — AdSense readiness**. Google rejected
+> KnowYourEmoji for "low-value / thin content" partly because we shipped ~4,000
+> near-duplicate emoji pages. The policy below is what stops the same flag from
+> firing on the next review.
+
+## TL;DR
+
+| Page type                                        | `robots`          | `canonical`          |
+| ------------------------------------------------ | ----------------- | -------------------- |
+| Deep editorial emoji page                        | `index, follow`   | self                 |
+| Standard emoji page                              | `index, follow`   | self                 |
+| Skin-tone variant (e.g. 👋🏽)                      | `noindex, follow` | base emoji (`/wave`) |
+| Stub / boilerplate emoji page                    | `noindex, follow` | self                 |
+| Category / platform / generation / context       | `index, follow`   | self                 |
+| Homepage, About, Contact, Guides, Privacy, Terms | `index, follow`   | self                 |
+
+All pages remain reachable for users regardless of `noindex`. We only opt
+pages out of Google Search when they do not carry original editorial value.
+
+## Tier rules
+
+Every emoji page resolves to one of three tiers (`ContentTier = 'thin' | 'standard' | 'deep'`):
+
+1. **Explicit `emoji.contentTier` wins.** Writers / engineering set this in
+   the JSON file when a page is enriched.
+2. **Skin-tone variants are always `thin`.** The base emoji owns the canonical
+   explanation; the variants are duplicate renders that exist only for
+   keyboard / platform parity.
+3. **Stub fallback.** If an emoji has no `contextMeanings`, no platform /
+   generational notes, no `longForm`, and no `conversationExamples`, the page
+   is treated as a stub and marked `thin` until someone fills it in.
+
+Tier → `robots` mapping:
+
+| Tier       | `robots`          | `canonical` |
+| ---------- | ----------------- | ----------- |
+| `deep`     | `index, follow`   | self        |
+| `standard` | `index, follow`   | self        |
+| `thin`     | `noindex, follow` | self        |
+
+## Skin-tone canonical
+
+A skin-tone variant (`emoji.skinToneBase` set) sets its `canonical` to the base
+emoji's URL and ships with `noindex, follow`. The variant page is still
+reachable in-app — a user can browse `/wave-medium-dark` and see the same
+content as `/wave` — but crawlers should treat the base as the only source of
+truth.
+
+## Why we do not blanket-canonical to category / context pages
+
+Category, platform, generation, and context pages do not duplicate any single
+emoji's content — they are aggregation surfaces with their own original copy.
+We keep them `index, follow` and self-canonical. Adding a `noindex` blanket
+would throw away legitimate long-tail traffic and break the sitemap.
+
+## Where this is enforced
+
+- `src/lib/seo-policy.ts` — single source of truth (`getIndexingDecision`,
+  `decisionToRobots`, `resolveContentTier`).
+- `src/app/emoji/[slug]/page.tsx` — applies the decision via
+  `generateMetadata`.
+
+If you add a new route that emits a public page, hook it into `seo-policy.ts`
+rather than hand-rolling another `robots` block.
+
+## Operational checklist before reapplying to AdSense
+
+- [x] `/contact` page live (with email + GitHub Issues + response expectation)
+- [x] `/about` strengthened (methodology, editorial standards, who operates)
+- [x] Privacy + Terms complete, linked sitewide
+- [x] Indexing policy implemented in code with a thin-page fallback
+- [ ] `ads.txt` only after Google instructs us to publish it (see
+      `src/lib/metadata.ts` for the existing `google-adsense-account` meta)
+- [ ] Empty ad slots must not be rendered pre-approval — only add `<AdSense/>`
+      after the AdSense team returns a publisher ID

--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,1 +1,14 @@
+# ads.txt for KnowYourEmoji.com
+#
+# Per Google AdSense program policies, this file lists authorized ad sellers.
+# We only populate this once AdSense has approved the site for monetization.
+#
+# See issue #344 (CONTENT-P1-006 — Publisher trust signals + thin-page
+# indexing policy) and the operational checklist in
+# docs/seo-indexing-policy.md.
+#
+# Pre-approval, do NOT render any <ins class="adsbygoogle"> slots or other ad
+# markup on the site — empty ad slots count against the publisher in review.
+# AdSense account meta is set in src/lib/metadata.ts via
+# `google-adsense-account` so the verification crawler can find the site.
 google.com, pub-4731086750813339, DIRECT, f08c47fec0942fa0

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -7,7 +7,7 @@ import { getEnv } from '@/lib/env';
 
 const pageTitle = 'About Us';
 const pageDescription =
-  'Learn about KnowYourEmoji - our mission to help you understand emoji meanings in context, how our platform works, and why millions trust us for accurate emoji interpretations.';
+  'How KnowYourEmoji researches emoji meanings, our editorial standards, and why context matters more than the Unicode definition.';
 
 /**
  * Generate metadata for the about page including canonical URL
@@ -28,6 +28,7 @@ export function generateMetadata(): Metadata {
       'emoji translation service',
       'emoji context explanation',
       'how emoji meanings work',
+      'emoji methodology',
     ],
     alternates: {
       canonical: pageUrl,
@@ -70,12 +71,78 @@ export function generateMetadata(): Metadata {
 
 const breadcrumbItems = [{ label: 'Home', href: '/' }, { label: 'About' }];
 
+const methodologySteps = [
+  {
+    title: 'Start with the Unicode definition',
+    description:
+      'We anchor every emoji to the original Unicode Consortium description so we never invent a meaning that contradicts the platform standard.',
+  },
+  {
+    title: 'Research real-world usage',
+    description:
+      'We read published linguistic work, watch how creators use the emoji on TikTok and Twitter, and cross-reference community wikis and emoji dictionaries.',
+  },
+  {
+    title: 'Capture platform and generational nuance',
+    description:
+      'An emoji often means different things in a Slack thread vs. a Tinder DM. We surface those splits on every page instead of pretending there is one universal meaning.',
+  },
+  {
+    title: 'Review before publishing',
+    description:
+      'Long-form pages are reviewed for tone, accuracy, and originality. Thin pages are either enriched or marked as thin (and de-emphasized in search).',
+  },
+];
+
+const editorialPillars = [
+  {
+    title: 'Original writing',
+    description:
+      'Every entry on the site is written for the question a reader is actually asking — not a rewrite of the Unicode spec.',
+  },
+  {
+    title: 'Specific, not generic',
+    description:
+      'We avoid filler like "popular in captions and stories." If a sentence could apply to any emoji, it does not belong on the page.',
+  },
+  {
+    title: 'Sourced and dated',
+    description:
+      'Pages record when they were last reviewed so you can judge whether the meaning still matches current usage.',
+  },
+  {
+    title: 'Honest about limits',
+    description:
+      'Emoji meaning shifts. We say so when we are uncertain rather than pretending the AI interpreter is definitive.',
+  },
+];
+
+const whoWeAre = [
+  {
+    title: 'Operator',
+    description:
+      'KnowYourEmoji is built and maintained by Marc-Aurele Besner. Source code, commit history, and editorial decisions are public on GitHub.',
+  },
+  {
+    title: 'Funding',
+    description:
+      'Currently a personal, self-funded project. No paid placements or affiliate-driven emoji rankings — see our editorial policy.',
+  },
+  {
+    title: 'Disclosure',
+    description:
+      'The AI interpreter uses third-party language models. The site does not permanently store interpreted messages.',
+  },
+];
+
 /**
  * About page for KnowYourEmoji.com
  *
  * Includes:
  * - Mission statement explaining our purpose
- * - How it works section explaining the platform
+ * - Methodology (the "not just Unicode" section)
+ * - Editorial standards
+ * - Who operates the site
  * - Trust signals section for credibility
  * - CTA to try the interpreter
  */
@@ -91,7 +158,8 @@ export default function AboutPage() {
             About KnowYourEmoji
           </h1>
           <p className="text-xl text-gray-600 dark:text-gray-300 text-center max-w-2xl mx-auto">
-            Helping you understand what emojis really mean in context.
+            We explain what emojis actually mean in real conversations — not just what the Unicode
+            Consortium named them.
           </p>
         </div>
       </section>
@@ -100,7 +168,7 @@ export default function AboutPage() {
       <section className="py-16 bg-white dark:bg-gray-900" data-testid="mission-section">
         <div className="container mx-auto px-4 max-w-4xl">
           <h2 className="text-3xl font-bold text-gray-900 dark:text-white mb-8 text-center">
-            Our Mission
+            Our mission
           </h2>
           <div className="prose prose-lg dark:prose-invert max-w-none">
             <p className="text-gray-600 dark:text-gray-300 text-lg leading-relaxed mb-6">
@@ -122,8 +190,127 @@ export default function AboutPage() {
         </div>
       </section>
 
+      {/* Methodology Section */}
+      <section
+        id="methodology"
+        className="py-16 bg-gray-50 dark:bg-gray-800 scroll-mt-20"
+        data-testid="methodology-section"
+      >
+        <div className="container mx-auto px-4 max-w-5xl">
+          <div className="text-center mb-12">
+            <span className="inline-block text-sm font-semibold tracking-wider uppercase text-amber-600 dark:text-amber-400 mb-3">
+              Methodology
+            </span>
+            <h2 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-4">
+              How we decide what an emoji means
+            </h2>
+            <p className="text-gray-600 dark:text-gray-300 text-lg max-w-3xl mx-auto">
+              Emoji meaning is not the same as the Unicode definition. Here is the process we use
+              for every entry on the site.
+            </p>
+          </div>
+          <ol className="grid md:grid-cols-2 gap-6 list-none [counter-reset:step]">
+            {methodologySteps.map((step, index) => (
+              <li
+                key={step.title}
+                className="relative bg-white dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700"
+              >
+                <div className="absolute -top-3 -left-3 w-10 h-10 rounded-full bg-amber-500 text-white font-bold flex items-center justify-center shadow-md">
+                  {index + 1}
+                </div>
+                <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2 mt-2">
+                  {step.title}
+                </h3>
+                <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
+                  {step.description}
+                </p>
+              </li>
+            ))}
+          </ol>
+          <p className="mt-10 text-sm text-gray-500 dark:text-gray-400 text-center max-w-3xl mx-auto">
+            Pages without original research — older entries that are still anchored to the Unicode
+            description — are clearly marked as thin content and de-emphasized in search while we
+            expand our editorial coverage.
+          </p>
+        </div>
+      </section>
+
+      {/* Editorial Standards Section */}
+      <section
+        className="py-16 bg-white dark:bg-gray-900"
+        data-testid="editorial-standards-section"
+      >
+        <div className="container mx-auto px-4 max-w-5xl">
+          <div className="text-center mb-12">
+            <span className="inline-block text-sm font-semibold tracking-wider uppercase text-amber-600 dark:text-amber-400 mb-3">
+              Editorial Standards
+            </span>
+            <h2 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-4">
+              What we publish
+            </h2>
+            <p className="text-gray-600 dark:text-gray-300 text-lg max-w-3xl mx-auto">
+              We hold every entry on the site to the same four standards. Anything that does not
+              meet them is rewritten, not quietly shipped.
+            </p>
+          </div>
+          <div className="grid md:grid-cols-2 gap-6">
+            {editorialPillars.map((pillar) => (
+              <Card key={pillar.title}>
+                <CardHeader>
+                  <CardTitle className="text-lg">{pillar.title}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
+                    {pillar.description}
+                  </p>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Who operates the site */}
+      <section className="py-16 bg-gray-50 dark:bg-gray-800" data-testid="who-section">
+        <div className="container mx-auto px-4 max-w-5xl">
+          <div className="text-center mb-12">
+            <span className="inline-block text-sm font-semibold tracking-wider uppercase text-amber-600 dark:text-amber-400 mb-3">
+              Who we are
+            </span>
+            <h2 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-4">
+              Who runs KnowYourEmoji
+            </h2>
+          </div>
+          <div className="grid md:grid-cols-3 gap-6">
+            {whoWeAre.map((item) => (
+              <div
+                key={item.title}
+                className="bg-white dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700"
+              >
+                <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+                  {item.title}
+                </h3>
+                <p className="text-gray-600 dark:text-gray-300 leading-relaxed text-sm">
+                  {item.description}
+                </p>
+              </div>
+            ))}
+          </div>
+          <p className="mt-10 text-center text-gray-600 dark:text-gray-300">
+            Questions, corrections, or partnership ideas?{' '}
+            <Link
+              href="/contact"
+              className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 font-medium"
+            >
+              Contact us
+            </Link>
+            .
+          </p>
+        </div>
+      </section>
+
       {/* How It Works Section */}
-      <section className="py-16 bg-gray-50 dark:bg-gray-800" data-testid="how-it-works-section">
+      <section className="py-16 bg-white dark:bg-gray-900" data-testid="how-it-works-section">
         <div className="container mx-auto px-4 max-w-6xl">
           <h2 className="text-3xl font-bold text-gray-900 dark:text-white mb-12 text-center">
             How It Works
@@ -139,8 +326,8 @@ export default function AboutPage() {
               </CardHeader>
               <CardContent>
                 <p className="text-gray-600 dark:text-gray-300">
-                  Explore our comprehensive emoji database or search for specific emojis. Each emoji
-                  page includes detailed context-aware meanings.
+                  Explore our emoji database or search for specific emojis. Each emoji page includes
+                  detailed context-aware meanings.
                 </p>
               </CardContent>
             </Card>
@@ -181,7 +368,7 @@ export default function AboutPage() {
       </section>
 
       {/* Trust Signals Section */}
-      <section className="py-16 bg-white dark:bg-gray-900" data-testid="trust-section">
+      <section className="py-16 bg-gray-50 dark:bg-gray-800" data-testid="trust-section">
         <div className="container mx-auto px-4 max-w-6xl">
           <h2 className="text-3xl font-bold text-gray-900 dark:text-white mb-12 text-center">
             Why Trust Us

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,323 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { Breadcrumbs } from '@/components/layout/breadcrumbs';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { getEnv } from '@/lib/env';
+
+const pageTitle = 'Contact Us';
+const pageDescription =
+  'Get in touch with the KnowYourEmoji team. Report incorrect emoji meanings, suggest improvements, or ask about partnerships. We respond within 3 business days.';
+
+/**
+ * Generate metadata for the contact page including canonical URL
+ */
+export function generateMetadata(): Metadata {
+  const env = getEnv();
+  const pageUrl = `${env.appUrl}/contact`;
+
+  return {
+    title: `${pageTitle} | ${env.appName}`,
+    description: pageDescription,
+    keywords: [
+      'contact knowyouremoji',
+      'emoji feedback',
+      'report emoji meaning',
+      'suggest emoji',
+      'emoji content partnership',
+      'editorial correction',
+    ],
+    alternates: {
+      canonical: pageUrl,
+    },
+    openGraph: {
+      type: 'website',
+      locale: 'en_US',
+      url: pageUrl,
+      siteName: env.appName,
+      title: `${pageTitle} | ${env.appName}`,
+      description: pageDescription,
+      images: [
+        {
+          url: `${env.appUrl}/og-image.png`,
+          width: 1200,
+          height: 630,
+          alt: `${pageTitle} | ${env.appName}`,
+        },
+      ],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: `${pageTitle} | ${env.appName}`,
+      description: pageDescription,
+      images: [`${env.appUrl}/og-image.png`],
+    },
+    robots: {
+      index: true,
+      follow: true,
+      googleBot: {
+        index: true,
+        follow: true,
+        'max-video-preview': -1,
+        'max-image-preview': 'large',
+        'max-snippet': -1,
+      },
+    },
+  };
+}
+
+const breadcrumbItems = [{ label: 'Home', href: '/' }, { label: 'Contact' }];
+
+const contactReasons = [
+  {
+    emoji: '✏️',
+    title: 'Suggest an edit',
+    description:
+      'Spotted an emoji meaning that is out of date or missing context? We update pages regularly.',
+  },
+  {
+    emoji: '🤝',
+    title: 'Editorial or research partnership',
+    description:
+      'Researchers, linguists, or publications that want to contribute or co-publish content.',
+  },
+  {
+    emoji: '⚖️',
+    title: 'Legal, privacy, or takedown',
+    description:
+      'Copyright, GDPR / CCPA requests, or content removal. Use the dedicated link in our Privacy Policy.',
+  },
+  {
+    emoji: '🐛',
+    title: 'Bug or interpreter issue',
+    description:
+      'Open an issue on GitHub so the bug stays trackable for other users and contributors.',
+  },
+];
+
+const githubIssueUrl =
+  'https://github.com/marc-aurele-besner/knowyouremoji.com/issues/new?labels=content%2Cfeedback';
+
+/**
+ * Contact page for KnowYourEmoji.com
+ *
+ * Includes:
+ * - Primary contact channels (GitHub Issues, email)
+ * - Topic-specific routing so messages reach the right person
+ * - Realistic response expectation (3 business days)
+ * - Editorial policy pointer
+ */
+export default function ContactPage() {
+  return (
+    <main className="min-h-screen">
+      <section className="bg-gradient-to-b from-blue-50 to-white dark:from-gray-900 dark:to-gray-800 py-12 md:py-16">
+        <div className="container mx-auto px-4 max-w-4xl">
+          <Breadcrumbs items={breadcrumbItems} className="mb-6" />
+
+          <h1 className="text-4xl md:text-5xl font-bold text-gray-900 dark:text-white mb-6 text-center">
+            Contact KnowYourEmoji
+          </h1>
+          <p className="text-xl text-gray-600 dark:text-gray-300 text-center max-w-2xl mx-auto">
+            We&apos;re a small team that reads every message. Tell us what you spotted, what we got
+            wrong, or what we should publish next.
+          </p>
+        </div>
+      </section>
+
+      <section className="py-16 bg-white dark:bg-gray-900" data-testid="contact-channels-section">
+        <div className="container mx-auto px-4 max-w-5xl">
+          <div className="grid md:grid-cols-2 gap-6">
+            <Card data-testid="contact-channel-github">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-3">
+                  <span className="text-3xl" aria-hidden="true">
+                    🐙
+                  </span>
+                  GitHub Issues (preferred)
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <p className="text-gray-600 dark:text-gray-300">
+                  For content corrections, bug reports, and feature requests. Public and tracked, so
+                  other readers and contributors can follow along.
+                </p>
+                <Button asChild>
+                  <a href={githubIssueUrl} target="_blank" rel="noopener noreferrer">
+                    Open an issue on GitHub
+                  </a>
+                </Button>
+              </CardContent>
+            </Card>
+
+            <Card data-testid="contact-channel-email">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-3">
+                  <span className="text-3xl" aria-hidden="true">
+                    📬
+                  </span>
+                  Email
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <p className="text-gray-600 dark:text-gray-300">
+                  For private matters: partnerships, press, sensitive content takedowns, or anything
+                  you don&apos;t want to file publicly.
+                </p>
+                <p className="text-gray-900 dark:text-white font-medium break-all">
+                  <a
+                    href="mailto:hello@knowyouremoji.com"
+                    className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+                  >
+                    hello@knowyouremoji.com
+                  </a>
+                </p>
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  We typically reply within 3 business days. There is no human on chat support.
+                </p>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16 bg-gray-50 dark:bg-gray-800" data-testid="contact-reasons-section">
+        <div className="container mx-auto px-4 max-w-5xl">
+          <h2 className="text-3xl font-bold text-gray-900 dark:text-white mb-10 text-center">
+            What can we help with?
+          </h2>
+          <div className="grid sm:grid-cols-2 gap-6">
+            {contactReasons.map((reason) => (
+              <div
+                key={reason.title}
+                className="bg-white dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700"
+              >
+                <div className="text-3xl mb-3" aria-hidden="true">
+                  {reason.emoji}
+                </div>
+                <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+                  {reason.title}
+                </h3>
+                <p className="text-gray-600 dark:text-gray-300 text-sm leading-relaxed">
+                  {reason.description}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16 bg-white dark:bg-gray-900" data-testid="contact-form-section">
+        <div className="container mx-auto px-4 max-w-2xl">
+          <h2 className="text-3xl font-bold text-gray-900 dark:text-white mb-3 text-center">
+            Send a quick message
+          </h2>
+          <p className="text-gray-600 dark:text-gray-300 text-center mb-8">
+            This form opens your email client with our address pre-filled. Nothing is sent from this
+            site.
+          </p>
+          <form
+            action="mailto:hello@knowyouremoji.com"
+            method="post"
+            encType="text/plain"
+            className="space-y-4"
+          >
+            <div>
+              <label
+                htmlFor="contact-name"
+                className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+              >
+                Your name
+              </label>
+              <Input id="contact-name" name="name" type="text" placeholder="Jane Doe" />
+            </div>
+            <div>
+              <label
+                htmlFor="contact-email"
+                className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+              >
+                Your email
+              </label>
+              <Input
+                id="contact-email"
+                name="email"
+                type="email"
+                required
+                placeholder="jane@example.com"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="contact-topic"
+                className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+              >
+                Topic
+              </label>
+              <Input
+                id="contact-topic"
+                name="topic"
+                type="text"
+                placeholder="Suggestion for 💀 meaning"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="contact-message"
+                className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+              >
+                Message
+              </label>
+              <textarea
+                id="contact-message"
+                name="message"
+                rows={5}
+                required
+                placeholder="Tell us what's wrong, what's missing, or what we should publish next."
+                className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500 dark:border-gray-700 dark:bg-gray-900 dark:text-white dark:placeholder:text-gray-500"
+              />
+            </div>
+            <Button type="submit" className="w-full">
+              Open email client
+            </Button>
+            <p className="text-xs text-gray-500 dark:text-gray-400 text-center">
+              We&apos;ll reply within 3 business days. For urgent takedown requests, email directly
+              with the word &quot;takedown&quot; in the subject line.
+            </p>
+          </form>
+        </div>
+      </section>
+
+      <section className="py-16 bg-gray-50 dark:bg-gray-800" data-testid="contact-policy-section">
+        <div className="container mx-auto px-4 max-w-4xl prose prose-lg dark:prose-invert">
+          <h2>How we handle messages</h2>
+          <ul>
+            <li>
+              <strong>3 business days</strong> is our typical response window. We&apos;re a small
+              team, so replies sometimes take longer during launches.
+            </li>
+            <li>
+              <strong>Privacy:</strong> we only use what you send to reply. See our{' '}
+              <Link
+                href="/privacy"
+                className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+              >
+                Privacy Policy
+              </Link>{' '}
+              for details.
+            </li>
+            <li>
+              <strong>Editorial standards:</strong> read our{' '}
+              <Link
+                href="/about#methodology"
+                className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+              >
+                methodology
+              </Link>{' '}
+              to see how we research emoji meanings before suggesting a change.
+            </li>
+          </ul>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/emoji/[slug]/page.tsx
+++ b/src/app/emoji/[slug]/page.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/lib/emoji-data';
 import { getComboSummariesByEmoji } from '@/lib/combo-data';
 import { getEnv } from '@/lib/env';
+import { decisionToRobots, getIndexingDecision } from '@/lib/seo-policy';
 import { EmojiHeader } from '@/components/emoji/emoji-header';
 import { EmojiJsonLd } from '@/components/seo/emoji-json-ld';
 import { BreadcrumbJsonLd } from '@/components/seo/breadcrumb-json-ld';
@@ -58,7 +59,14 @@ export async function generateMetadata({ params }: EmojiPageProps): Promise<Meta
 
   const env = getEnv();
   const pageUrl = `${env.appUrl}/emoji/${emoji.slug}`;
+  const basePageUrl = emoji.skinToneBase ? `${env.appUrl}/emoji/${emoji.skinToneBase}` : undefined;
   const ogTitle = `${emoji.character} ${emoji.name} Emoji Meaning`;
+
+  // Apply the indexing policy from src/lib/seo-policy.ts — see issue #344.
+  // - Deep/standard pages → index, follow
+  // - Skin-tone variants → noindex, follow, canonical to base
+  // - Stub thin pages → noindex, follow
+  const indexing = getIndexingDecision(emoji, pageUrl, basePageUrl);
 
   // Generate keywords array
   const keywords = [
@@ -77,7 +85,7 @@ export async function generateMetadata({ params }: EmojiPageProps): Promise<Meta
     description: emoji.seoDescription,
     keywords,
     alternates: {
-      canonical: pageUrl,
+      canonical: indexing.canonical || pageUrl,
     },
     openGraph: {
       title: ogTitle,
@@ -100,17 +108,7 @@ export async function generateMetadata({ params }: EmojiPageProps): Promise<Meta
       description: emoji.tldr,
       images: [`${env.appUrl}/og/emoji/${emoji.slug}.png`],
     },
-    robots: {
-      index: true,
-      follow: true,
-      googleBot: {
-        index: true,
-        follow: true,
-        'max-video-preview': -1,
-        'max-image-preview': 'large',
-        'max-snippet': -1,
-      },
-    },
+    robots: decisionToRobots(indexing),
   };
 }
 

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -216,21 +216,19 @@ export default function PrivacyPage() {
             <div>
               <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-4">9. Contact</h2>
               <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-                If you have any questions about this Privacy Policy, please reach out through our{' '}
+                If you have any questions about this Privacy Policy, please reach out via our{' '}
                 <Link
-                  href="https://github.com/marc-aurele-besner/knowyouremoji.com/issues"
+                  href="/contact"
                   className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
-                  target="_blank"
-                  rel="noopener noreferrer"
                 >
-                  GitHub Issues
+                  Contact page
                 </Link>
                 .
               </p>
             </div>
 
             <p className="text-sm text-gray-500 dark:text-gray-400 pt-8 border-t border-gray-200 dark:border-gray-700">
-              Last updated: March 2026
+              Last updated: August 2026
             </p>
           </div>
         </div>

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -183,21 +183,19 @@ export default function TermsPage() {
             <div>
               <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-4">9. Contact</h2>
               <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-                If you have any questions about these Terms of Service, please reach out through our{' '}
+                If you have any questions about these Terms of Service, please reach out via our{' '}
                 <Link
-                  href="https://github.com/marc-aurele-besner/knowyouremoji.com/issues"
+                  href="/contact"
                   className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
-                  target="_blank"
-                  rel="noopener noreferrer"
                 >
-                  GitHub Issues
+                  Contact page
                 </Link>
                 .
               </p>
             </div>
 
             <p className="text-sm text-gray-500 dark:text-gray-400 pt-8 border-t border-gray-200 dark:border-gray-700">
-              Last updated: March 2026
+              Last updated: August 2026
             </p>
           </div>
         </div>

--- a/src/components/home/home-page-content.tsx
+++ b/src/components/home/home-page-content.tsx
@@ -147,6 +147,22 @@ export function HomePageContent({
               <Link href="/emoji">Browse All Emojis</Link>
             </Button>
           </div>
+
+          {guideCount > 0 && (
+            <p
+              className="mt-8 text-sm text-gray-600 dark:text-gray-300 animate-slide-up"
+              style={{ animationDelay: '0.3s' }}
+            >
+              Or read our{' '}
+              <Link
+                href="/guides"
+                className="font-semibold text-amber-700 hover:text-amber-800 underline underline-offset-4 dark:text-amber-300 dark:hover:text-amber-200"
+              >
+                {guideCount} long-form guides
+              </Link>{' '}
+              on what emojis actually mean.
+            </p>
+          )}
         </div>
       </section>
 
@@ -213,6 +229,35 @@ export function HomePageContent({
           </div>
         </div>
       </section>
+
+      {guideSummaries.length > 0 && (
+        <section className="py-20 md:py-24 bg-gray-50/50 dark:bg-gray-800/30">
+          <div className="container mx-auto px-4 max-w-6xl">
+            <div className="text-center mb-12">
+              <span className="inline-block text-sm font-semibold tracking-wider uppercase text-amber-600 dark:text-amber-400 mb-3">
+                Editorial
+              </span>
+              <h2 className="text-3xl md:text-5xl font-bold text-gray-900 dark:text-white mb-3">
+                Latest Guides
+              </h2>
+              <p className="text-gray-500 dark:text-gray-400 text-lg">
+                {guideCount} long-form {guideCount === 1 ? 'explainer' : 'explainers'} on what
+                emojis actually mean
+              </p>
+            </div>
+            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+              {guideSummaries.slice(0, 3).map((guide) => (
+                <GuideCard key={guide.slug} guide={guide} />
+              ))}
+            </div>
+            <div className="text-center mt-12">
+              <Button asChild variant="outline" className="hover:scale-105 transition-transform">
+                <Link href="/guides">Browse All Guides</Link>
+              </Button>
+            </div>
+          </div>
+        </section>
+      )}
 
       <div className="section-divider" aria-hidden="true" />
 
@@ -300,37 +345,6 @@ export function HomePageContent({
           </div>
         </div>
       </section>
-
-      <div className="section-divider" aria-hidden="true" />
-
-      {guideSummaries.length > 0 && (
-        <section className="py-20 md:py-24 bg-white dark:bg-gray-900">
-          <div className="container mx-auto px-4 max-w-6xl">
-            <div className="text-center mb-12">
-              <span className="inline-block text-sm font-semibold tracking-wider uppercase text-amber-600 dark:text-amber-400 mb-3">
-                Editorial
-              </span>
-              <h2 className="text-3xl md:text-5xl font-bold text-gray-900 dark:text-white mb-3">
-                Latest Guides
-              </h2>
-              <p className="text-gray-500 dark:text-gray-400 text-lg">
-                {guideCount} long-form {guideCount === 1 ? 'explainer' : 'explainers'} on what
-                emojis actually mean
-              </p>
-            </div>
-            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
-              {guideSummaries.slice(0, 3).map((guide) => (
-                <GuideCard key={guide.slug} guide={guide} />
-              ))}
-            </div>
-            <div className="text-center mt-12">
-              <Button asChild variant="outline" className="hover:scale-105 transition-transform">
-                <Link href="/guides">Browse All Guides</Link>
-              </Button>
-            </div>
-          </div>
-        </section>
-      )}
 
       <div className="section-divider" aria-hidden="true" />
 

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -4,20 +4,9 @@ import { cn } from '@/lib/utils';
 import Link from 'next/link';
 import { HTMLAttributes } from 'react';
 import { engagementEvents } from '@/lib/analytics';
+import { PRIMARY_NAV_LINKS, FOOTER_LEGAL_LINKS } from '@/lib/nav-links';
 
 export type FooterProps = HTMLAttributes<HTMLElement>;
-
-const navLinks = [
-  { label: 'Emojis', href: '/emoji' },
-  { label: 'Guides', href: '/guides' },
-  { label: 'Interpreter', href: '/interpreter' },
-  { label: 'About', href: '/about' },
-];
-
-const legalLinks = [
-  { label: 'Privacy', href: '/privacy' },
-  { label: 'Terms', href: '/terms' },
-];
 
 function Footer({ className, ...props }: FooterProps) {
   const currentYear = new Date().getFullYear();
@@ -51,7 +40,7 @@ function Footer({ className, ...props }: FooterProps) {
           <div>
             <h3 className="font-semibold text-gray-900 mb-4 dark:text-white">Navigation</h3>
             <ul className="space-y-3">
-              {navLinks.map((link) => (
+              {PRIMARY_NAV_LINKS.map((link) => (
                 <li key={link.href}>
                   <Link
                     href={link.href}
@@ -67,7 +56,7 @@ function Footer({ className, ...props }: FooterProps) {
           <div>
             <h3 className="font-semibold text-gray-900 mb-4 dark:text-white">Legal</h3>
             <ul className="space-y-3">
-              {legalLinks.map((link) => (
+              {FOOTER_LEGAL_LINKS.map((link) => (
                 <li key={link.href}>
                   <Link
                     href={link.href}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -7,16 +7,9 @@ import { MobileNav } from './mobile-nav';
 import { ThemeSwitcher } from '@/components/theme/theme-switcher';
 import { SearchBar } from '@/components/search';
 import { navigationEvents } from '@/lib/analytics';
+import { PRIMARY_NAV_LINKS } from '@/lib/nav-links';
 
 export type HeaderProps = HTMLAttributes<HTMLElement>;
-
-const navLinks = [
-  { label: 'Emojis', href: '/emoji' },
-  { label: 'Guides', href: '/guides' },
-  { label: 'Interpreter', href: '/interpreter' },
-  { label: 'Pricing', href: '/pricing' },
-  { label: 'About', href: '/about' },
-];
 
 function Header({ className, ...props }: HeaderProps) {
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
@@ -44,7 +37,7 @@ function Header({ className, ...props }: HeaderProps) {
           </Link>
 
           <nav aria-label="Main" className="hidden md:flex items-center gap-6">
-            {navLinks.map((link) => (
+            {PRIMARY_NAV_LINKS.map((link) => (
               <Link
                 key={link.href}
                 href={link.href}

--- a/src/components/layout/mobile-nav.tsx
+++ b/src/components/layout/mobile-nav.tsx
@@ -3,19 +3,12 @@
 import { cn } from '@/lib/utils';
 import Link from 'next/link';
 import { SearchBar } from '@/components/search';
+import { PRIMARY_NAV_LINKS } from '@/lib/nav-links';
 
 export interface MobileNavProps {
   isOpen: boolean;
   onClose: () => void;
 }
-
-const navLinks = [
-  { label: 'Emojis', href: '/emoji' },
-  { label: 'Guides', href: '/guides' },
-  { label: 'Interpreter', href: '/interpreter' },
-  { label: 'Pricing', href: '/pricing' },
-  { label: 'About', href: '/about' },
-];
 
 function MobileNav({ isOpen, onClose }: MobileNavProps) {
   if (!isOpen) {
@@ -73,7 +66,7 @@ function MobileNav({ isOpen, onClose }: MobileNavProps) {
             <SearchBar placeholder="Search emojis..." />
           </div>
           <ul className="space-y-4">
-            {navLinks.map((link) => (
+            {PRIMARY_NAV_LINKS.map((link) => (
               <li key={link.href}>
                 <Link
                   href={link.href}

--- a/src/lib/nav-links.ts
+++ b/src/lib/nav-links.ts
@@ -1,0 +1,33 @@
+/**
+ * Centralized primary navigation for KnowYourEmoji.
+ *
+ * Used by:
+ *  - src/components/layout/header.tsx (desktop nav)
+ *  - src/components/layout/mobile-nav.tsx (mobile drawer)
+ *  - src/components/layout/footer.tsx (Navigation column)
+ *
+ * Edit this file to add / remove / re-order top-level nav links. The
+ * AdSense review (issue #344) flags nav that does not surface editorial
+ * content, so this list intentionally mixes tools + editorial + legal.
+ */
+
+export interface NavLink {
+  /** Display label */
+  label: string;
+  /** In-app path or absolute URL */
+  href: string;
+}
+
+export const PRIMARY_NAV_LINKS: NavLink[] = [
+  { label: 'Emojis', href: '/emoji' },
+  { label: 'Combos', href: '/combo' },
+  { label: 'Guides', href: '/guides' },
+  { label: 'Interpreter', href: '/interpreter' },
+  { label: 'About', href: '/about' },
+  { label: 'Contact', href: '/contact' },
+];
+
+export const FOOTER_LEGAL_LINKS: NavLink[] = [
+  { label: 'Privacy', href: '/privacy' },
+  { label: 'Terms', href: '/terms' },
+];

--- a/src/lib/seo-policy.ts
+++ b/src/lib/seo-policy.ts
@@ -1,0 +1,114 @@
+/**
+ * Indexing / robots policy for KnowYourEmoji
+ *
+ * AdSense reviewers flag large volumes of auto-generated, near-duplicate pages.
+ * To stay out of the "thin doorway" bucket we classify every emoji page by
+ * `contentTier` and apply the following rules:
+ *
+ * 1. `deep`     pages  → index, follow (canonical = self)
+ * 2. `standard` pages  → index, follow (canonical = self)
+ * 3. `thin`     pages  → noindex, follow (canonical = self, page still serves users)
+ * 4. Skin-tone variations of a base emoji → noindex, follow, canonical = base emoji
+ * 5. Low-content "stub" emoji JSON (no context meanings AND no long-form)
+ *    → noindex, follow (canonical = self)
+ *
+ * Pages remain visible to humans in every case — we only de-emphasize them
+ * in Google Search so the site as a whole reads as a publisher, not a
+ * template farm.
+ *
+ * See issue #344 (CONTENT-P1-006) and the sibling ticket CONTENT-P1-001 for
+ * the content-tier taxonomy.
+ */
+
+import type { Emoji, ContentTier } from '@/types/emoji';
+
+export interface IndexingDecision {
+  /** Whether search engines should index the page */
+  index: boolean;
+  /** Whether crawlers should follow links on the page */
+  follow: boolean;
+  /** Whether to set a canonical URL (string = absolute URL, false = no canonical) */
+  canonical: string | false;
+  /** Reason for the decision, surfaced for debugging + JSON-LD */
+  reason: string;
+}
+
+/**
+ * Effective content tier after applying thin-page heuristics.
+ * Order of precedence: explicit `contentTier` > skin-tone derivation > stub check.
+ */
+export function resolveContentTier(emoji: Emoji): ContentTier {
+  if (emoji.contentTier) return emoji.contentTier;
+
+  // Skin-tone variations are by definition thin duplicates.
+  if (emoji.skinToneBase) return 'thin';
+
+  // Stub JSON: no context meanings, no platform/generational notes, no long-form.
+  const isStub =
+    emoji.contextMeanings.length === 0 &&
+    emoji.platformNotes.length === 0 &&
+    emoji.generationalNotes.length === 0 &&
+    !emoji.longForm &&
+    !emoji.conversationExamples?.length;
+
+  return isStub ? 'thin' : 'standard';
+}
+
+/**
+ * Decide how a given emoji page should be indexed and canonicalized.
+ *
+ * @param emoji        The full emoji record.
+ * @param pageUrl      Absolute URL of the page being generated (used for canonical).
+ * @param basePageUrl  Absolute URL of the skin-tone base page, when applicable.
+ */
+export function getIndexingDecision(
+  emoji: Emoji,
+  pageUrl: string,
+  basePageUrl?: string
+): IndexingDecision {
+  // Skin-tone variant → noindex + canonical to base.
+  if (emoji.skinToneBase && basePageUrl) {
+    return {
+      index: false,
+      follow: true,
+      canonical: basePageUrl,
+      reason: 'skin-tone variant → canonical to base emoji',
+    };
+  }
+
+  const tier = resolveContentTier(emoji);
+
+  if (tier === 'thin') {
+    return {
+      index: false,
+      follow: true,
+      canonical: pageUrl,
+      reason: 'thin content → keep reachable for users, de-emphasize in search',
+    };
+  }
+
+  return {
+    index: true,
+    follow: true,
+    canonical: pageUrl,
+    reason: `${tier} content → index,follow`,
+  };
+}
+
+/**
+ * Convert an {@link IndexingDecision} into the Next.js `robots` metadata shape
+ * (`Metadata.robots`).
+ */
+export function decisionToRobots(decision: IndexingDecision) {
+  return {
+    index: decision.index,
+    follow: decision.follow,
+    googleBot: {
+      index: decision.index,
+      follow: decision.follow,
+      'max-video-preview': -1,
+      'max-image-preview': 'large' as const,
+      'max-snippet': -1,
+    },
+  };
+}

--- a/tests/unit/lib/nav-links.test.ts
+++ b/tests/unit/lib/nav-links.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test';
+import { FOOTER_LEGAL_LINKS, PRIMARY_NAV_LINKS } from '../../../src/lib/nav-links';
+
+describe('nav-links', () => {
+  test('PRIMARY_NAV_LINKS includes the publisher-trust links required by #344', () => {
+    const labels = PRIMARY_NAV_LINKS.map((l) => l.label);
+    expect(labels).toContain('Guides');
+    expect(labels).toContain('About');
+    expect(labels).toContain('Contact');
+  });
+
+  test('PRIMARY_NAV_LINKS exposes at least one tool + one editorial surface', () => {
+    const labels = PRIMARY_NAV_LINKS.map((l) => l.label);
+    expect(labels).toContain('Interpreter');
+    expect(labels.some((l) => l === 'Guides' || l === 'Emojis' || l === 'Combos')).toBe(true);
+  });
+
+  test('every nav link has a non-empty label and href', () => {
+    for (const link of [...PRIMARY_NAV_LINKS, ...FOOTER_LEGAL_LINKS]) {
+      expect(link.label).toBeTruthy();
+      expect(link.href).toBeTruthy();
+      expect(link.href.startsWith('/') || link.href.startsWith('http')).toBe(true);
+    }
+  });
+
+  test('FOOTER_LEGAL_LINKS links only Privacy and Terms', () => {
+    const labels = FOOTER_LEGAL_LINKS.map((l) => l.label);
+    expect(labels).toContain('Privacy');
+    expect(labels).toContain('Terms');
+    // About / Contact live in PRIMARY_NAV_LINKS instead so they appear once
+    expect(labels).not.toContain('About');
+    expect(labels).not.toContain('Contact');
+  });
+});

--- a/tests/unit/lib/seo-policy.test.ts
+++ b/tests/unit/lib/seo-policy.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  decisionToRobots,
+  getIndexingDecision,
+  resolveContentTier,
+} from '../../../src/lib/seo-policy';
+import { createEmoji } from '../../utils/factories/emoji.factory';
+import { createContextMeaning } from '../../utils/factories/emoji.factory';
+
+describe('seo-policy', () => {
+  describe('resolveContentTier', () => {
+    test('returns explicit contentTier when set', () => {
+      expect(resolveContentTier(createEmoji({ contentTier: 'deep' }))).toBe('deep');
+      expect(resolveContentTier(createEmoji({ contentTier: 'standard' }))).toBe('standard');
+      expect(resolveContentTier(createEmoji({ contentTier: 'thin' }))).toBe('thin');
+    });
+
+    test('treats skin-tone variants as thin', () => {
+      const variant = createEmoji({
+        skinToneBase: 'wave',
+        skinToneModifier: 'medium-dark',
+        contextMeanings: [createContextMeaning()],
+      });
+      expect(resolveContentTier(variant)).toBe('thin');
+    });
+
+    test('treats stub JSON as thin', () => {
+      // All arrays empty, no longForm, no conversationExamples → stub
+      const stub = createEmoji();
+      expect(resolveContentTier(stub)).toBe('thin');
+    });
+
+    test('promotes page with context meanings to standard', () => {
+      const standard = createEmoji({
+        contextMeanings: [createContextMeaning()],
+      });
+      expect(resolveContentTier(standard)).toBe('standard');
+    });
+
+    test('promotes page with long-form content to standard', () => {
+      const standard = createEmoji({
+        longForm: { overview: 'A long overview paragraph...' },
+      });
+      expect(resolveContentTier(standard)).toBe('standard');
+    });
+
+    test('promotes page with conversation examples to standard', () => {
+      const standard = createEmoji({
+        conversationExamples: [
+          {
+            setting: 'friends',
+            message: 'lol 💀',
+            interpretation: 'reacting to a joke',
+          },
+        ],
+      });
+      expect(resolveContentTier(standard)).toBe('standard');
+    });
+
+    test('promotes page with platform notes to standard', () => {
+      const standard = createEmoji({
+        platformNotes: [{ platform: 'TIKTOK', note: 'Common in comment sections' }],
+      });
+      expect(resolveContentTier(standard)).toBe('standard');
+    });
+  });
+
+  describe('getIndexingDecision', () => {
+    test('skin-tone variant → noindex + canonical to base', () => {
+      const variant = createEmoji({
+        slug: 'wave-medium-dark',
+        skinToneBase: 'wave',
+        skinToneModifier: 'medium-dark',
+      });
+      const decision = getIndexingDecision(
+        variant,
+        'https://knowyouremoji.com/emoji/wave-medium-dark',
+        'https://knowyouremoji.com/emoji/wave'
+      );
+
+      expect(decision.index).toBe(false);
+      expect(decision.follow).toBe(true);
+      expect(decision.canonical).toBe('https://knowyouremoji.com/emoji/wave');
+      expect(decision.reason).toContain('skin-tone');
+    });
+
+    test('thin stub → noindex, follow, self canonical', () => {
+      const stub = createEmoji();
+      const url = 'https://knowyouremoji.com/emoji/test-stub';
+      const decision = getIndexingDecision(stub, url);
+
+      expect(decision.index).toBe(false);
+      expect(decision.follow).toBe(true);
+      expect(decision.canonical).toBe(url);
+      expect(decision.reason).toContain('thin');
+    });
+
+    test('standard page → index, follow, self canonical', () => {
+      const standard = createEmoji({
+        contextMeanings: [createContextMeaning()],
+      });
+      const url = 'https://knowyouremoji.com/emoji/standard';
+      const decision = getIndexingDecision(standard, url);
+
+      expect(decision.index).toBe(true);
+      expect(decision.follow).toBe(true);
+      expect(decision.canonical).toBe(url);
+    });
+
+    test('deep page → index, follow, self canonical', () => {
+      const deep = createEmoji({ contentTier: 'deep' });
+      const url = 'https://knowyouremoji.com/emoji/deep';
+      const decision = getIndexingDecision(deep, url);
+
+      expect(decision.index).toBe(true);
+      expect(decision.follow).toBe(true);
+      expect(decision.canonical).toBe(url);
+      expect(decision.reason).toContain('deep');
+    });
+
+    test('skin-tone variant with no base URL falls back to noindex + self', () => {
+      const variant = createEmoji({
+        slug: 'wave-medium-dark',
+        skinToneBase: 'wave',
+      });
+      const url = 'https://knowyouremoji.com/emoji/wave-medium-dark';
+      const decision = getIndexingDecision(variant, url);
+
+      expect(decision.index).toBe(false);
+      expect(decision.follow).toBe(true);
+      // Falls back to self canonical when base URL missing
+      expect(decision.canonical).toBe(url);
+    });
+  });
+
+  describe('decisionToRobots', () => {
+    test('preserves index/follow in Next.js robots shape', () => {
+      const decision = getIndexingDecision(
+        createEmoji({ contentTier: 'standard' }),
+        'https://x.test/y'
+      );
+      const robots = decisionToRobots(decision);
+
+      expect(robots.index).toBe(true);
+      expect(robots.follow).toBe(true);
+      expect(robots.googleBot?.index).toBe(true);
+      expect(robots.googleBot?.follow).toBe(true);
+      expect(robots.googleBot?.['max-video-preview']).toBe(-1);
+      expect(robots.googleBot?.['max-image-preview']).toBe('large');
+      expect(robots.googleBot?.['max-snippet']).toBe(-1);
+    });
+
+    test('propagates noindex through googleBot override', () => {
+      const decision = getIndexingDecision(createEmoji(), 'https://x.test/y');
+      const robots = decisionToRobots(decision);
+
+      expect(robots.index).toBe(false);
+      expect(robots.follow).toBe(true);
+      expect(robots.googleBot?.index).toBe(false);
+      expect(robots.googleBot?.follow).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `/contact` page with GitHub Issues + email channels, topic routing, and a 3-business-day response expectation
- Strengthen `/about` with a Methodology section (Unicode → research → nuance → review), editorial standards, and a "who runs the site" disclosure linking to `/contact`
- Add `src/lib/seo-policy.ts` and wire it into `src/app/emoji/[slug]/page.tsx`: deep/standard pages stay `index,follow`; skin-tone variants get `noindex,follow` with canonical pointed at the base emoji; stub JSON falls back to `noindex,follow`. Pages still render for users in every case — only Google Search is de-emphasized for duplicates
- Surface editorial content above the content-section fold on the homepage: hero links to `/guides` when guides exist, and the Latest Guides section moves from below Combos to right after Popular Emojis
- Central `PRIMARY_NAV_LINKS` / `FOOTER_LEGAL_LINKS` in `src/lib/nav-links.ts` drives the header, mobile drawer, and footer; the nav now lists Emojis, Combos, Guides, Interpreter, About, Contact sitewide
- Privacy + Terms contact sections point to `/contact` instead of GitHub Issues
- Document the policy + AdSense reapply checklist in `docs/seo-indexing-policy.md` and add a comment to `public/ads.txt` explaining why empty ad slots must not be rendered pre-approval

## Test plan
- `bun run typecheck` — clean
- `bun run lint` — clean
- `bun run test:coverage` — 3630 tests pass, 99.37% function / 99.58% line coverage (thresholds met)
- `bun run build` — succeeds, `/contact` route is emitted as a static page
- New unit tests cover `resolveContentTier`, `getIndexingDecision` (skin-tone canonical override, stub fallback, standard/deep), and `decisionToRobots` shape

Fixes #344

## Intentionally left out of scope
- Mass-deepening the remaining ~4,000 emoji JSON files to "deep" tier (separate epic #341)
- The `ads.txt` file is left in place but only populated with the single AdSense-pub line already there — adding more rows or rendering ad slots pre-approval is gated by the checklist in `docs/seo-indexing-policy.md`
- Newsletter, live chat, or any "human on chat support" promise — the contact page is explicit that responses take up to 3 business days