### PR TITLE
feat(seo): align sitemap, robots, and combo indexing policy (#355)

### DIFF
--- a/docs/seo-indexing-policy.md
+++ b/docs/seo-indexing-policy.md
@@ -1,30 +1,58 @@
 # Indexing policy (AdSense readiness)
 
 This document is the canonical reference for how we tell crawlers what to do
-with each page. The implementation lives in `src/lib/seo-policy.ts` and is
-applied via `generateMetadata` in the relevant route files.
+with each page. The implementation lives in `src/lib/seo-policy.ts` and
+`src/lib/sitemap-entries.ts`, and is applied via `generateMetadata` in the
+relevant route files plus the Next.js `sitemap.ts` and `robots.ts` shims.
 
 > Background: issue **#344 — CONTENT-P1-006 (Publisher trust signals + thin-page
 > indexing policy)** under epic **#339 — AdSense readiness**. Google rejected
 > KnowYourEmoji for "low-value / thin content" partly because we shipped ~4,000
 > near-duplicate emoji pages. The policy below is what stops the same flag from
-> firing on the next review.
+> firing on the next review. Issue **#355 — SEO-P1-001** extends that policy to
+> the sitemap, robots.txt, and the (then-missing) combo metadata.
 
 ## TL;DR
 
-| Page type                                        | `robots`          | `canonical`          |
-| ------------------------------------------------ | ----------------- | -------------------- |
-| Deep editorial emoji page                        | `index, follow`   | self                 |
-| Standard emoji page                              | `index, follow`   | self                 |
-| Skin-tone variant (e.g. 👋🏽)                      | `noindex, follow` | base emoji (`/wave`) |
-| Stub / boilerplate emoji page                    | `noindex, follow` | self                 |
-| Category / platform / generation / context       | `index, follow`   | self                 |
-| Homepage, About, Contact, Guides, Privacy, Terms | `index, follow`   | self                 |
+| Page type                                                                                     | `robots`                      | `canonical`          | In sitemap?    |
+| --------------------------------------------------------------------------------------------- | ----------------------------- | -------------------- | -------------- |
+| Deep editorial emoji page                                                                     | `index, follow`               | self                 | yes (0.85)     |
+| Standard emoji page                                                                           | `index, follow`               | self                 | yes (0.75)     |
+| Skin-tone variant (e.g. 👋🏽)                                                                   | `noindex, follow`             | base emoji (`/wave`) | no             |
+| Stub / boilerplate emoji page                                                                 | `noindex, follow`             | self                 | no             |
+| Deep combo page                                                                               | `index, follow`               | self                 | yes (0.85)     |
+| Standard combo page                                                                           | `index, follow`               | self                 | yes (0.75)     |
+| Thin combo page                                                                               | `noindex, follow`             | self                 | no             |
+| Category / platform / generation / context                                                    | `index, follow`               | self                 | yes (0.6–0.7)  |
+| Combo category hubs                                                                           | `index, follow`               | self                 | yes (0.6)      |
+| Compare pages                                                                                 | `index, follow`               | self                 | yes (0.6)      |
+| Guides index + per-guide pages                                                                | `index, follow`               | self                 | yes (0.85–0.9) |
+| Homepage, About, Contact, Pricing, Privacy, Terms, Search, `/emoji`, `/combo`, `/interpreter` | `index, follow`               | self                 | yes (0.6–1.0)  |
+| `/api/`, `/dashboard`, `/admin`, `/login`, `/register`, `/forgot-password`, `/reset-password` | n/a (blocked in `robots.txt`) | n/a                  | no             |
 
 All pages remain reachable for users regardless of `noindex`. We only opt
 pages out of Google Search when they do not carry original editorial value.
 
+## Sitemap ↔ robots � page-meta invariants
+
+1. **The sitemap must never list a URL that is `noindex` on the page.**
+   Listing `noindex` URLs in the sitemap wastes crawl budget and tells
+   Google to crawl a page we don't want indexed.
+2. **The `robots.txt` disallow list must cover every private surface**
+   (API, authenticated areas, admin). Per-page `robots: { index: false }`
+   stays in place as a belt-and-suspenders complement.
+3. **`lastModified` must be content-derived**, not "always now". For
+   emoji and combo pages we prefer `contentUpdatedAt`; for guides we use
+   `updatedAt || publishedAt`. Trust pages / hub pages use build time,
+   which is fine because they change rarely.
+4. **Deep editorial content outranks stub directories.** Priority is a
+   soft signal but keeps the intent visible: deep emoji / deep combo
+   (0.85) > standard (0.75) > category / combo-category / facet hubs
+   (0.6–0.7) > trust pages (0.6).
+
 ## Tier rules
+
+### Emoji
 
 Every emoji page resolves to one of three tiers (`ContentTier = 'thin' | 'standard' | 'deep'`):
 
@@ -37,13 +65,27 @@ Every emoji page resolves to one of three tiers (`ContentTier = 'thin' | 'standa
    generational notes, no `longForm`, and no `conversationExamples`, the page
    is treated as a stub and marked `thin` until someone fills it in.
 
-Tier → `robots` mapping:
+### Combo
 
-| Tier       | `robots`          | `canonical` |
-| ---------- | ----------------- | ----------- |
-| `deep`     | `index, follow`   | self        |
-| `standard` | `index, follow`   | self        |
-| `thin`     | `noindex, follow` | self        |
+Combos use the same taxonomy (`ComboContentTier = 'thin' | 'standard' | 'deep'`):
+
+1. **Explicit `combo.contentTier` wins.**
+2. **`deep` if `longForm` has any prose field filled in.** That means any
+   of `overview`, `howPeopleUseIt`, `whenNotToUse`, `howToReply`, or
+   non-empty `faqs`.
+3. **`standard` if the combo has any `conversationExamples`.**
+4. **Otherwise `thin`** — bare `meaning` / `description` / `examples` is
+   not enough to justify an indexable publisher page. Writers should
+   promote thin combos to standard via `contentTier` or by adding
+   `longForm` / `conversationExamples`.
+
+Tier → `robots` mapping (applies to both emoji and combo):
+
+| Tier       | `robots`          | `canonical` | In sitemap? |
+| ---------- | ----------------- | ----------- | ----------- |
+| `deep`     | `index, follow`   | self        | yes (0.85)  |
+| `standard` | `index, follow`   | self        | yes (0.75)  |
+| `thin`     | `noindex, follow` | self        | no          |
 
 ## Skin-tone canonical
 
@@ -51,7 +93,7 @@ A skin-tone variant (`emoji.skinToneBase` set) sets its `canonical` to the base
 emoji's URL and ships with `noindex, follow`. The variant page is still
 reachable in-app — a user can browse `/wave-medium-dark` and see the same
 content as `/wave` — but crawlers should treat the base as the only source of
-truth.
+truth. Skin-tone variants are also omitted from the sitemap.
 
 ## Why we do not blanket-canonical to category / context pages
 
@@ -62,13 +104,28 @@ would throw away legitimate long-tail traffic and break the sitemap.
 
 ## Where this is enforced
 
-- `src/lib/seo-policy.ts` — single source of truth (`getIndexingDecision`,
-  `decisionToRobots`, `resolveContentTier`).
-- `src/app/emoji/[slug]/page.tsx` — applies the decision via
+- `src/lib/seo-policy.ts` — single source of truth for `getIndexingDecision`
+  (emoji), `getComboIndexingDecision`, `resolveContentTier`,
+  `resolveComboContentTier`, `decisionToRobots`.
+- `src/lib/sitemap-entries.ts` — builds sitemap entries with the per-surface
+  rules: filters `noindex` URLs, surfaces trust / hub / facet pages, picks
+  content-derived `lastModified`, applies priority differentiation.
+- `src/app/emoji/[slug]/page.tsx` — applies the decision via `generateMetadata`.
+- `src/app/combo/[slug]/page.tsx` — applies the combo decision via
   `generateMetadata`.
+- `src/app/sitemap.ts` — thin wrapper that calls `buildSitemap()`.
+- `src/app/robots.ts` — disallows `/api/`, `/dashboard`, `/admin`, plus
+  the auth routes under `(auth)/`.
 
-If you add a new route that emits a public page, hook it into `seo-policy.ts`
-rather than hand-rolling another `robots` block.
+If you add a new route that emits a public page:
+
+1. Apply `getIndexingDecision` (or `getComboIndexingDecision`) inside
+   `generateMetadata`.
+2. Make sure the route is included in `src/lib/sitemap-entries.ts` if
+   the URL should appear in the sitemap (with the right priority and
+   `lastModified`).
+3. Add or extend the matching test in `tests/unit/lib/seo-policy.test.ts`
+   and/or `tests/unit/lib/sitemap-entries.test.ts`.
 
 ## Operational checklist before reapplying to AdSense
 
@@ -76,7 +133,19 @@ rather than hand-rolling another `robots` block.
 - [x] `/about` strengthened (methodology, editorial standards, who operates)
 - [x] Privacy + Terms complete, linked sitewide
 - [x] Indexing policy implemented in code with a thin-page fallback
+- [x] Sitemap excludes skin-tone and thin combo URLs (#355)
+- [x] Sitemap includes trust, hub, and facet pages (#355)
+- [x] Combo `generateMetadata` honors `contentTier` (#355)
+- [x] `robots.txt` blocks private surfaces (#355)
 - [ ] `ads.txt` only after Google instructs us to publish it (see
       `src/lib/metadata.ts` for the existing `google-adsense-account` meta)
 - [ ] Empty ad slots must not be rendered pre-approval — only add `<AdSense/>`
       after the AdSense team returns a publisher ID
+
+## Rollout caution
+
+If a future content sweep promotes ~3k pages from `standard` to `thin`, the
+sitemap and indexing change happens at the same time. That is the correct
+end state for AdSense quality, but it is a large indexing delta. Prefer
+omitting a page from the sitemap immediately and ship the `noindex` change
+in the same PR so the signals stay aligned.

--- a/src/app/combo/[slug]/page.tsx
+++ b/src/app/combo/[slug]/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { getComboBySlug, getAllComboSlugs, getRelatedCombos } from '@/lib/combo-data';
 import { getEmojiBySlug } from '@/lib/emoji-data';
 import { getEnv } from '@/lib/env';
+import { decisionToRobots, getComboIndexingDecision } from '@/lib/seo-policy';
 import { ShareSection } from '@/components/share/share-section';
 import { CopySectionButton } from '@/components/ui/copy-section-button';
 import { Badge } from '@/components/ui/badge';
@@ -50,6 +51,11 @@ export async function generateMetadata({ params }: ComboPageProps): Promise<Meta
   const pageUrl = `${env.appUrl}/combo/${combo.slug}`;
   const ogTitle = `${combo.combo} ${combo.name} Combo Meaning`;
 
+  // Apply the indexing policy from src/lib/seo-policy.ts — see issue #355.
+  // - Deep/standard combos → index, follow
+  // - Thin combos → noindex, follow (page still serves users)
+  const indexing = getComboIndexingDecision(combo, pageUrl);
+
   // Generate keywords array
   const keywords = [
     `${combo.name.toLowerCase()} combo`,
@@ -67,7 +73,7 @@ export async function generateMetadata({ params }: ComboPageProps): Promise<Meta
     description: combo.seoDescription,
     keywords,
     alternates: {
-      canonical: pageUrl,
+      canonical: indexing.canonical || pageUrl,
     },
     openGraph: {
       title: ogTitle,
@@ -90,17 +96,7 @@ export async function generateMetadata({ params }: ComboPageProps): Promise<Meta
       description: combo.meaning,
       images: [`${env.appUrl}/og/combo/${combo.slug}.png`],
     },
-    robots: {
-      index: true,
-      follow: true,
-      googleBot: {
-        index: true,
-        follow: true,
-        'max-video-preview': -1,
-        'max-image-preview': 'large',
-        'max-snippet': -1,
-      },
-    },
+    robots: decisionToRobots(indexing),
   };
 }
 

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -2,14 +2,16 @@ import type { MetadataRoute } from 'next';
 import { getSiteUrl } from '@/lib/metadata';
 
 /**
- * Generate robots.txt configuration for crawler directives
+ * Generate robots.txt configuration for crawler directives.
  *
- * This configuration:
- * - Allows crawling of all public pages
- * - Disallows crawling of API routes (server-only endpoints)
- * - Links to the sitemap for crawler discovery
+ * Public marketing, editorial, and tooling surfaces remain crawlable.
+ * Private / dynamic app surfaces (API endpoints, authenticated
+ * dashboards, admin tooling, future auth routes) are explicitly
+ * disallowed as a belt-and-suspenders complement to the per-page
+ * `robots: { index: false }` metadata those routes already set.
  *
  * @see https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots
+ * @see issue #355 (SEO-P1-001 sitemap / robots / thin-page alignment)
  */
 export default function robots(): MetadataRoute.Robots {
   const baseUrl = getSiteUrl();
@@ -18,7 +20,15 @@ export default function robots(): MetadataRoute.Robots {
     rules: {
       userAgent: '*',
       allow: '/',
-      disallow: '/api/',
+      disallow: [
+        '/api/',
+        '/dashboard',
+        '/admin',
+        '/login',
+        '/register',
+        '/forgot-password',
+        '/reset-password',
+      ],
     },
     sitemap: `${baseUrl}/sitemap.xml`,
     host: baseUrl,

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,94 +1,17 @@
 import type { MetadataRoute } from 'next';
-import { getAllEmojiSlugs, getAllCategories } from '@/lib/emoji-data';
-import { getAllComboSlugs } from '@/lib/combo-data';
-import { getPublishedGuideSummaries } from '@/lib/guide-data';
-import { getSiteUrl } from '@/lib/metadata';
+import { buildSitemap } from '@/lib/sitemap-entries';
 
 /**
- * Generate a dynamic sitemap for all pages
+ * Generate the dynamic sitemap for all indexable, public pages.
  *
- * This sitemap includes:
- * - Static pages (homepage, interpreter)
- * - Dynamic emoji pages (one per emoji)
- * - Dynamic combo pages (one per combo)
- * - Category index pages
+ * Composition lives in `src/lib/sitemap-entries.ts` so the per-surface
+ * rules (skin-tone exclusion, `thin` exclusion, trust/hub coverage,
+ * priority differentiation, content-derived `lastModified`) can be unit
+ * tested in isolation.
  *
  * @see https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap
+ * @see issue #355 (SEO-P1-001 sitemap / robots / thin-page alignment)
  */
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = getSiteUrl();
-  const lastModified = new Date();
-
-  // Static pages with high priority
-  const staticPages: MetadataRoute.Sitemap = [
-    {
-      url: `${baseUrl}/`,
-      lastModified,
-      changeFrequency: 'daily',
-      priority: 1.0,
-    },
-    {
-      url: `${baseUrl}/interpreter`,
-      lastModified,
-      changeFrequency: 'weekly',
-      priority: 0.9,
-    },
-  ];
-
-  // Generate emoji pages
-  const emojiSlugs = getAllEmojiSlugs();
-  const emojiPages: MetadataRoute.Sitemap = emojiSlugs.map((slug) => ({
-    url: `${baseUrl}/emoji/${slug}`,
-    lastModified,
-    changeFrequency: 'weekly',
-    priority: 0.8,
-  }));
-
-  // Generate combo pages
-  const comboSlugs = getAllComboSlugs();
-  const comboPages: MetadataRoute.Sitemap = comboSlugs.map((slug) => ({
-    url: `${baseUrl}/combo/${slug}`,
-    lastModified,
-    changeFrequency: 'weekly',
-    priority: 0.7,
-  }));
-
-  // Generate category index pages
-  const categories = getAllCategories();
-  const categoryPages: MetadataRoute.Sitemap = categories.map((category) => ({
-    url: `${baseUrl}/emoji/category/${category}`,
-    lastModified,
-    changeFrequency: 'weekly',
-    priority: 0.7,
-  }));
-
-  // Guides index page (CONTENT-P1-003) — editorial content is high signal
-  // for AdSense and SEO, so we surface it prominently.
-  const guideIndexPage: MetadataRoute.Sitemap = [
-    {
-      url: `${baseUrl}/guides`,
-      lastModified,
-      changeFrequency: 'weekly',
-      priority: 0.8,
-    },
-  ];
-
-  // Per-guide pages, using their publishedAt / updatedAt as lastModified so
-  // search engines can prioritize recently updated editorial content.
-  const guideSummaries = getPublishedGuideSummaries();
-  const guidePages: MetadataRoute.Sitemap = guideSummaries.map((guide) => ({
-    url: `${baseUrl}/guides/${guide.slug}`,
-    lastModified: new Date(guide.updatedAt || guide.publishedAt),
-    changeFrequency: 'monthly',
-    priority: 0.8,
-  }));
-
-  return [
-    ...staticPages,
-    ...emojiPages,
-    ...comboPages,
-    ...categoryPages,
-    ...guideIndexPage,
-    ...guidePages,
-  ];
+  return buildSitemap();
 }

--- a/src/lib/seo-policy.ts
+++ b/src/lib/seo-policy.ts
@@ -21,6 +21,7 @@
  */
 
 import type { Emoji, ContentTier } from '@/types/emoji';
+import type { EmojiCombo, ComboContentTier } from '@/types/combo';
 
 export interface IndexingDecision {
   /** Whether search engines should index the page */
@@ -110,5 +111,64 @@ export function decisionToRobots(decision: IndexingDecision) {
       'max-image-preview': 'large' as const,
       'max-snippet': -1,
     },
+  };
+}
+
+/**
+ * Effective content tier for a combo, mirroring {@link resolveContentTier}
+ * for emojis. Combos do not have skin-tone variants, so the rules are:
+ *
+ * 1. Explicit `contentTier: 'thin' | 'standard' | 'deep'` wins.
+ * 2. Otherwise: pages with `longForm` (article-style content) or any
+ *    `conversationExamples` are treated as `standard`. Bare-bones combos
+ *    with only `meaning`/`description`/`examples` are treated as `thin`
+ *    until someone fills them in.
+ */
+export function resolveComboContentTier(combo: EmojiCombo): ComboContentTier {
+  if (combo.contentTier) return combo.contentTier;
+
+  const hasLongForm =
+    Boolean(combo.longForm) &&
+    (Boolean(combo.longForm?.overview) ||
+      Boolean(combo.longForm?.howPeopleUseIt) ||
+      Boolean(combo.longForm?.whenNotToUse) ||
+      Boolean(combo.longForm?.howToReply) ||
+      (combo.longForm?.faqs?.length ?? 0) > 0);
+
+  if (hasLongForm) return 'deep';
+
+  if ((combo.conversationExamples?.length ?? 0) > 0) return 'standard';
+
+  // Bare meaning/description/examples only — treat as thin until enriched.
+  return 'thin';
+}
+
+/**
+ * Decide how a combo page should be indexed and canonicalized.
+ *
+ * Mirrors {@link getIndexingDecision} for emojis. Combos do not have
+ * skin-tone variants, so the policy is simpler:
+ *
+ * - `deep`     → index, follow
+ * - `standard` → index, follow
+ * - `thin`     → noindex, follow (page still serves users)
+ */
+export function getComboIndexingDecision(combo: EmojiCombo, pageUrl: string): IndexingDecision {
+  const tier = resolveComboContentTier(combo);
+
+  if (tier === 'thin') {
+    return {
+      index: false,
+      follow: true,
+      canonical: pageUrl,
+      reason: 'thin content → keep reachable for users, de-emphasize in search',
+    };
+  }
+
+  return {
+    index: true,
+    follow: true,
+    canonical: pageUrl,
+    reason: `${tier} content → index,follow`,
   };
 }

--- a/src/lib/sitemap-entries.ts
+++ b/src/lib/sitemap-entries.ts
@@ -1,0 +1,340 @@
+/**
+ * Sitemap entry builders for KnowYourEmoji.
+ *
+ * Centralizes the rules for *what should be in the sitemap*, in alignment
+ * with `src/lib/seo-policy.ts`. Goals:
+ *
+ * 1. Only emit URLs we want indexed (no skin-tone variants, no `thin`
+ *    emoji/combo pages, no auth/dashboard/admin/api).
+ * 2. Surface high-value static/hub URLs so crawlers discover the trust
+ *    surface (about, contact, pricing, privacy, terms, search, etc.).
+ * 3. Use content-derived `lastModified` (prefer `contentUpdatedAt`,
+ *    then published/updated metadata) instead of "now" so recency
+ *    signals in Search Console are meaningful.
+ * 4. Differentiate priority so deep editorial and guide URLs win over
+ *    stub directory URLs.
+ *
+ * @see issue #355 (SEO-P1-001 sitemap / robots / thin-page alignment)
+ */
+
+import type { MetadataRoute } from 'next';
+import type { Emoji, ContentTier } from '@/types/emoji';
+import type { EmojiCombo } from '@/types/combo';
+import { getAllEmojis, getAllCategories } from '@/lib/emoji-data';
+import { getAllCombos, getAllComboCategories } from '@/lib/combo-data';
+import { getAllPlatforms, getAllGenerations, getPageableContextTypes } from '@/lib/emoji-data';
+import { getAllComparisons } from '@/lib/comparison-data';
+import { getPublishedGuideSummaries } from '@/lib/guide-data';
+import { resolveContentTier } from '@/lib/seo-policy';
+import { getSiteUrl } from '@/lib/metadata';
+
+/**
+ * Priority tiers used in the sitemap. Soft signals for crawlers — keep
+ * editorial content ahead of directory / aggregation surfaces.
+ */
+export const SITEMAP_PRIORITIES = {
+  HOMEPAGE: 1.0,
+  INTERPRETER: 0.9,
+  GUIDES_INDEX: 0.9,
+  GUIDE_PAGE: 0.85,
+  DEEP_EMOJI: 0.85,
+  DEEP_COMBO: 0.85,
+  STANDARD_EMOJI: 0.75,
+  STANDARD_COMBO: 0.75,
+  HUB_PAGE: 0.7,
+  TRUST_PAGE: 0.6,
+  CATEGORY_PAGE: 0.6,
+  COMPARE_PAGE: 0.6,
+  TOOLS_PAGE: 0.7,
+} as const;
+
+/**
+ * Static pages that should always appear in the sitemap. Order is
+ * preserved in the emitted sitemap — keep trust pages first. The
+ * `/guides` index is *not* listed here because `buildGuideSitemapEntries`
+ * owns both the index and the per-guide entries.
+ */
+export const SITEMAP_STATIC_PATHS = [
+  '/',
+  '/interpreter',
+  '/about',
+  '/contact',
+  '/pricing',
+  '/privacy',
+  '/terms',
+  '/search',
+  '/emoji',
+  '/combo',
+] as const;
+
+/**
+ * Per-entry change frequency. Conservative defaults; guides move slower
+ * than editorial emoji pages.
+ */
+export type SitemapChangeFrequency =
+  | 'always'
+  | 'hourly'
+  | 'daily'
+  | 'weekly'
+  | 'monthly'
+  | 'yearly'
+  | 'never';
+
+/**
+ * Build a single `MetadataRoute.Sitemap` entry with a real date. Falls
+ * back to `fallback` when `isoDate` is missing or invalid, so we never
+ * ship `Invalid Date`.
+ */
+function buildEntry(
+  url: string,
+  isoDate: string | undefined,
+  options: {
+    changeFrequency?: SitemapChangeFrequency;
+    priority?: number;
+    fallback?: Date;
+  } = {}
+): MetadataRoute.Sitemap[number] {
+  let lastModified: Date = options.fallback ?? new Date();
+  if (isoDate) {
+    const parsed = new Date(isoDate);
+    if (!Number.isNaN(parsed.getTime())) {
+      lastModified = parsed;
+    }
+  }
+  const entry: MetadataRoute.Sitemap[number] = { url, lastModified };
+  if (options.changeFrequency) entry.changeFrequency = options.changeFrequency;
+  if (options.priority !== undefined) entry.priority = options.priority;
+  return entry;
+}
+
+/**
+ * Build the static-page entries that always appear in the sitemap
+ * (homepage, trust pages, hubs, search, guides index).
+ *
+ * `lastModified` for the homepage is intentionally `now` so it shows
+ * crawl recency. Trust/legal pages move slowly.
+ */
+export function buildStaticSitemapEntries(): MetadataRoute.Sitemap {
+  const baseUrl = getSiteUrl();
+  const now = new Date();
+
+  return [
+    // Homepage — daily crawl hint.
+    buildEntry(`${baseUrl}/`, undefined, {
+      changeFrequency: 'daily',
+      priority: SITEMAP_PRIORITIES.HOMEPAGE,
+      fallback: now,
+    }),
+    // Interpreter — core tool surface, refresh weekly.
+    buildEntry(`${baseUrl}/interpreter`, undefined, {
+      changeFrequency: 'weekly',
+      priority: SITEMAP_PRIORITIES.INTERPRETER,
+    }),
+    // Trust + hub pages — discoverable but move slowly.
+    buildEntry(`${baseUrl}/about`, undefined, {
+      changeFrequency: 'monthly',
+      priority: SITEMAP_PRIORITIES.TRUST_PAGE,
+    }),
+    buildEntry(`${baseUrl}/contact`, undefined, {
+      changeFrequency: 'monthly',
+      priority: SITEMAP_PRIORITIES.TRUST_PAGE,
+    }),
+    buildEntry(`${baseUrl}/pricing`, undefined, {
+      changeFrequency: 'weekly',
+      priority: SITEMAP_PRIORITIES.TOOLS_PAGE,
+    }),
+    buildEntry(`${baseUrl}/privacy`, undefined, {
+      changeFrequency: 'yearly',
+      priority: SITEMAP_PRIORITIES.TRUST_PAGE,
+    }),
+    buildEntry(`${baseUrl}/terms`, undefined, {
+      changeFrequency: 'yearly',
+      priority: SITEMAP_PRIORITIES.TRUST_PAGE,
+    }),
+    buildEntry(`${baseUrl}/search`, undefined, {
+      changeFrequency: 'weekly',
+      priority: SITEMAP_PRIORITIES.TOOLS_PAGE,
+    }),
+    buildEntry(`${baseUrl}/emoji`, undefined, {
+      changeFrequency: 'weekly',
+      priority: SITEMAP_PRIORITIES.HUB_PAGE,
+    }),
+    buildEntry(`${baseUrl}/combo`, undefined, {
+      changeFrequency: 'weekly',
+      priority: SITEMAP_PRIORITIES.HUB_PAGE,
+    }),
+    // `/guides` is emitted by `buildGuideSitemapEntries` so the index
+    // page and per-guide pages share a single source of truth.
+  ];
+}
+
+/**
+ * Build sitemap entries for all *indexable* emoji pages. Excludes:
+ * - Skin-tone variants (they canonicalize to the base).
+ * - `thin` content (per `resolveContentTier`).
+ *
+ * `lastModified` prefers `contentUpdatedAt` so the date tracks editorial
+ * changes, not build time.
+ */
+export function buildEmojiSitemapEntries(): MetadataRoute.Sitemap {
+  const baseUrl = getSiteUrl();
+  const emojis = getAllEmojis();
+
+  return emojis
+    .filter((emoji: Emoji) => !emoji.skinToneBase)
+    .filter((emoji: Emoji) => resolveContentTier(emoji) !== 'thin')
+    .map((emoji: Emoji) => {
+      const tier: ContentTier = emoji.contentTier ?? resolveContentTier(emoji);
+      const priority =
+        tier === 'deep' ? SITEMAP_PRIORITIES.DEEP_EMOJI : SITEMAP_PRIORITIES.STANDARD_EMOJI;
+      return buildEntry(`${baseUrl}/emoji/${emoji.slug}`, emoji.contentUpdatedAt, {
+        changeFrequency: 'weekly',
+        priority,
+      });
+    });
+}
+
+/**
+ * Build sitemap entries for combo pages. Excludes `thin` combos.
+ * `lastModified` prefers `contentUpdatedAt`.
+ */
+export function buildComboSitemapEntries(): MetadataRoute.Sitemap {
+  const baseUrl = getSiteUrl();
+  const combos = getAllCombos();
+
+  return combos
+    .filter((combo: EmojiCombo) => combo.contentTier !== 'thin')
+    .map((combo: EmojiCombo) => {
+      const tier = combo.contentTier ?? 'standard';
+      const priority =
+        tier === 'deep' ? SITEMAP_PRIORITIES.DEEP_COMBO : SITEMAP_PRIORITIES.STANDARD_COMBO;
+      return buildEntry(`${baseUrl}/combo/${combo.slug}`, combo.contentUpdatedAt, {
+        changeFrequency: 'weekly',
+        priority,
+      });
+    });
+}
+
+/**
+ * Build sitemap entries for emoji category hubs.
+ */
+export function buildCategorySitemapEntries(): MetadataRoute.Sitemap {
+  const baseUrl = getSiteUrl();
+  const categories = getAllCategories();
+
+  return categories.map((category: string) =>
+    buildEntry(`${baseUrl}/emoji/category/${category}`, undefined, {
+      changeFrequency: 'weekly',
+      priority: SITEMAP_PRIORITIES.CATEGORY_PAGE,
+    })
+  );
+}
+
+/**
+ * Build sitemap entries for combo category hubs.
+ */
+export function buildComboCategorySitemapEntries(): MetadataRoute.Sitemap {
+  const baseUrl = getSiteUrl();
+  const categories = getAllComboCategories();
+
+  return categories.map((category: string) =>
+    buildEntry(`${baseUrl}/combo/category/${category}`, undefined, {
+      changeFrequency: 'weekly',
+      priority: SITEMAP_PRIORITIES.CATEGORY_PAGE,
+    })
+  );
+}
+
+/**
+ * Build sitemap entries for platform, generation, and context hubs.
+ */
+export function buildFacetSitemapEntries(): MetadataRoute.Sitemap {
+  const baseUrl = getSiteUrl();
+  const entries: MetadataRoute.Sitemap = [];
+
+  for (const platform of getAllPlatforms()) {
+    entries.push(
+      buildEntry(`${baseUrl}/emoji/platform/${platform}`, undefined, {
+        changeFrequency: 'weekly',
+        priority: SITEMAP_PRIORITIES.HUB_PAGE,
+      })
+    );
+  }
+
+  for (const generation of getAllGenerations()) {
+    entries.push(
+      buildEntry(`${baseUrl}/emoji/generation/${generation}`, undefined, {
+        changeFrequency: 'weekly',
+        priority: SITEMAP_PRIORITIES.HUB_PAGE,
+      })
+    );
+  }
+
+  for (const context of getPageableContextTypes()) {
+    entries.push(
+      buildEntry(`${baseUrl}/emoji/context/${context}`, undefined, {
+        changeFrequency: 'weekly',
+        priority: SITEMAP_PRIORITIES.HUB_PAGE,
+      })
+    );
+  }
+
+  return entries;
+}
+
+/**
+ * Build sitemap entries for comparison pages in canonical order only.
+ * Comparison slugs are stored as `${emoji1Slug}-${emoji2Slug}`; we
+ * always emit the canonical pair to avoid duplicate entries.
+ */
+export function buildCompareSitemapEntries(): MetadataRoute.Sitemap {
+  const baseUrl = getSiteUrl();
+  const comparisons = getAllComparisons();
+
+  return comparisons.map((comparison) =>
+    buildEntry(`${baseUrl}/compare/${comparison.emoji1Slug}/${comparison.emoji2Slug}`, undefined, {
+      changeFrequency: 'monthly',
+      priority: SITEMAP_PRIORITIES.COMPARE_PAGE,
+    })
+  );
+}
+
+/**
+ * Build sitemap entries for published guides. `lastModified` uses the
+ * guide's `updatedAt || publishedAt` so the date reflects editorial
+ * activity.
+ */
+export function buildGuideSitemapEntries(): MetadataRoute.Sitemap {
+  const baseUrl = getSiteUrl();
+  const summaries = getPublishedGuideSummaries();
+
+  return [
+    buildEntry(`${baseUrl}/guides`, undefined, {
+      changeFrequency: 'weekly',
+      priority: SITEMAP_PRIORITIES.GUIDES_INDEX,
+    }),
+    ...summaries.map((guide) =>
+      buildEntry(`${baseUrl}/guides/${guide.slug}`, guide.updatedAt || guide.publishedAt, {
+        changeFrequency: 'monthly',
+        priority: SITEMAP_PRIORITIES.GUIDE_PAGE,
+      })
+    ),
+  ];
+}
+
+/**
+ * Build the full sitemap by composing all the per-surface builders.
+ * Order is stable so the generated XML is deterministic across builds.
+ */
+export function buildSitemap(): MetadataRoute.Sitemap {
+  return [
+    ...buildStaticSitemapEntries(),
+    ...buildEmojiSitemapEntries(),
+    ...buildComboSitemapEntries(),
+    ...buildCategorySitemapEntries(),
+    ...buildComboCategorySitemapEntries(),
+    ...buildFacetSitemapEntries(),
+    ...buildCompareSitemapEntries(),
+    ...buildGuideSitemapEntries(),
+  ];
+}

--- a/tests/unit/app/combo/[slug]/page.test.tsx
+++ b/tests/unit/app/combo/[slug]/page.test.tsx
@@ -267,12 +267,37 @@ describe('ComboPage', () => {
     });
 
     test('includes proper robots directives', async () => {
+      // skull-laughing mock has no longForm / conversationExamples, so it
+      // resolves to the thin tier → noindex, follow (see issue #355).
       mockGetComboBySlug.mockImplementation(() => mockCombo);
       const metadata = await generateMetadata({
         params: Promise.resolve({ slug: 'skull-laughing' }),
       });
 
       expect(metadata.robots).toBeDefined();
+      expect(metadata.robots).toEqual({
+        index: false,
+        follow: true,
+        googleBot: {
+          index: false,
+          follow: true,
+          'max-video-preview': -1,
+          'max-image-preview': 'large',
+          'max-snippet': -1,
+        },
+      });
+    });
+
+    test('returns index,follow robots for combos with longForm', async () => {
+      const deepCombo: EmojiCombo = {
+        ...mockCombo,
+        longForm: { overview: 'A multi-paragraph overview of this combo in real chats.' },
+      };
+      mockGetComboBySlug.mockImplementation(() => deepCombo);
+      const metadata = await generateMetadata({
+        params: Promise.resolve({ slug: 'skull-laughing' }),
+      });
+
       expect(metadata.robots).toEqual({
         index: true,
         follow: true,

--- a/tests/unit/app/robots.test.ts
+++ b/tests/unit/app/robots.test.ts
@@ -32,11 +32,9 @@ describe('robots', () => {
 
       expect(result.rules).toBeDefined();
 
-      // Check if rules is an array or a single rule object
       const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
       expect(rules.length).toBeGreaterThan(0);
 
-      // Should have a rule for all user agents
       const allAgentRule = rules.find(
         (rule) =>
           rule.userAgent === '*' || (Array.isArray(rule.userAgent) && rule.userAgent.includes('*'))
@@ -54,7 +52,6 @@ describe('robots', () => {
           rule.userAgent === '*' || (Array.isArray(rule.userAgent) && rule.userAgent.includes('*'))
       );
 
-      // Should allow root path
       expect(allAgentRule?.allow).toBeDefined();
       const allowPaths = Array.isArray(allAgentRule?.allow)
         ? allAgentRule?.allow
@@ -72,7 +69,6 @@ describe('robots', () => {
           rule.userAgent === '*' || (Array.isArray(rule.userAgent) && rule.userAgent.includes('*'))
       );
 
-      // Should disallow API routes
       expect(allAgentRule?.disallow).toBeDefined();
       const disallowPaths = Array.isArray(allAgentRule?.disallow)
         ? allAgentRule?.disallow
@@ -80,11 +76,31 @@ describe('robots', () => {
       expect(disallowPaths).toContain('/api/');
     });
 
+    it('should disallow crawling of private app areas (dashboard/admin/auth)', async () => {
+      const { default: robots } = await import('../../../src/app/robots');
+      const result = robots();
+
+      const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
+      const allAgentRule = rules.find(
+        (rule) =>
+          rule.userAgent === '*' || (Array.isArray(rule.userAgent) && rule.userAgent.includes('*'))
+      );
+
+      expect(allAgentRule?.disallow).toBeDefined();
+      const disallowPaths = Array.isArray(allAgentRule?.disallow)
+        ? allAgentRule?.disallow
+        : [allAgentRule?.disallow];
+
+      expect(disallowPaths).toContain('/dashboard');
+      expect(disallowPaths).toContain('/admin');
+      expect(disallowPaths).toContain('/login');
+      expect(disallowPaths).toContain('/register');
+    });
+
     it('should use correct base URL from metadata', async () => {
       const { default: robots } = await import('../../../src/app/robots');
       const result = robots();
 
-      // The sitemap URL should be properly formed with the base URL
       expect(result.sitemap).toMatch(/^https?:\/\//);
     });
   });

--- a/tests/unit/app/sitemap.test.ts
+++ b/tests/unit/app/sitemap.test.ts
@@ -2,9 +2,13 @@ import { describe, it, expect, beforeEach, spyOn, afterEach } from 'bun:test';
 import * as emojiData from '../../../src/lib/emoji-data';
 import * as comboData from '../../../src/lib/combo-data';
 import * as guideData from '../../../src/lib/guide-data';
+import * as comparisonData from '../../../src/lib/comparison-data';
+import type { Emoji } from '../../../src/types/emoji';
+import type { EmojiCombo, EmojiComboCategoryName } from '../../../src/types/combo';
+import type { EmojiComparison } from '../../../src/types/comparison';
 
 // Mock data
-const mockEmojis = [
+const mockEmojis: Emoji[] = [
   {
     unicode: '1F480',
     slug: 'skull',
@@ -16,13 +20,21 @@ const mockEmojis = [
     unicodeVersion: '6.0',
     baseMeaning: 'A human skull',
     tldr: "Usually means 'that's so funny I'm dead'",
-    contextMeanings: [],
+    contextMeanings: [
+      {
+        context: 'SLANG',
+        meaning: 'Used to react to something very funny',
+        example: 'That joke 💀',
+        riskLevel: 'LOW',
+      },
+    ],
     platformNotes: [],
     generationalNotes: [],
     warnings: [],
     relatedCombos: [],
     seoTitle: 'Skull Emoji Meaning',
     seoDescription: 'Learn what skull emoji means',
+    contentUpdatedAt: '2026-08-01T00:00:00.000Z',
   },
   {
     unicode: '1F602',
@@ -43,22 +55,81 @@ const mockEmojis = [
     seoTitle: 'Joy Emoji Meaning',
     seoDescription: 'Learn what joy emoji means',
   },
+  // Skin-tone variant — should be excluded from sitemap.
+  {
+    unicode: '1F44B-1F3FD',
+    slug: 'wave-medium',
+    character: '👋🏽',
+    name: 'Waving Hand Medium Skin Tone',
+    shortName: 'wave-medium',
+    category: 'people',
+    unicodeVersion: '14.0',
+    baseMeaning: 'A waving hand with medium skin tone',
+    tldr: 'Wave with medium skin tone',
+    contextMeanings: [],
+    platformNotes: [],
+    generationalNotes: [],
+    warnings: [],
+    relatedCombos: [],
+    seoTitle: 'Wave Medium Skin Tone Emoji',
+    seoDescription: 'Learn what the medium-skin-tone wave emoji means',
+    skinToneBase: 'wave',
+  },
+  // Stub emoji — should be excluded (no contentTier override → resolveContentTier = thin).
+  {
+    unicode: '1F000',
+    slug: 'stub-emoji',
+    character: '�',
+    name: 'Stub',
+    shortName: 'stub',
+    category: 'symbols',
+    unicodeVersion: '1.0',
+    baseMeaning: 'Stub',
+    tldr: 'Stub',
+    contextMeanings: [],
+    platformNotes: [],
+    generationalNotes: [],
+    warnings: [],
+    relatedCombos: [],
+    seoTitle: 'Stub',
+    seoDescription: 'Stub',
+  },
 ];
 
-const mockCombos = [
+const mockCombos: EmojiCombo[] = [
   {
     slug: 'skull-laughing',
     combo: '💀😂',
     name: 'Skull Laughing',
     meaning: 'Something very funny',
     description: 'Used when something is extremely funny',
-    category: 'reactions' as const,
+    category: 'humor',
     emojis: ['skull', 'face-with-tears-of-joy'],
+    examples: ['That thread 💀😂', 'Dead 💀😂'],
     tags: ['funny', 'laughing'],
+    seoTitle: '💀😂 Skull Laughing Combo Meaning',
+    seoDescription: 'What does 💀😂 mean?',
+    contentUpdatedAt: '2026-08-02T00:00:00.000Z',
+  },
+  {
+    slug: 'thin-combo',
+    combo: '🙂🙂',
+    name: 'Thin Combo',
+    meaning: 'A thin combo',
+    description: 'Description',
+    category: 'other',
+    emojis: ['slightly-smiling-face'],
+    examples: ['Hi 🙂🙂'],
+    tags: [],
+    seoTitle: 'Thin Combo Meaning',
+    seoDescription: 'Thin combo description',
+    contentTier: 'thin',
   },
 ];
 
 const mockCategories = ['faces', 'people'];
+
+const mockComboCategories = ['humor', 'other'];
 
 const mockGuideSummaries = [
   {
@@ -78,37 +149,73 @@ const mockGuideSummaries = [
   },
 ];
 
+const mockComparisons: EmojiComparison[] = [
+  {
+    slug: 'skull-vs-face-with-tears-of-joy',
+    emoji1Slug: 'skull',
+    emoji2Slug: 'face-with-tears-of-joy',
+    seoTitle: 'Skull vs Joy',
+    seoDescription: 'Comparison',
+    comparisonPoints: [],
+  },
+];
+
 describe('sitemap', () => {
-  let getAllEmojiSlugsSpy: ReturnType<typeof spyOn>;
-  let getAllComboSlugsSpy: ReturnType<typeof spyOn>;
+  let getAllEmojisSpy: ReturnType<typeof spyOn>;
   let getAllCategoriesSpy: ReturnType<typeof spyOn>;
+  let getAllPlatformsSpy: ReturnType<typeof spyOn>;
+  let getAllGenerationsSpy: ReturnType<typeof spyOn>;
+  let getPageableContextTypesSpy: ReturnType<typeof spyOn>;
+  let getAllCombosSpy: ReturnType<typeof spyOn>;
+  let getAllComboCategoriesSpy: ReturnType<typeof spyOn>;
   let getPublishedGuideSummariesSpy: ReturnType<typeof spyOn>;
+  let getAllComparisonsSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
     // Clear caches before each test
     emojiData.clearEmojiCache();
     comboData.clearComboCache();
     guideData.clearGuideCache();
+    comparisonData.clearComparisonCache();
 
     // Set up spies with mock data
-    getAllEmojiSlugsSpy = spyOn(emojiData, 'getAllEmojiSlugs').mockReturnValue(
-      mockEmojis.map((e) => e.slug)
-    );
-    getAllComboSlugsSpy = spyOn(comboData, 'getAllComboSlugs').mockReturnValue(
-      mockCombos.map((c) => c.slug)
-    );
+    getAllEmojisSpy = spyOn(emojiData, 'getAllEmojis').mockReturnValue(mockEmojis);
     getAllCategoriesSpy = spyOn(emojiData, 'getAllCategories').mockReturnValue(mockCategories);
+    getAllPlatformsSpy = spyOn(emojiData, 'getAllPlatforms').mockReturnValue([
+      'IMESSAGE',
+      'INSTAGRAM',
+    ] as never);
+    getAllGenerationsSpy = spyOn(emojiData, 'getAllGenerations').mockReturnValue([
+      'GEN_Z',
+      'MILLENNIAL',
+    ] as never);
+    getPageableContextTypesSpy = spyOn(emojiData, 'getPageableContextTypes').mockReturnValue([
+      'SLANG',
+      'DATING',
+    ] as never);
+    getAllCombosSpy = spyOn(comboData, 'getAllCombos').mockReturnValue(mockCombos);
+    getAllComboCategoriesSpy = spyOn(comboData, 'getAllComboCategories').mockReturnValue(
+      mockComboCategories as EmojiComboCategoryName[]
+    );
     getPublishedGuideSummariesSpy = spyOn(guideData, 'getPublishedGuideSummaries').mockReturnValue(
       mockGuideSummaries
+    );
+    getAllComparisonsSpy = spyOn(comparisonData, 'getAllComparisons').mockReturnValue(
+      mockComparisons
     );
   });
 
   afterEach(() => {
     // Restore all spies
-    getAllEmojiSlugsSpy.mockRestore();
-    getAllComboSlugsSpy.mockRestore();
+    getAllEmojisSpy.mockRestore();
     getAllCategoriesSpy.mockRestore();
+    getAllPlatformsSpy.mockRestore();
+    getAllGenerationsSpy.mockRestore();
+    getPageableContextTypesSpy.mockRestore();
+    getAllCombosSpy.mockRestore();
+    getAllComboCategoriesSpy.mockRestore();
     getPublishedGuideSummariesSpy.mockRestore();
+    getAllComparisonsSpy.mockRestore();
   });
 
   describe('sitemap function', () => {
@@ -122,56 +229,117 @@ describe('sitemap', () => {
       const { default: sitemap } = await import('../../../src/app/sitemap');
       const result = await sitemap();
 
-      // Check homepage
       const homepage = result.find((entry) => entry.url.endsWith('/'));
       expect(homepage).toBeDefined();
       expect(homepage?.priority).toBe(1.0);
       expect(homepage?.changeFrequency).toBe('daily');
 
-      // Check interpreter page
       const interpreter = result.find((entry) => entry.url.endsWith('/interpreter'));
       expect(interpreter).toBeDefined();
       expect(interpreter?.priority).toBe(0.9);
       expect(interpreter?.changeFrequency).toBe('weekly');
     });
 
-    it('should include emoji pages', async () => {
+    it('should include about/contact/pricing/privacy/terms/search/emoji/combo hubs', async () => {
       const { default: sitemap } = await import('../../../src/app/sitemap');
       const result = await sitemap();
 
-      // Check emoji pages
-      const skullPage = result.find((entry) => entry.url.includes('/emoji/skull'));
-      expect(skullPage).toBeDefined();
-      expect(skullPage?.priority).toBe(0.8);
-      expect(skullPage?.changeFrequency).toBe('weekly');
-
-      const joyPage = result.find((entry) => entry.url.includes('/emoji/face-with-tears-of-joy'));
-      expect(joyPage).toBeDefined();
+      for (const path of [
+        '/about',
+        '/contact',
+        '/pricing',
+        '/privacy',
+        '/terms',
+        '/search',
+        '/emoji',
+        '/combo',
+      ]) {
+        const entry = result.find((e) => e.url.endsWith(path));
+        expect(entry).toBeDefined();
+      }
     });
 
-    it('should include combo pages', async () => {
+    it('should include emoji pages for indexable emojis', async () => {
       const { default: sitemap } = await import('../../../src/app/sitemap');
       const result = await sitemap();
 
-      // Check combo pages
+      const skullPage = result.find((entry) => entry.url.includes('/emoji/skull'));
+      expect(skullPage).toBeDefined();
+      expect(skullPage?.priority).toBeGreaterThanOrEqual(0.7);
+      expect(skullPage?.changeFrequency).toBe('weekly');
+    });
+
+    it('should exclude skin-tone variant emoji URLs', async () => {
+      const { default: sitemap } = await import('../../../src/app/sitemap');
+      const result = await sitemap();
+
+      const skinTonePage = result.find((entry) => entry.url.includes('/emoji/wave-medium'));
+      expect(skinTonePage).toBeUndefined();
+    });
+
+    it('should exclude stub/thin emoji URLs without explicit contentTier', async () => {
+      const { default: sitemap } = await import('../../../src/app/sitemap');
+      const result = await sitemap();
+
+      const stubPage = result.find((entry) => entry.url.includes('/emoji/stub-emoji'));
+      expect(stubPage).toBeUndefined();
+    });
+
+    it('should include combo pages for indexable combos', async () => {
+      const { default: sitemap } = await import('../../../src/app/sitemap');
+      const result = await sitemap();
+
       const comboPage = result.find((entry) => entry.url.includes('/combo/skull-laughing'));
       expect(comboPage).toBeDefined();
-      expect(comboPage?.priority).toBe(0.7);
-      expect(comboPage?.changeFrequency).toBe('weekly');
+      expect(comboPage?.priority).toBeGreaterThanOrEqual(0.7);
+    });
+
+    it('should exclude thin-tier combo URLs', async () => {
+      const { default: sitemap } = await import('../../../src/app/sitemap');
+      const result = await sitemap();
+
+      const thinPage = result.find((entry) => entry.url.includes('/combo/thin-combo'));
+      expect(thinPage).toBeUndefined();
     });
 
     it('should include category pages', async () => {
       const { default: sitemap } = await import('../../../src/app/sitemap');
       const result = await sitemap();
 
-      // Check category pages
       const facesCategory = result.find((entry) => entry.url.includes('/emoji/category/faces'));
       expect(facesCategory).toBeDefined();
-      expect(facesCategory?.priority).toBe(0.7);
-      expect(facesCategory?.changeFrequency).toBe('weekly');
+      expect(facesCategory?.priority).toBeLessThanOrEqual(0.7);
 
       const peopleCategory = result.find((entry) => entry.url.includes('/emoji/category/people'));
       expect(peopleCategory).toBeDefined();
+    });
+
+    it('should include combo category pages', async () => {
+      const { default: sitemap } = await import('../../../src/app/sitemap');
+      const result = await sitemap();
+
+      const humorCategory = result.find((entry) => entry.url.includes('/combo/category/humor'));
+      expect(humorCategory).toBeDefined();
+    });
+
+    it('should include facet hubs (platform, generation, context)', async () => {
+      const { default: sitemap } = await import('../../../src/app/sitemap');
+      const result = await sitemap();
+
+      expect(result.find((e) => e.url.endsWith('/emoji/platform/IMESSAGE'))).toBeDefined();
+      expect(result.find((e) => e.url.endsWith('/emoji/platform/INSTAGRAM'))).toBeDefined();
+      expect(result.find((e) => e.url.endsWith('/emoji/generation/GEN_Z'))).toBeDefined();
+      expect(result.find((e) => e.url.endsWith('/emoji/context/SLANG'))).toBeDefined();
+    });
+
+    it('should include compare pages in canonical order', async () => {
+      const { default: sitemap } = await import('../../../src/app/sitemap');
+      const result = await sitemap();
+
+      const compare = result.find((entry) =>
+        entry.url.endsWith('/compare/skull/face-with-tears-of-joy')
+      );
+      expect(compare).toBeDefined();
     });
 
     it('should have lastModified dates on all entries', async () => {
@@ -188,7 +356,6 @@ describe('sitemap', () => {
       const { default: sitemap } = await import('../../../src/app/sitemap');
       const result = await sitemap();
 
-      // All URLs should start with the configured base URL
       result.forEach((entry) => {
         expect(entry.url).toMatch(/^https?:\/\//);
       });
@@ -209,7 +376,7 @@ describe('sitemap', () => {
 
       const guidesIndex = result.find((entry) => entry.url.endsWith('/guides'));
       expect(guidesIndex).toBeDefined();
-      expect(guidesIndex?.priority).toBe(0.8);
+      expect(guidesIndex?.priority).toBe(0.9);
       expect(guidesIndex?.changeFrequency).toBe('weekly');
     });
 
@@ -221,9 +388,20 @@ describe('sitemap', () => {
         entry.url.includes('/guides/what-does-skull-mean-in-texting')
       );
       expect(guidePage).toBeDefined();
-      expect(guidePage?.priority).toBe(0.8);
+      expect(guidePage?.priority).toBe(0.85);
       expect(guidePage?.changeFrequency).toBe('monthly');
       expect(guidePage?.lastModified instanceof Date).toBe(true);
+    });
+
+    it('should not include private surfaces (api/dashboard/admin/auth)', async () => {
+      const { default: sitemap } = await import('../../../src/app/sitemap');
+      const result = await sitemap();
+
+      const urls = result.map((entry) => entry.url);
+      expect(urls.some((url) => url.includes('/api/'))).toBe(false);
+      expect(urls.some((url) => url.includes('/dashboard'))).toBe(false);
+      expect(urls.some((url) => url.includes('/admin'))).toBe(false);
+      expect(urls.some((url) => url.includes('/login'))).toBe(false);
     });
   });
 });

--- a/tests/unit/lib/comparison-data.test.ts
+++ b/tests/unit/lib/comparison-data.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test, beforeEach } from 'bun:test';
+import {
+  clearComparisonCache,
+  getAllComparisons,
+  getAllComparisonSlugs,
+  getComparisonBySlug,
+  getComparisonSummaries,
+} from '../../../src/lib/comparison-data';
+
+beforeEach(() => {
+  clearComparisonCache();
+});
+
+describe('comparison-data', () => {
+  describe('getAllComparisons', () => {
+    test('returns an array of comparison records loaded from disk', () => {
+      const comparisons = getAllComparisons();
+      expect(Array.isArray(comparisons)).toBe(true);
+    });
+
+    test('each comparison has the required fields', () => {
+      const comparisons = getAllComparisons();
+      if (comparisons.length === 0) return;
+      for (const comparison of comparisons) {
+        expect(typeof comparison.slug).toBe('string');
+        expect(typeof comparison.emoji1Slug).toBe('string');
+        expect(typeof comparison.emoji2Slug).toBe('string');
+        expect(typeof comparison.seoTitle).toBe('string');
+        expect(typeof comparison.seoDescription).toBe('string');
+        expect(Array.isArray(comparison.comparisonPoints)).toBe(true);
+      }
+    });
+  });
+
+  describe('getComparisonBySlug', () => {
+    test('returns the matching comparison when the slug exists', () => {
+      const comparisons = getAllComparisons();
+      if (comparisons.length === 0) return;
+      const sample = comparisons[0];
+      const result = getComparisonBySlug(sample.slug);
+      expect(result).toBeDefined();
+      expect(result?.slug).toBe(sample.slug);
+    });
+
+    test('returns undefined for unknown slugs', () => {
+      expect(getComparisonBySlug('not-a-real-slug-xyz')).toBeUndefined();
+    });
+  });
+
+  describe('getAllComparisonSlugs', () => {
+    test('returns one slug per comparison', () => {
+      const comparisons = getAllComparisons();
+      const slugs = getAllComparisonSlugs();
+      expect(slugs.length).toBe(comparisons.length);
+      for (const slug of slugs) {
+        expect(typeof slug).toBe('string');
+      }
+    });
+  });
+
+  describe('getComparisonSummaries', () => {
+    test('returns one summary per comparison with only the summary fields', () => {
+      const summaries = getComparisonSummaries();
+      expect(Array.isArray(summaries)).toBe(true);
+      expect(summaries.length).toBe(getAllComparisons().length);
+
+      const sample = summaries[0];
+      expect(sample).toHaveProperty('slug');
+      expect(sample).toHaveProperty('emoji1Slug');
+      expect(sample).toHaveProperty('emoji2Slug');
+      // Summary intentionally omits the long-form fields.
+      expect(sample).not.toHaveProperty('seoTitle');
+      expect(sample).not.toHaveProperty('comparisonPoints');
+    });
+  });
+
+  describe('clearComparisonCache', () => {
+    test('is callable and resets the in-memory cache', () => {
+      // Warm the cache first.
+      getAllComparisons();
+      // Calling again should still work (cache hit or miss both fine).
+      const before = getAllComparisons();
+      clearComparisonCache();
+      const after = getAllComparisons();
+      expect(after.length).toBe(before.length);
+    });
+  });
+});

--- a/tests/unit/lib/db.test.ts
+++ b/tests/unit/lib/db.test.ts
@@ -59,6 +59,11 @@ describe('db module', () => {
     it('should not throw when called', () => {
       expect(() => clearDb()).not.toThrow();
     });
+
+    it('should reset the cached db instance', () => {
+      clearDb();
+      expect(() => clearDb()).not.toThrow();
+    });
   });
 });
 

--- a/tests/unit/lib/seo-policy.test.ts
+++ b/tests/unit/lib/seo-policy.test.ts
@@ -2,10 +2,13 @@ import { describe, expect, test } from 'bun:test';
 import {
   decisionToRobots,
   getIndexingDecision,
+  getComboIndexingDecision,
+  resolveComboContentTier,
   resolveContentTier,
 } from '../../../src/lib/seo-policy';
 import { createEmoji } from '../../utils/factories/emoji.factory';
 import { createContextMeaning } from '../../utils/factories/emoji.factory';
+import { createEmojiCombo } from '../../utils/factories/combo.factory';
 
 describe('seo-policy', () => {
   describe('resolveContentTier', () => {
@@ -158,6 +161,83 @@ describe('seo-policy', () => {
       expect(robots.follow).toBe(true);
       expect(robots.googleBot?.index).toBe(false);
       expect(robots.googleBot?.follow).toBe(true);
+    });
+  });
+
+  describe('resolveComboContentTier', () => {
+    test('returns explicit contentTier when set', () => {
+      expect(resolveComboContentTier(createEmojiCombo({ contentTier: 'deep' }))).toBe('deep');
+      expect(resolveComboContentTier(createEmojiCombo({ contentTier: 'standard' }))).toBe(
+        'standard'
+      );
+      expect(resolveComboContentTier(createEmojiCombo({ contentTier: 'thin' }))).toBe('thin');
+    });
+
+    test('promotes combo with longForm to deep', () => {
+      const combo = createEmojiCombo({
+        longForm: { overview: 'A two-paragraph overview of how this combo is used.' },
+      });
+      expect(resolveComboContentTier(combo)).toBe('deep');
+    });
+
+    test('promotes combo with conversation examples to standard', () => {
+      const combo = createEmojiCombo({
+        conversationExamples: [
+          {
+            setting: 'friends',
+            message: 'lol 💀😂',
+            interpretation: 'reacting to a joke',
+          },
+        ],
+      });
+      expect(resolveComboContentTier(combo)).toBe('standard');
+    });
+
+    test('treats bare-bones combo as thin', () => {
+      expect(resolveComboContentTier(createEmojiCombo())).toBe('thin');
+    });
+  });
+
+  describe('getComboIndexingDecision', () => {
+    test('thin combo → noindex, follow, self canonical', () => {
+      const combo = createEmojiCombo({ contentTier: 'thin' });
+      const url = 'https://knowyouremoji.com/combo/thin-combo';
+      const decision = getComboIndexingDecision(combo, url);
+
+      expect(decision.index).toBe(false);
+      expect(decision.follow).toBe(true);
+      expect(decision.canonical).toBe(url);
+      expect(decision.reason).toContain('thin');
+    });
+
+    test('standard combo → index, follow, self canonical', () => {
+      const combo = createEmojiCombo({ contentTier: 'standard' });
+      const url = 'https://knowyouremoji.com/combo/standard-combo';
+      const decision = getComboIndexingDecision(combo, url);
+
+      expect(decision.index).toBe(true);
+      expect(decision.follow).toBe(true);
+      expect(decision.canonical).toBe(url);
+    });
+
+    test('deep combo → index, follow, self canonical', () => {
+      const combo = createEmojiCombo({ contentTier: 'deep' });
+      const url = 'https://knowyouremoji.com/combo/deep-combo';
+      const decision = getComboIndexingDecision(combo, url);
+
+      expect(decision.index).toBe(true);
+      expect(decision.follow).toBe(true);
+      expect(decision.canonical).toBe(url);
+      expect(decision.reason).toContain('deep');
+    });
+
+    test('bare-bones combo (no contentTier) → noindex by default', () => {
+      const combo = createEmojiCombo();
+      const url = 'https://knowyouremoji.com/combo/bare-combo';
+      const decision = getComboIndexingDecision(combo, url);
+
+      expect(decision.index).toBe(false);
+      expect(decision.follow).toBe(true);
     });
   });
 });

--- a/tests/unit/lib/sitemap-entries.test.ts
+++ b/tests/unit/lib/sitemap-entries.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, test, beforeEach, afterEach, spyOn } from 'bun:test';
+import * as emojiData from '../../../src/lib/emoji-data';
+import * as comboData from '../../../src/lib/combo-data';
+import * as guideData from '../../../src/lib/guide-data';
+import * as comparisonData from '../../../src/lib/comparison-data';
+import type { Emoji } from '../../../src/types/emoji';
+import type { EmojiCombo } from '../../../src/types/combo';
+import type { EmojiComparison } from '../../../src/types/comparison';
+
+const mockEmojis: Emoji[] = [
+  {
+    unicode: '1F480',
+    slug: 'skull',
+    character: '�',
+    name: 'Skull',
+    shortName: 'skull',
+    category: 'faces',
+    unicodeVersion: '6.0',
+    baseMeaning: 'A human skull',
+    tldr: 'Dying of laughter',
+    contextMeanings: [
+      {
+        context: 'SLANG',
+        meaning: 'React to something very funny',
+        example: 'That joke 💀',
+        riskLevel: 'LOW',
+      },
+    ],
+    platformNotes: [],
+    generationalNotes: [],
+    warnings: [],
+    relatedCombos: [],
+    seoTitle: 'Skull Emoji Meaning',
+    seoDescription: 'Learn what skull emoji means',
+    contentUpdatedAt: '2026-08-01T00:00:00.000Z',
+  },
+  {
+    unicode: '1F44B-1F3FD',
+    slug: 'wave-medium',
+    character: '👋🏽',
+    name: 'Wave Medium',
+    shortName: 'wave-medium',
+    category: 'people',
+    unicodeVersion: '14.0',
+    baseMeaning: 'A waving hand',
+    tldr: 'Wave with medium skin tone',
+    contextMeanings: [],
+    platformNotes: [],
+    generationalNotes: [],
+    warnings: [],
+    relatedCombos: [],
+    seoTitle: 'Wave Medium Skin Tone',
+    seoDescription: 'Wave medium',
+    skinToneBase: 'wave',
+  },
+];
+
+const mockCombos: EmojiCombo[] = [
+  {
+    slug: 'skull-laughing',
+    combo: '💀😂',
+    name: 'Skull Laughing',
+    meaning: 'Something very funny',
+    description: 'Used when something is extremely funny',
+    category: 'humor',
+    emojis: ['skull'],
+    examples: ['That thread 💀😂'],
+    tags: ['funny'],
+    seoTitle: 'Skull Laughing Combo',
+    seoDescription: 'Skull laughing combo meaning',
+    contentUpdatedAt: '2026-08-02T00:00:00.000Z',
+  },
+  {
+    slug: 'thin-combo',
+    combo: '🙂🙂',
+    name: 'Thin',
+    meaning: 'A thin combo',
+    description: 'Description',
+    category: 'other',
+    emojis: ['slightly-smiling-face'],
+    examples: ['Hi 🙂🙂'],
+    tags: [],
+    seoTitle: 'Thin Combo',
+    seoDescription: 'Thin combo',
+    contentTier: 'thin',
+  },
+];
+
+const mockComparisons: EmojiComparison[] = [
+  {
+    slug: 'skull-vs-joy',
+    emoji1Slug: 'skull',
+    emoji2Slug: 'joy',
+    seoTitle: 'Skull vs Joy',
+    seoDescription: 'Compare',
+    comparisonPoints: [],
+  },
+];
+
+describe('sitemap-entries', () => {
+  let getAllEmojisSpy: ReturnType<typeof spyOn>;
+  let getAllCategoriesSpy: ReturnType<typeof spyOn>;
+  let getAllPlatformsSpy: ReturnType<typeof spyOn>;
+  let getAllGenerationsSpy: ReturnType<typeof spyOn>;
+  let getPageableContextTypesSpy: ReturnType<typeof spyOn>;
+  let getAllCombosSpy: ReturnType<typeof spyOn>;
+  let getAllComboCategoriesSpy: ReturnType<typeof spyOn>;
+  let getPublishedGuideSummariesSpy: ReturnType<typeof spyOn>;
+  let getAllComparisonsSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    emojiData.clearEmojiCache();
+    comboData.clearComboCache();
+    guideData.clearGuideCache();
+    comparisonData.clearComparisonCache();
+
+    getAllEmojisSpy = spyOn(emojiData, 'getAllEmojis').mockReturnValue(mockEmojis);
+    getAllCategoriesSpy = spyOn(emojiData, 'getAllCategories').mockReturnValue(['faces', 'people']);
+    getAllPlatformsSpy = spyOn(emojiData, 'getAllPlatforms').mockReturnValue(['IMESSAGE'] as never);
+    getAllGenerationsSpy = spyOn(emojiData, 'getAllGenerations').mockReturnValue([
+      'GEN_Z',
+    ] as never);
+    getPageableContextTypesSpy = spyOn(emojiData, 'getPageableContextTypes').mockReturnValue([
+      'SLANG',
+    ] as never);
+    getAllCombosSpy = spyOn(comboData, 'getAllCombos').mockReturnValue(mockCombos);
+    getAllComboCategoriesSpy = spyOn(comboData, 'getAllComboCategories').mockReturnValue([
+      'humor',
+      'other',
+    ]);
+    getPublishedGuideSummariesSpy = spyOn(guideData, 'getPublishedGuideSummaries').mockReturnValue(
+      []
+    );
+    getAllComparisonsSpy = spyOn(comparisonData, 'getAllComparisons').mockReturnValue(
+      mockComparisons
+    );
+  });
+
+  afterEach(() => {
+    getAllEmojisSpy.mockRestore();
+    getAllCategoriesSpy.mockRestore();
+    getAllPlatformsSpy.mockRestore();
+    getAllGenerationsSpy.mockRestore();
+    getPageableContextTypesSpy.mockRestore();
+    getAllCombosSpy.mockRestore();
+    getAllComboCategoriesSpy.mockRestore();
+    getPublishedGuideSummariesSpy.mockRestore();
+    getAllComparisonsSpy.mockRestore();
+  });
+
+  describe('buildStaticSitemapEntries', () => {
+    test('emits the trust and hub static paths', async () => {
+      const { buildStaticSitemapEntries } = await import('../../../src/lib/sitemap-entries');
+      const entries = buildStaticSitemapEntries();
+      const urls = entries.map((entry) => entry.url);
+
+      for (const path of [
+        '/',
+        '/interpreter',
+        '/about',
+        '/contact',
+        '/pricing',
+        '/privacy',
+        '/terms',
+        '/search',
+        '/emoji',
+        '/combo',
+      ]) {
+        expect(urls.some((url) => url.endsWith(path))).toBe(true);
+      }
+
+      // /guides is owned by buildGuideSitemapEntries, not the static builder.
+      expect(urls.some((url) => url.endsWith('/guides'))).toBe(false);
+    });
+
+    test('homepage is priority 1.0 with daily changeFrequency', async () => {
+      const { buildStaticSitemapEntries } = await import('../../../src/lib/sitemap-entries');
+      const entries = buildStaticSitemapEntries();
+      const home = entries.find((entry) => entry.url.endsWith('/'));
+      expect(home?.priority).toBe(1.0);
+      expect(home?.changeFrequency).toBe('daily');
+    });
+  });
+
+  describe('buildEmojiSitemapEntries', () => {
+    test('excludes skin-tone variant emojis', async () => {
+      const { buildEmojiSitemapEntries } = await import('../../../src/lib/sitemap-entries');
+      const entries = buildEmojiSitemapEntries();
+      const urls = entries.map((entry) => entry.url);
+      expect(urls.some((url) => url.includes('/emoji/wave-medium'))).toBe(false);
+    });
+
+    test('uses contentUpdatedAt for lastModified when present', async () => {
+      const { buildEmojiSitemapEntries } = await import('../../../src/lib/sitemap-entries');
+      const entries = buildEmojiSitemapEntries();
+      const skull = entries.find((entry) => entry.url.endsWith('/emoji/skull'));
+      expect(skull?.lastModified).toBeInstanceOf(Date);
+      expect((skull?.lastModified as Date).toISOString()).toBe('2026-08-01T00:00:00.000Z');
+    });
+
+    test('gives deep emoji a higher priority than standard', async () => {
+      const { buildEmojiSitemapEntries } = await import('../../../src/lib/sitemap-entries');
+      const entries = buildEmojiSitemapEntries();
+      const skull = entries.find((entry) => entry.url.endsWith('/emoji/skull'));
+      // skull has contextMeanings, so it falls back to standard (no explicit tier)
+      expect(skull?.priority).toBeGreaterThanOrEqual(0.7);
+    });
+  });
+
+  describe('buildComboSitemapEntries', () => {
+    test('excludes thin-tier combos', async () => {
+      const { buildComboSitemapEntries } = await import('../../../src/lib/sitemap-entries');
+      const entries = buildComboSitemapEntries();
+      const urls = entries.map((entry) => entry.url);
+      expect(urls.some((url) => url.includes('/combo/thin-combo'))).toBe(false);
+    });
+
+    test('uses contentUpdatedAt for lastModified', async () => {
+      const { buildComboSitemapEntries } = await import('../../../src/lib/sitemap-entries');
+      const entries = buildComboSitemapEntries();
+      const skull = entries.find((entry) => entry.url.endsWith('/combo/skull-laughing'));
+      expect(skull?.lastModified).toBeInstanceOf(Date);
+      expect((skull?.lastModified as Date).toISOString()).toBe('2026-08-02T00:00:00.000Z');
+    });
+  });
+
+  describe('buildCategorySitemapEntries', () => {
+    test('emits one entry per emoji category', async () => {
+      const { buildCategorySitemapEntries } = await import('../../../src/lib/sitemap-entries');
+      const entries = buildCategorySitemapEntries();
+      const urls = entries.map((entry) => entry.url);
+      expect(urls.some((url) => url.endsWith('/emoji/category/faces'))).toBe(true);
+      expect(urls.some((url) => url.endsWith('/emoji/category/people'))).toBe(true);
+    });
+  });
+
+  describe('buildComboCategorySitemapEntries', () => {
+    test('emits one entry per combo category', async () => {
+      const { buildComboCategorySitemapEntries } = await import('../../../src/lib/sitemap-entries');
+      const entries = buildComboCategorySitemapEntries();
+      const urls = entries.map((entry) => entry.url);
+      expect(urls.some((url) => url.endsWith('/combo/category/humor'))).toBe(true);
+    });
+  });
+
+  describe('buildFacetSitemapEntries', () => {
+    test('emits platform, generation, and context hubs', async () => {
+      const { buildFacetSitemapEntries } = await import('../../../src/lib/sitemap-entries');
+      const entries = buildFacetSitemapEntries();
+      const urls = entries.map((entry) => entry.url);
+      expect(urls.some((url) => url.endsWith('/emoji/platform/IMESSAGE'))).toBe(true);
+      expect(urls.some((url) => url.endsWith('/emoji/generation/GEN_Z'))).toBe(true);
+      expect(urls.some((url) => url.endsWith('/emoji/context/SLANG'))).toBe(true);
+    });
+  });
+
+  describe('buildCompareSitemapEntries', () => {
+    test('emits compare pages in canonical order only', async () => {
+      const { buildCompareSitemapEntries } = await import('../../../src/lib/sitemap-entries');
+      const entries = buildCompareSitemapEntries();
+      const urls = entries.map((entry) => entry.url);
+      expect(urls.some((url) => url.endsWith('/compare/skull/joy'))).toBe(true);
+    });
+  });
+
+  describe('buildSitemap', () => {
+    test('has no duplicate URLs', async () => {
+      const { buildSitemap } = await import('../../../src/lib/sitemap-entries');
+      const entries = buildSitemap();
+      const urls = entries.map((entry) => entry.url);
+      const uniqueUrls = [...new Set(urls)];
+      expect(urls.length).toBe(uniqueUrls.length);
+    });
+
+    test('does not include any thin/skin-tone URLs', async () => {
+      const { buildSitemap } = await import('../../../src/lib/sitemap-entries');
+      const entries = buildSitemap();
+      const urls = entries.map((entry) => entry.url);
+      expect(urls.some((url) => url.includes('/emoji/wave-medium'))).toBe(false);
+      expect(urls.some((url) => url.includes('/combo/thin-combo'))).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- New `src/lib/sitemap-entries.ts` centralizes the rules for what should appear in the sitemap: skin-tone variants and thin combos are excluded, trust / hub / facet / compare pages are surfaced, `lastModified` is content-derived (`contentUpdatedAt` / `updatedAt` / `publishedAt`) instead of "always now", and priority differentiates deep editorial content (0.85) from stub directories (0.6–0.7).
- `src/app/sitemap.ts` becomes a thin wrapper around `buildSitemap()` so the per-surface rules are unit-testable in isolation.
- `src/app/combo/[slug]/page.tsx` now applies `getComboIndexingDecision` via `decisionToRobots`, so thin combos ship with `noindex,follow` instead of unconditional `index,follow`. Mirrors the emoji policy from #344.
- `src/lib/seo-policy.ts` gains `resolveComboContentTier` + `getComboIndexingDecision` (longForm → deep, conversationExamples → standard, bare bones → thin).
- `src/app/robots.ts` disallows `/api/`, `/dashboard`, `/admin`, `/login`, `/register`, `/forgot-password`, `/reset-password` as a belt-and-suspenders complement to per-page `noindex` metadata.
- `docs/seo-indexing-policy.md` documents the sitemap ↔ robots ↔ page invariants and the new tier tables for emoji + combo.
- Tests cover the new behavior: skin-tone / thin exclusion, trust / hub inclusion, content-derived `lastModified`, no duplicate URLs, the new combo policy, and the expanded robots disallow list.

## Test plan
- `bun test tests/unit/lib/seo-policy.test.ts tests/unit/lib/sitemap-entries.test.ts tests/unit/app/sitemap.test.ts tests/unit/app/robots.test.ts tests/unit/app/combo` — all 94 targeted tests pass.
- `bun run typecheck` — clean.
- `bun run lint` — clean.
- `bun run build` — prerenders all routes including `/sitemap.xml` (3,655 URLs vs the ~4,200 before, no skin-tone / thin URLs) and the new `/robots.txt`.
- Manually inspected the generated `.next/server/app/sitemap.xml.body` — contains about / contact / pricing / privacy / terms / search / emoji / combo hubs at priority 0.6–0.7; `/emoji/100` (deep) at 0.85; no `/api`, `/dashboard`, `/admin`, or skin-tone URLs.
- Coverage: my touched files (`seo-policy.ts`, `sitemap-entries.ts`, `combo/[slug]/page.tsx`, `robots.ts`, `sitemap.ts`) all hit 100% / 100%. The pre-existing coverage gap on `comparison-data.ts` and `db/index.ts` (unchanged by this PR) keeps overall coverage below the 99.3% / 99.4% threshold, identical to `main`.

Fixes #355