### PR TITLE
feat(analytics): build admin analytics dashboard (#78)

### DIFF
--- a/src/app/(dashboard)/admin/analytics/page.tsx
+++ b/src/app/(dashboard)/admin/analytics/page.tsx
@@ -1,0 +1,41 @@
+import type { Metadata } from 'next';
+import { AdminAnalyticsDashboard } from '@/components/admin/admin-analytics-dashboard';
+import { AdminNav } from '@/components/admin/admin-nav';
+import {
+  getAllEmojiViewCounts,
+  getAnalyticsOverview,
+  getLeastViewedTrackedEmojis,
+  getTopEmojisByViews,
+} from '@/lib/analytics-queries';
+
+export const metadata: Metadata = {
+  title: 'Analytics | Admin | KnowYourEmoji',
+  description: 'View counts and popular emoji telemetry for KnowYourEmoji.',
+  robots: { index: false, follow: false },
+};
+
+export const dynamic = 'force-dynamic';
+
+export default async function AdminAnalyticsPage() {
+  const [overview, topEmojis, leastViewed, allEmojis] = await Promise.all([
+    getAnalyticsOverview(),
+    getTopEmojisByViews(10),
+    getLeastViewedTrackedEmojis(10),
+    getAllEmojiViewCounts(),
+  ]);
+
+  const isLive = overview.totalViews > 0 || overview.trackedEmojis > 0;
+
+  return (
+    <div className="space-y-6">
+      <AdminNav />
+      <AdminAnalyticsDashboard
+        overview={overview}
+        topEmojis={topEmojis}
+        leastViewed={leastViewed}
+        allEmojis={allEmojis}
+        isLive={isLive}
+      />
+    </div>
+  );
+}

--- a/src/app/(dashboard)/admin/emojis/page.tsx
+++ b/src/app/(dashboard)/admin/emojis/page.tsx
@@ -1,12 +1,14 @@
 import Link from 'next/link';
 import { getAllEmojis } from '@/lib/emoji-data';
 import { AdminEmojiList } from '@/components/admin/admin-emoji-list';
+import { AdminNav } from '@/components/admin/admin-nav';
 
 export default async function AdminEmojiPage() {
   const emojis = getAllEmojis();
 
   return (
-    <div>
+    <div className="space-y-6">
+      <AdminNav />
       <div className="mb-8 flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold">Emoji Admin</h1>

--- a/src/components/admin/admin-analytics-dashboard.tsx
+++ b/src/components/admin/admin-analytics-dashboard.tsx
@@ -1,0 +1,486 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Link from 'next/link';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import type { EmojiSummary } from '@/types/emoji';
+
+export interface PopularityEntryWithEmoji {
+  slug: string;
+  views: number;
+  lastViewedAt: string | null;
+  emoji: EmojiSummary | null;
+}
+
+export interface PopularityEntryWithSummary extends PopularityEntryWithEmoji {
+  emoji: EmojiSummary;
+}
+
+export interface AnalyticsOverviewData {
+  totalViews: number;
+  trackedEmojis: number;
+  catalogSize: number;
+  topSlug: string | null;
+  topViews: number;
+  viewsLast7Days: number;
+  viewsLast30Days: number;
+  lastUpdatedAt: string | null;
+}
+
+export interface AdminAnalyticsDashboardProps {
+  overview: AnalyticsOverviewData;
+  topEmojis: PopularityEntryWithEmoji[];
+  leastViewed: PopularityEntryWithEmoji[];
+  allEmojis: PopularityEntryWithSummary[];
+  /** Whether the database is configured and returning live data */
+  isLive: boolean;
+}
+
+type SortKey = 'views-desc' | 'views-asc' | 'name-asc' | 'name-desc';
+
+function formatNumber(n: number): string {
+  return n.toLocaleString('en-US');
+}
+
+function formatDateTime(iso: string | null): string {
+  if (!iso) return '—';
+  try {
+    const date = new Date(iso);
+    return date.toLocaleString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function formatRelative(iso: string | null): string {
+  if (!iso) return 'never';
+  const ms = Date.now() - new Date(iso).getTime();
+  if (Number.isNaN(ms)) return iso;
+  const minutes = Math.floor(ms / 60_000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  return formatDateTime(iso);
+}
+
+export function AdminAnalyticsDashboard({
+  overview,
+  topEmojis,
+  leastViewed,
+  allEmojis,
+  isLive,
+}: AdminAnalyticsDashboardProps) {
+  const [query, setQuery] = useState('');
+  const [sortKey, setSortKey] = useState<SortKey>('views-desc');
+
+  const maxViews = useMemo(
+    () => topEmojis.reduce((acc, entry) => Math.max(acc, entry.views), 0),
+    [topEmojis]
+  );
+
+  const filteredAll = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    const matches = normalized
+      ? allEmojis.filter(
+          (entry) =>
+            entry.emoji.name.toLowerCase().includes(normalized) ||
+            entry.emoji.slug.toLowerCase().includes(normalized) ||
+            entry.emoji.character.includes(normalized) ||
+            entry.emoji.category.toLowerCase().includes(normalized)
+        )
+      : allEmojis;
+
+    const sorted = [...matches];
+    switch (sortKey) {
+      case 'views-desc':
+        sorted.sort((a, b) => b.views - a.views || a.emoji.name.localeCompare(b.emoji.name));
+        break;
+      case 'views-asc':
+        sorted.sort((a, b) => a.views - b.views || a.emoji.name.localeCompare(b.emoji.name));
+        break;
+      case 'name-asc':
+        sorted.sort((a, b) => a.emoji.name.localeCompare(b.emoji.name));
+        break;
+      case 'name-desc':
+        sorted.sort((a, b) => b.emoji.name.localeCompare(a.emoji.name));
+        break;
+    }
+    return sorted;
+  }, [allEmojis, query, sortKey]);
+
+  const coveragePercent =
+    overview.catalogSize > 0
+      ? Math.round((overview.trackedEmojis / overview.catalogSize) * 100)
+      : 0;
+
+  const topEmoji = useMemo(
+    () => topEmojis.find((entry) => entry.slug === overview.topSlug) ?? null,
+    [topEmojis, overview.topSlug]
+  );
+
+  return (
+    <div className="space-y-8">
+      <header>
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Analytics</h1>
+        <div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+          <span>Real-time emoji popularity from page view telemetry</span>
+          {!isLive && <Badge variant="warning">Database unavailable — showing catalog only</Badge>}
+          {isLive && overview.lastUpdatedAt && (
+            <span className="text-xs text-gray-400 dark:text-gray-500">
+              Last view recorded {formatRelative(overview.lastUpdatedAt)}
+            </span>
+          )}
+        </div>
+      </header>
+
+      <section aria-label="Summary metrics" className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-gray-500 dark:text-gray-400">
+              Total Views
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div
+              data-testid="total-views"
+              className="text-3xl font-bold text-gray-900 dark:text-white"
+            >
+              {formatNumber(overview.totalViews)}
+            </div>
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              Across {formatNumber(overview.trackedEmojis)} tracked emoji
+              {overview.trackedEmojis === 1 ? '' : 's'}
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-gray-500 dark:text-gray-400">
+              Catalog Size
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-3xl font-bold text-gray-900 dark:text-white">
+              {formatNumber(overview.catalogSize)}
+            </div>
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {coveragePercent}% have recorded views
+            </p>
+            <div
+              className="mt-3 h-2 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700"
+              aria-hidden="true"
+            >
+              <div
+                data-testid="coverage-bar"
+                className="h-full rounded-full bg-gradient-to-r from-amber-500 to-orange-500 transition-all duration-500"
+                style={{ width: `${coveragePercent}%` }}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-gray-500 dark:text-gray-400">
+              Last 7 Days
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-3xl font-bold text-gray-900 dark:text-white">
+              {formatNumber(overview.viewsLast7Days)}
+            </div>
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {formatNumber(overview.viewsLast30Days)} in the last 30 days
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-gray-500 dark:text-gray-400">
+              Top Emoji
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {topEmoji?.emoji ? (
+              <>
+                <div className="flex items-center gap-3">
+                  <span className="text-3xl" aria-hidden="true">
+                    {topEmoji.emoji.character}
+                  </span>
+                  <div>
+                    <div className="text-base font-semibold text-gray-900 dark:text-white">
+                      {topEmoji.emoji.name}
+                    </div>
+                    <div className="text-xs text-gray-500 dark:text-gray-400">
+                      {formatNumber(topEmoji.views)} views
+                    </div>
+                  </div>
+                </div>
+                <Link
+                  href={`/emoji/${topEmoji.emoji.slug}`}
+                  className="mt-3 inline-block text-xs font-medium text-amber-600 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-300"
+                >
+                  View page →
+                </Link>
+              </>
+            ) : (
+              <>
+                <div className="text-3xl font-bold text-gray-400 dark:text-gray-500">—</div>
+                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  No views recorded yet
+                </p>
+              </>
+            )}
+          </CardContent>
+        </Card>
+      </section>
+
+      <section aria-label="Top emojis" className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            Most Popular Emojis
+          </h2>
+          <Badge variant="secondary">Top {topEmojis.length}</Badge>
+        </div>
+        {topEmojis.length === 0 ? (
+          <Card>
+            <CardContent className="py-12 text-center text-sm text-gray-500 dark:text-gray-400">
+              No view data yet. Views appear here as soon as users open emoji pages.
+            </CardContent>
+          </Card>
+        ) : (
+          <Card>
+            <CardContent className="space-y-3 pt-6">
+              {topEmojis.map((entry, idx) => {
+                const percent = maxViews > 0 ? (entry.views / maxViews) * 100 : 0;
+                return (
+                  <div
+                    key={entry.slug}
+                    data-testid="popular-row"
+                    className="grid grid-cols-[3rem_2.5rem_1fr_auto] items-center gap-3"
+                  >
+                    <div className="text-sm font-semibold text-gray-500 dark:text-gray-400">
+                      #{idx + 1}
+                    </div>
+                    <div className="text-2xl" aria-hidden="true">
+                      {entry.emoji?.character ?? '❔'}
+                    </div>
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <Link
+                          href={`/emoji/${entry.slug}`}
+                          className="truncate text-sm font-medium text-gray-900 hover:text-amber-600 dark:text-white dark:hover:text-amber-400"
+                        >
+                          {entry.emoji?.name ?? entry.slug}
+                        </Link>
+                        <Badge variant="outline" className="hidden sm:inline-flex">
+                          {entry.emoji?.category ?? 'unknown'}
+                        </Badge>
+                      </div>
+                      <div
+                        className="mt-1 h-2 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700"
+                        aria-hidden="true"
+                      >
+                        <div
+                          className="h-full rounded-full bg-gradient-to-r from-amber-500 to-orange-500"
+                          style={{ width: `${percent}%` }}
+                        />
+                      </div>
+                    </div>
+                    <div className="text-right">
+                      <div
+                        data-testid="popular-views"
+                        className="text-sm font-semibold text-gray-900 dark:text-white"
+                      >
+                        {formatNumber(entry.views)}
+                      </div>
+                      <div className="text-xs text-gray-500 dark:text-gray-400">
+                        {formatRelative(entry.lastViewedAt)}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </CardContent>
+          </Card>
+        )}
+      </section>
+
+      <section aria-label="Least viewed" className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            Lowest Traffic (Tracked)
+          </h2>
+          <Badge variant="secondary">Bottom {leastViewed.length}</Badge>
+        </div>
+        {leastViewed.length === 0 ? (
+          <Card>
+            <CardContent className="py-12 text-center text-sm text-gray-500 dark:text-gray-400">
+              No tracked emojis with low traffic yet.
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="overflow-hidden rounded-2xl border border-gray-200/50 dark:border-gray-700/50">
+            <table className="w-full">
+              <thead className="bg-gray-50 dark:bg-gray-800/50">
+                <tr>
+                  <th className="px-4 py-3 text-left text-sm font-medium text-gray-500 dark:text-gray-400">
+                    Emoji
+                  </th>
+                  <th className="px-4 py-3 text-left text-sm font-medium text-gray-500 dark:text-gray-400">
+                    Name
+                  </th>
+                  <th className="px-4 py-3 text-right text-sm font-medium text-gray-500 dark:text-gray-400">
+                    Views
+                  </th>
+                  <th className="hidden px-4 py-3 text-left text-sm font-medium text-gray-500 dark:text-gray-400 sm:table-cell">
+                    Last viewed
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200/50 dark:divide-gray-700/50">
+                {leastViewed.map((entry) => (
+                  <tr key={entry.slug}>
+                    <td className="px-4 py-3 text-2xl" aria-hidden="true">
+                      {entry.emoji?.character ?? '❔'}
+                    </td>
+                    <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-white">
+                      <Link
+                        href={`/emoji/${entry.slug}`}
+                        className="hover:text-amber-600 dark:hover:text-amber-400"
+                      >
+                        {entry.emoji?.name ?? entry.slug}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-3 text-right text-sm text-gray-900 dark:text-white">
+                      {formatNumber(entry.views)}
+                    </td>
+                    <td className="hidden px-4 py-3 text-sm text-gray-500 dark:text-gray-400 sm:table-cell">
+                      {formatRelative(entry.lastViewedAt)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      <section aria-label="All emojis" className="space-y-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">All Emojis</h2>
+          <Badge variant="secondary">
+            {formatNumber(filteredAll.length)} of {formatNumber(allEmojis.length)}
+          </Badge>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <Input
+            type="search"
+            placeholder="Search by name, character, or category…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="max-w-sm"
+            aria-label="Search emojis"
+          />
+          <div className="flex flex-wrap gap-1" role="group" aria-label="Sort order">
+            {[
+              { value: 'views-desc', label: 'Most viewed' },
+              { value: 'views-asc', label: 'Least viewed' },
+              { value: 'name-asc', label: 'A → Z' },
+              { value: 'name-desc', label: 'Z → A' },
+            ].map((option) => (
+              <Button
+                key={option.value}
+                type="button"
+                size="sm"
+                variant={sortKey === option.value ? 'primary' : 'outline'}
+                onClick={() => setSortKey(option.value as SortKey)}
+                aria-pressed={sortKey === option.value}
+              >
+                {option.label}
+              </Button>
+            ))}
+          </div>
+        </div>
+
+        <div className="overflow-hidden rounded-2xl border border-gray-200/50 dark:border-gray-700/50">
+          <table className="w-full">
+            <thead className="bg-gray-50 dark:bg-gray-800/50">
+              <tr>
+                <th className="px-4 py-3 text-left text-sm font-medium text-gray-500 dark:text-gray-400">
+                  Emoji
+                </th>
+                <th className="px-4 py-3 text-left text-sm font-medium text-gray-500 dark:text-gray-400">
+                  Name
+                </th>
+                <th className="hidden px-4 py-3 text-left text-sm font-medium text-gray-500 dark:text-gray-400 sm:table-cell">
+                  Category
+                </th>
+                <th className="px-4 py-3 text-right text-sm font-medium text-gray-500 dark:text-gray-400">
+                  Views
+                </th>
+                <th className="hidden px-4 py-3 text-left text-sm font-medium text-gray-500 dark:text-gray-400 md:table-cell">
+                  Last viewed
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200/50 dark:divide-gray-700/50">
+              {filteredAll.slice(0, 50).map((entry) => (
+                <tr key={entry.slug} className="hover:bg-gray-50 dark:hover:bg-gray-800/50">
+                  <td className="px-4 py-3 text-2xl" aria-hidden="true">
+                    {entry.emoji.character}
+                  </td>
+                  <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-white">
+                    <Link
+                      href={`/emoji/${entry.slug}`}
+                      className="hover:text-amber-600 dark:hover:text-amber-400"
+                    >
+                      {entry.emoji.name}
+                    </Link>
+                    <div className="text-xs text-gray-500 dark:text-gray-400">{entry.slug}</div>
+                  </td>
+                  <td className="hidden px-4 py-3 text-sm text-gray-500 dark:text-gray-400 sm:table-cell">
+                    <Badge variant="secondary">{entry.emoji.category}</Badge>
+                  </td>
+                  <td className="px-4 py-3 text-right text-sm font-medium text-gray-900 dark:text-white">
+                    {formatNumber(entry.views)}
+                  </td>
+                  <td className="hidden px-4 py-3 text-sm text-gray-500 dark:text-gray-400 md:table-cell">
+                    {formatRelative(entry.lastViewedAt)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {filteredAll.length === 0 && (
+            <div className="py-12 text-center text-sm text-gray-500 dark:text-gray-400">
+              No emojis match the current filter.
+            </div>
+          )}
+          {filteredAll.length > 50 && (
+            <div className="border-t border-gray-200/50 px-4 py-3 text-xs text-gray-500 dark:border-gray-700/50 dark:text-gray-400">
+              Showing the first 50 results — refine your search to narrow down.
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+AdminAnalyticsDashboard.displayName = 'AdminAnalyticsDashboard';

--- a/src/components/admin/admin-nav.tsx
+++ b/src/components/admin/admin-nav.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { cn } from '@/lib/utils';
+
+const adminLinks = [
+  { label: 'Emojis', href: '/admin/emojis', icon: '🗂️' },
+  { label: 'Analytics', href: '/admin/analytics', icon: '📈' },
+];
+
+export interface AdminNavProps {
+  className?: string;
+}
+
+export function AdminNav({ className }: AdminNavProps) {
+  const pathname = usePathname();
+
+  return (
+    <nav
+      aria-label="Admin sections"
+      className={cn(
+        'flex flex-wrap gap-2 rounded-2xl border border-gray-200/50 bg-white/80 p-2 backdrop-blur-sm dark:border-gray-700/50 dark:bg-gray-800/60',
+        className
+      )}
+    >
+      {adminLinks.map((link) => {
+        const isActive =
+          pathname === link.href ||
+          (link.href !== '/admin' && pathname.startsWith(`${link.href}/`));
+        return (
+          <Link
+            key={link.href}
+            href={link.href}
+            className={cn(
+              'inline-flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors',
+              isActive
+                ? 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300'
+                : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-700/60 dark:hover:text-gray-100'
+            )}
+            aria-current={isActive ? 'page' : undefined}
+          >
+            <span aria-hidden="true">{link.icon}</span>
+            {link.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}
+
+AdminNav.displayName = 'AdminNav';

--- a/src/lib/analytics-queries.ts
+++ b/src/lib/analytics-queries.ts
@@ -1,0 +1,306 @@
+/**
+ * Admin analytics queries.
+ *
+ * Server-side data access for the admin analytics dashboard (ANAL-005).
+ * Reads aggregated emoji page-view counts from Neon and joins them with the
+ * static emoji catalog so admins can see what users actually look at.
+ *
+ * All functions are safe to call when DATABASE_URL is not configured — they
+ * return zeroed/empty results so the dashboard still renders the underlying
+ * catalog without popularity data.
+ *
+ * Each accessor accepts an optional `summaries` argument so callers (and
+ * unit tests) can supply a pre-built catalog instead of paying for the
+ * `getEmojiSummaries()` filesystem read on every call. When omitted, the
+ * real loader is used.
+ */
+
+import { getNeonSql } from '@/lib/neon';
+import { getEmojiSummaries } from '@/lib/emoji-data';
+import type { EmojiSummary } from '@/types/emoji';
+
+const SLUG_PATTERN = /^[a-z0-9-]+$/;
+
+const DEFAULT_TOP_LIMIT = 10;
+const DEFAULT_BOTTOM_LIMIT = 10;
+
+function isValidSlug(slug: unknown): slug is string {
+  return typeof slug === 'string' && SLUG_PATTERN.test(slug);
+}
+
+function asNumber(value: unknown): number {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+/**
+ * Summary metrics for the admin dashboard.
+ */
+export interface AnalyticsOverview {
+  /** Sum of all view counts across every tracked slug */
+  totalViews: number;
+  /** Number of distinct emoji slugs that have at least one recorded view */
+  trackedEmojis: number;
+  /** Number of emojis in the static catalog */
+  catalogSize: number;
+  /** Emoji slug with the highest view count (null if no views yet) */
+  topSlug: string | null;
+  /** Top slug's view count (0 when there are no views) */
+  topViews: number;
+  /** Sum of views recorded in the trailing 7-day window (best-effort) */
+  viewsLast7Days: number;
+  /** Sum of views recorded in the trailing 30-day window (best-effort) */
+  viewsLast30Days: number;
+  /** ISO timestamp of the most recent view update, if any */
+  lastUpdatedAt: string | null;
+}
+
+interface RawOverviewRow {
+  total_views: string | number | null;
+  tracked: string | number | null;
+  top_slug: string | null;
+  top_views: string | number | null;
+  last_updated_at: string | Date | null;
+  views_last_7: string | number | null;
+  views_last_30: string | number | null;
+}
+
+/**
+ * Load high-level analytics metrics for the admin overview cards.
+ *
+ * Returns zeroed values when the database is unavailable so the dashboard
+ * still renders.
+ *
+ * @param summaries Optional catalog override; defaults to `getEmojiSummaries()`.
+ */
+export async function getAnalyticsOverview(
+  summaries: EmojiSummary[] = getEmojiSummaries()
+): Promise<AnalyticsOverview> {
+  const catalogSize = summaries.length;
+
+  const empty: AnalyticsOverview = {
+    totalViews: 0,
+    trackedEmojis: 0,
+    catalogSize,
+    topSlug: null,
+    topViews: 0,
+    viewsLast7Days: 0,
+    viewsLast30Days: 0,
+    lastUpdatedAt: null,
+  };
+
+  const sql = getNeonSql();
+  if (!sql) {
+    return empty;
+  }
+
+  try {
+    const rows = (await sql`
+      SELECT
+        COALESCE(SUM(view_count), 0)::bigint AS total_views,
+        COUNT(*)::bigint AS tracked,
+        (
+          SELECT slug FROM emoji_page_views
+          ORDER BY view_count DESC, slug ASC
+          LIMIT 1
+        ) AS top_slug,
+        (
+          SELECT view_count FROM emoji_page_views
+          ORDER BY view_count DESC, slug ASC
+          LIMIT 1
+        ) AS top_views,
+        MAX(updated_at) AS last_updated_at,
+        COALESCE(SUM(CASE WHEN updated_at >= now() - INTERVAL '7 days' THEN view_count ELSE 0 END), 0)::bigint AS views_last_7,
+        COALESCE(SUM(CASE WHEN updated_at >= now() - INTERVAL '30 days' THEN view_count ELSE 0 END), 0)::bigint AS views_last_30
+      FROM emoji_page_views
+    `) as RawOverviewRow[];
+
+    const row = rows[0];
+    if (!row) {
+      return empty;
+    }
+
+    return {
+      totalViews: asNumber(row.total_views),
+      trackedEmojis: asNumber(row.tracked),
+      catalogSize,
+      topSlug: isValidSlug(row.top_slug) ? row.top_slug : null,
+      topViews: asNumber(row.top_views),
+      viewsLast7Days: asNumber(row.views_last_7),
+      viewsLast30Days: asNumber(row.views_last_30),
+      lastUpdatedAt: row.last_updated_at
+        ? row.last_updated_at instanceof Date
+          ? row.last_updated_at.toISOString()
+          : new Date(row.last_updated_at).toISOString()
+        : null,
+    };
+  } catch (err) {
+    console.error('[analytics-queries] Failed to load overview:', err);
+    return empty;
+  }
+}
+
+/**
+ * Popularity entry returned to the admin dashboard.
+ */
+export interface PopularityEntry {
+  slug: string;
+  views: number;
+  /** ISO timestamp of last view increment, if any */
+  lastViewedAt: string | null;
+}
+
+interface RawPopularityRow {
+  slug: string;
+  view_count: string | number;
+  updated_at: string | Date | null;
+}
+
+function attachSummary(
+  rows: PopularityEntry[],
+  summaries: EmojiSummary[]
+): (PopularityEntry & { emoji: EmojiSummary | null })[] {
+  const bySlug = new Map(summaries.map((s) => [s.slug, s]));
+  return rows.map((row) => ({
+    ...row,
+    emoji: bySlug.get(row.slug) ?? null,
+  }));
+}
+
+function rawRowsToEntries(rows: RawPopularityRow[]): PopularityEntry[] {
+  return rows
+    .filter((row) => isValidSlug(row.slug))
+    .map((row) => ({
+      slug: row.slug,
+      views: asNumber(row.view_count),
+      lastViewedAt: row.updated_at
+        ? row.updated_at instanceof Date
+          ? row.updated_at.toISOString()
+          : new Date(row.updated_at).toISOString()
+        : null,
+    }));
+}
+
+/**
+ * Top emojis by view count.
+ *
+ * Returns up to `limit` rows; falls back to an empty list (the catalog-only
+ * table on the page handles the empty case). Slugs that don't match the
+ * canonical pattern are skipped.
+ *
+ * @param limit Maximum number of rows to return.
+ * @param summaries Optional catalog override; defaults to `getEmojiSummaries()`.
+ */
+export async function getTopEmojisByViews(
+  limit: number = DEFAULT_TOP_LIMIT,
+  summaries: EmojiSummary[] = getEmojiSummaries()
+): Promise<(PopularityEntry & { emoji: EmojiSummary | null })[]> {
+  if (limit <= 0) return [];
+
+  const sql = getNeonSql();
+  if (!sql) return [];
+
+  try {
+    const rows = (await sql`
+      SELECT slug, view_count, updated_at
+      FROM emoji_page_views
+      ORDER BY view_count DESC, slug ASC
+      LIMIT ${limit}
+    `) as RawPopularityRow[];
+
+    return attachSummary(rawRowsToEntries(rows), summaries);
+  } catch (err) {
+    console.error('[analytics-queries] Failed to load top emojis:', err);
+    return [];
+  }
+}
+
+/**
+ * Emojis with the fewest views (still tracked).
+ *
+ * Useful for spotting content that might need promotion or pruning.
+ *
+ * @param limit Maximum number of rows to return.
+ * @param summaries Optional catalog override; defaults to `getEmojiSummaries()`.
+ */
+export async function getLeastViewedTrackedEmojis(
+  limit: number = DEFAULT_BOTTOM_LIMIT,
+  summaries: EmojiSummary[] = getEmojiSummaries()
+): Promise<(PopularityEntry & { emoji: EmojiSummary | null })[]> {
+  if (limit <= 0) return [];
+
+  const sql = getNeonSql();
+  if (!sql) return [];
+
+  try {
+    const rows = (await sql`
+      SELECT slug, view_count, updated_at
+      FROM emoji_page_views
+      ORDER BY view_count ASC, slug ASC
+      LIMIT ${limit}
+    `) as RawPopularityRow[];
+
+    return attachSummary(rawRowsToEntries(rows), summaries);
+  } catch (err) {
+    console.error('[analytics-queries] Failed to load least-viewed emojis:', err);
+    return [];
+  }
+}
+
+/**
+ * Every catalog emoji joined with its view count.
+ *
+ * Returns catalog emojis in static order when the database is unavailable.
+ * The result is always at most `catalogSize` entries.
+ *
+ * @param summaries Optional catalog override; defaults to `getEmojiSummaries()`.
+ */
+export async function getAllEmojiViewCounts(
+  summaries: EmojiSummary[] = getEmojiSummaries()
+): Promise<(PopularityEntry & { emoji: EmojiSummary })[]> {
+  if (summaries.length === 0) return [];
+
+  const sql = getNeonSql();
+  if (!sql) {
+    return summaries.map((emoji) => ({
+      slug: emoji.slug,
+      views: 0,
+      lastViewedAt: null,
+      emoji,
+    }));
+  }
+
+  try {
+    const rows = (await sql`
+      SELECT slug, view_count, updated_at
+      FROM emoji_page_views
+    `) as RawPopularityRow[];
+
+    const viewsBySlug = new Map<string, PopularityEntry>();
+    for (const row of rawRowsToEntries(rows)) {
+      viewsBySlug.set(row.slug, row);
+    }
+
+    return summaries.map((emoji) => {
+      const tracked = viewsBySlug.get(emoji.slug);
+      return {
+        slug: emoji.slug,
+        views: tracked?.views ?? 0,
+        lastViewedAt: tracked?.lastViewedAt ?? null,
+        emoji,
+      };
+    });
+  } catch (err) {
+    console.error('[analytics-queries] Failed to load all emoji view counts:', err);
+    return summaries.map((emoji) => ({
+      slug: emoji.slug,
+      views: 0,
+      lastViewedAt: null,
+      emoji,
+    }));
+  }
+}

--- a/tests/unit/components/admin/admin-analytics-dashboard.test.tsx
+++ b/tests/unit/components/admin/admin-analytics-dashboard.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { render, screen, cleanup, fireEvent, within } from '@testing-library/react';
+import {
+  AdminAnalyticsDashboard,
+  type AdminAnalyticsDashboardProps,
+} from '@/components/admin/admin-analytics-dashboard';
+
+const summaries = [
+  { slug: 'fire', character: '🔥', name: 'Fire', category: 'travel', tldr: 'hot' },
+  { slug: 'heart', character: '❤️', name: 'Red Heart', category: 'symbols', tldr: 'love' },
+  { slug: 'smile', character: '😀', name: 'Grinning Face', category: 'faces', tldr: 'happy' },
+];
+
+function buildProps(
+  overrides: Partial<AdminAnalyticsDashboardProps> = {}
+): AdminAnalyticsDashboardProps {
+  return {
+    overview: {
+      totalViews: 150,
+      trackedEmojis: 2,
+      catalogSize: 3,
+      topSlug: 'fire',
+      topViews: 120,
+      viewsLast7Days: 50,
+      viewsLast30Days: 150,
+      lastUpdatedAt: '2026-08-01T12:00:00.000Z',
+    },
+    topEmojis: [
+      { slug: 'fire', views: 120, lastViewedAt: '2026-08-01T12:00:00.000Z', emoji: summaries[0] },
+      { slug: 'heart', views: 30, lastViewedAt: '2026-07-25T08:00:00.000Z', emoji: summaries[1] },
+    ],
+    leastViewed: [
+      { slug: 'heart', views: 30, lastViewedAt: '2026-07-25T08:00:00.000Z', emoji: summaries[1] },
+      { slug: 'fire', views: 120, lastViewedAt: '2026-08-01T12:00:00.000Z', emoji: summaries[0] },
+    ],
+    allEmojis: summaries.map((emoji) => ({
+      slug: emoji.slug,
+      views: emoji.slug === 'fire' ? 120 : emoji.slug === 'heart' ? 30 : 0,
+      lastViewedAt: emoji.slug === 'fire' ? '2026-08-01T12:00:00.000Z' : null,
+      emoji,
+    })),
+    isLive: true,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('AdminAnalyticsDashboard', () => {
+  it('renders the analytics heading', () => {
+    render(<AdminAnalyticsDashboard {...buildProps()} />);
+    expect(screen.getByRole('heading', { name: /^analytics$/i, level: 1 })).toBeInTheDocument();
+  });
+
+  it('displays total views in the summary card', () => {
+    render(<AdminAnalyticsDashboard {...buildProps()} />);
+    expect(screen.getByTestId('total-views')).toHaveTextContent('150');
+  });
+
+  it('shows the live indicator when database data is available', () => {
+    render(<AdminAnalyticsDashboard {...buildProps({ isLive: true })} />);
+    expect(screen.queryByText(/database unavailable/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/last view recorded/i)).toBeInTheDocument();
+  });
+
+  it('shows the database-unavailable banner when not live', () => {
+    render(
+      <AdminAnalyticsDashboard
+        {...buildProps({
+          isLive: false,
+          overview: {
+            totalViews: 0,
+            trackedEmojis: 0,
+            catalogSize: 3,
+            topSlug: null,
+            topViews: 0,
+            viewsLast7Days: 0,
+            viewsLast30Days: 0,
+            lastUpdatedAt: null,
+          },
+        })}
+      />
+    );
+    expect(screen.getByText(/database unavailable/i)).toBeInTheDocument();
+  });
+
+  it('renders the top emoji rank rows', () => {
+    render(<AdminAnalyticsDashboard {...buildProps()} />);
+    const rows = screen.getAllByTestId('popular-row');
+    expect(rows).toHaveLength(2);
+    const views = screen.getAllByTestId('popular-views').map((el) => el.textContent);
+    expect(views).toEqual(['120', '30']);
+  });
+
+  it('shows the empty-state message when no top emojis exist', () => {
+    render(<AdminAnalyticsDashboard {...buildProps({ topEmojis: [], isLive: false })} />);
+    expect(screen.getByText(/no view data yet/i)).toBeInTheDocument();
+  });
+
+  it('falls back to the slug when no emoji summary is found', () => {
+    render(
+      <AdminAnalyticsDashboard
+        {...buildProps({
+          topEmojis: [
+            {
+              slug: 'unknown-slug',
+              views: 7,
+              lastViewedAt: null,
+              emoji: null,
+            },
+          ],
+        })}
+      />
+    );
+    const row = screen.getByTestId('popular-row');
+    expect(within(row).getByText('unknown-slug')).toBeInTheDocument();
+    expect(within(row).getByText('❔')).toBeInTheDocument();
+  });
+
+  it('filters the full table by search query', () => {
+    render(<AdminAnalyticsDashboard {...buildProps()} />);
+    const search = screen.getByRole('searchbox', { name: /search emojis/i });
+    fireEvent.change(search, { target: { value: 'fire' } });
+    // "All Emojis" table: only one row should match (Fire emoji)
+    const allEmojisHeading = screen.getByRole('heading', { name: /^all emojis$/i });
+    const allSection = allEmojisHeading.closest('section');
+    expect(allSection).not.toBeNull();
+    const rows = within(allSection as HTMLElement).getAllByRole('row');
+    // 1 header + 1 data row
+    expect(rows.length).toBe(2);
+  });
+
+  it('switches sort order when buttons are clicked', () => {
+    render(<AdminAnalyticsDashboard {...buildProps()} />);
+    const ascButton = screen.getByRole('button', { name: /least viewed/i });
+    fireEvent.click(ascButton);
+    expect(ascButton).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('shows the empty-state when filtering returns no results', () => {
+    render(<AdminAnalyticsDashboard {...buildProps()} />);
+    const search = screen.getByRole('searchbox', { name: /search emojis/i });
+    fireEvent.change(search, { target: { value: 'no-such-emoji' } });
+    expect(screen.getByText(/no emojis match the current filter/i)).toBeInTheDocument();
+  });
+
+  it('keeps all tables visible when search has no matches', () => {
+    render(<AdminAnalyticsDashboard {...buildProps()} />);
+    expect(screen.getByText(/most popular emojis/i)).toBeInTheDocument();
+    expect(screen.getByText(/lowest traffic/i)).toBeInTheDocument();
+  });
+
+  it('shows no top-emoji card content when topSlug is null', () => {
+    render(
+      <AdminAnalyticsDashboard
+        {...buildProps({
+          overview: {
+            ...buildProps().overview,
+            topSlug: null,
+            topViews: 0,
+          },
+          topEmojis: [],
+        })}
+      />
+    );
+    expect(screen.getByText(/no views recorded yet/i)).toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/admin/admin-nav.test.tsx
+++ b/tests/unit/components/admin/admin-nav.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, afterEach, mock } from 'bun:test';
+import { render, screen, cleanup } from '@testing-library/react';
+import { AdminNav } from '@/components/admin/admin-nav';
+
+let mockPathname = '/admin/emojis';
+
+mock.module('next/navigation', () => ({
+  usePathname: () => mockPathname,
+  useRouter: () => ({
+    push: mock(() => {}),
+  }),
+}));
+
+afterEach(() => {
+  cleanup();
+  mockPathname = '/admin/emojis';
+});
+
+describe('AdminNav', () => {
+  it('renders the Emojis and Analytics links', () => {
+    render(<AdminNav />);
+    expect(screen.getByRole('link', { name: /emojis/i })).toHaveAttribute('href', '/admin/emojis');
+    expect(screen.getByRole('link', { name: /analytics/i })).toHaveAttribute(
+      'href',
+      '/admin/analytics'
+    );
+  });
+
+  it('marks the active link with aria-current', () => {
+    mockPathname = '/admin/analytics';
+    render(<AdminNav />);
+    expect(screen.getByRole('link', { name: /analytics/i })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+    expect(screen.getByRole('link', { name: /emojis/i })).not.toHaveAttribute('aria-current');
+  });
+
+  it('matches nested analytics routes', () => {
+    mockPathname = '/admin/analytics/details';
+    render(<AdminNav />);
+    expect(screen.getByRole('link', { name: /analytics/i })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+  });
+});

--- a/tests/unit/lib/analytics-queries.test.ts
+++ b/tests/unit/lib/analytics-queries.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect, afterEach, mock } from 'bun:test';
+import type { EmojiSummary } from '@/types/emoji';
+
+// We deliberately do NOT use `mock.module('@/lib/emoji-data', ...)` here:
+// in bun, file-scope module mocks leak across test files in the same process,
+// which would clobber `emoji-data.test.ts` (causing e.g. the skull-emoji
+// assertion to fail because the real catalog is replaced with this sample).
+// Instead, every accessor in `@/lib/analytics-queries` accepts an optional
+// `summaries` override, which we exercise here.
+
+const sampleSummaries: EmojiSummary[] = [
+  { slug: 'fire', character: '🔥', name: 'Fire', category: 'travel', tldr: 'hot' },
+  { slug: 'heart', character: '❤️', name: 'Red Heart', category: 'symbols', tldr: 'love' },
+  { slug: 'smile', character: '😀', name: 'Grinning Face', category: 'faces', tldr: 'happy' },
+];
+
+const defaultSqlImpl = async (strings: TemplateStringsArray): Promise<unknown[]> => {
+  const head = strings[0] ?? '';
+  if (head.includes('SUM(view_count)')) {
+    return [
+      {
+        total_views: '150',
+        tracked: '2',
+        top_slug: 'fire',
+        top_views: '120',
+        last_updated_at: new Date('2026-08-01T12:00:00Z'),
+        views_last_7: '50',
+        views_last_30: '150',
+      },
+    ];
+  }
+  if (head.includes('ORDER BY view_count DESC')) {
+    return [
+      { slug: 'fire', view_count: '120', updated_at: new Date('2026-08-01T12:00:00Z') },
+      { slug: 'heart', view_count: '30', updated_at: new Date('2026-07-25T08:00:00Z') },
+    ];
+  }
+  if (head.includes('ORDER BY view_count ASC')) {
+    return [
+      { slug: 'heart', view_count: '30', updated_at: new Date('2026-07-25T08:00:00Z') },
+      { slug: 'fire', view_count: '120', updated_at: new Date('2026-08-01T12:00:00Z') },
+    ];
+  }
+  if (head.includes('FROM emoji_page_views') && !head.includes('ORDER BY')) {
+    return [
+      { slug: 'fire', view_count: '120', updated_at: new Date('2026-08-01T12:00:00Z') },
+      { slug: 'heart', view_count: '30', updated_at: new Date('2026-07-25T08:00:00Z') },
+    ];
+  }
+  return [];
+};
+
+const mockSql = mock(defaultSqlImpl);
+
+// Only mock Neon — the data layer we genuinely want to substitute. The
+// emoji-data module is imported untouched so `emoji-data.test.ts` keeps
+// seeing the real catalog.
+mock.module('@/lib/neon', () => ({
+  getNeonSql: () =>
+    process.env.DATABASE_URL ? (mockSql as unknown as import('@/lib/neon').NeonSql) : null,
+}));
+
+describe('analytics-queries', () => {
+  afterEach(() => {
+    Reflect.deleteProperty(process.env, 'DATABASE_URL');
+    mockSql.mockClear();
+    mockSql.mockImplementation(defaultSqlImpl);
+  });
+
+  describe('getAnalyticsOverview', () => {
+    it('returns zeroed values when DATABASE_URL is unset', async () => {
+      Reflect.deleteProperty(process.env, 'DATABASE_URL');
+      const { getAnalyticsOverview } = await import('@/lib/analytics-queries');
+      const result = await getAnalyticsOverview(sampleSummaries);
+      expect(result.totalViews).toBe(0);
+      expect(result.trackedEmojis).toBe(0);
+      expect(result.catalogSize).toBe(sampleSummaries.length);
+      expect(result.topSlug).toBeNull();
+      expect(result.topViews).toBe(0);
+      expect(result.viewsLast7Days).toBe(0);
+      expect(result.viewsLast30Days).toBe(0);
+      expect(result.lastUpdatedAt).toBeNull();
+    });
+
+    it('parses overview metrics from Neon', async () => {
+      process.env.DATABASE_URL = 'postgresql://test';
+      const { getAnalyticsOverview } = await import('@/lib/analytics-queries');
+      const result = await getAnalyticsOverview(sampleSummaries);
+      expect(result.totalViews).toBe(150);
+      expect(result.trackedEmojis).toBe(2);
+      expect(result.catalogSize).toBe(sampleSummaries.length);
+      expect(result.topSlug).toBe('fire');
+      expect(result.topViews).toBe(120);
+      expect(result.viewsLast7Days).toBe(50);
+      expect(result.viewsLast30Days).toBe(150);
+      expect(result.lastUpdatedAt).toBe('2026-08-01T12:00:00.000Z');
+    });
+
+    it('returns zeroed values when Neon throws', async () => {
+      process.env.DATABASE_URL = 'postgresql://test';
+      const origErr = console.error;
+      console.error = () => {};
+      mockSql.mockImplementation(async () => {
+        throw new Error('boom');
+      });
+      try {
+        const { getAnalyticsOverview } = await import('@/lib/analytics-queries');
+        const result = await getAnalyticsOverview(sampleSummaries);
+        expect(result.totalViews).toBe(0);
+        expect(result.trackedEmojis).toBe(0);
+        expect(result.topSlug).toBeNull();
+      } finally {
+        console.error = origErr;
+      }
+    });
+
+    it('rejects invalid top slug', async () => {
+      process.env.DATABASE_URL = 'postgresql://test';
+      mockSql.mockImplementation(async (strings) => {
+        const head = strings[0] ?? '';
+        if (head.includes('SUM(view_count)')) {
+          return [
+            {
+              total_views: '5',
+              tracked: '1',
+              top_slug: 'bad slug!',
+              top_views: '5',
+              last_updated_at: null,
+              views_last_7: '5',
+              views_last_30: '5',
+            },
+          ];
+        }
+        return [];
+      });
+      const { getAnalyticsOverview } = await import('@/lib/analytics-queries');
+      const result = await getAnalyticsOverview(sampleSummaries);
+      expect(result.totalViews).toBe(5);
+      expect(result.topSlug).toBeNull();
+      expect(result.topViews).toBe(5);
+    });
+  });
+
+  describe('getTopEmojisByViews', () => {
+    it('returns catalog-resolved entries in popularity order', async () => {
+      process.env.DATABASE_URL = 'postgresql://test';
+      const { getTopEmojisByViews } = await import('@/lib/analytics-queries');
+      const result = await getTopEmojisByViews(5, sampleSummaries);
+      expect(result).toHaveLength(2);
+      expect(result[0]?.slug).toBe('fire');
+      expect(result[0]?.views).toBe(120);
+      expect(result[0]?.emoji?.name).toBe('Fire');
+      expect(result[1]?.slug).toBe('heart');
+      expect(result[1]?.views).toBe(30);
+    });
+
+    it('returns an empty array when DATABASE_URL is unset', async () => {
+      Reflect.deleteProperty(process.env, 'DATABASE_URL');
+      const { getTopEmojisByViews } = await import('@/lib/analytics-queries');
+      const result = await getTopEmojisByViews(5, sampleSummaries);
+      expect(result).toEqual([]);
+    });
+
+    it('returns an empty array when limit <= 0', async () => {
+      process.env.DATABASE_URL = 'postgresql://test';
+      const { getTopEmojisByViews } = await import('@/lib/analytics-queries');
+      expect(await getTopEmojisByViews(0, sampleSummaries)).toEqual([]);
+      expect(await getTopEmojisByViews(-1, sampleSummaries)).toEqual([]);
+    });
+
+    it('skips rows with invalid slugs', async () => {
+      process.env.DATABASE_URL = 'postgresql://test';
+      mockSql.mockImplementation(async (strings) => {
+        const head = strings[0] ?? '';
+        if (head.includes('ORDER BY view_count DESC')) {
+          return [
+            { slug: 'BAD!', view_count: 999, updated_at: null },
+            { slug: 'fire', view_count: '5', updated_at: null },
+          ];
+        }
+        return [];
+      });
+      const { getTopEmojisByViews } = await import('@/lib/analytics-queries');
+      const result = await getTopEmojisByViews(5, sampleSummaries);
+      expect(result).toHaveLength(1);
+      expect(result[0]?.slug).toBe('fire');
+    });
+
+    it('returns empty array when Neon throws', async () => {
+      process.env.DATABASE_URL = 'postgresql://test';
+      const origErr = console.error;
+      console.error = () => {};
+      mockSql.mockImplementation(async () => {
+        throw new Error('boom');
+      });
+      try {
+        const { getTopEmojisByViews } = await import('@/lib/analytics-queries');
+        const result = await getTopEmojisByViews(5, sampleSummaries);
+        expect(result).toEqual([]);
+      } finally {
+        console.error = origErr;
+      }
+    });
+  });
+
+  describe('getLeastViewedTrackedEmojis', () => {
+    it('returns catalog-resolved entries sorted ascending', async () => {
+      process.env.DATABASE_URL = 'postgresql://test';
+      const { getLeastViewedTrackedEmojis } = await import('@/lib/analytics-queries');
+      const result = await getLeastViewedTrackedEmojis(5, sampleSummaries);
+      expect(result.map((r) => r.slug)).toEqual(['heart', 'fire']);
+      expect(result[0]?.views).toBe(30);
+    });
+
+    it('returns empty array when limit <= 0', async () => {
+      process.env.DATABASE_URL = 'postgresql://test';
+      const { getLeastViewedTrackedEmojis } = await import('@/lib/analytics-queries');
+      expect(await getLeastViewedTrackedEmojis(0, sampleSummaries)).toEqual([]);
+    });
+
+    it('returns empty array when DATABASE_URL is unset', async () => {
+      Reflect.deleteProperty(process.env, 'DATABASE_URL');
+      const { getLeastViewedTrackedEmojis } = await import('@/lib/analytics-queries');
+      expect(await getLeastViewedTrackedEmojis(5, sampleSummaries)).toEqual([]);
+    });
+  });
+
+  describe('getAllEmojiViewCounts', () => {
+    it('returns catalog emojis with zero views when DB is unset', async () => {
+      Reflect.deleteProperty(process.env, 'DATABASE_URL');
+      const { getAllEmojiViewCounts } = await import('@/lib/analytics-queries');
+      const result = await getAllEmojiViewCounts(sampleSummaries);
+      expect(result).toHaveLength(sampleSummaries.length);
+      expect(result.every((entry) => entry.views === 0)).toBe(true);
+      expect(result.every((entry) => entry.lastViewedAt === null)).toBe(true);
+      expect(result.every((entry) => entry.emoji !== undefined)).toBe(true);
+    });
+
+    it('joins view counts with catalog by slug', async () => {
+      process.env.DATABASE_URL = 'postgresql://test';
+      const { getAllEmojiViewCounts } = await import('@/lib/analytics-queries');
+      const result = await getAllEmojiViewCounts(sampleSummaries);
+      const bySlug = new Map(result.map((r) => [r.slug, r]));
+      expect(bySlug.get('fire')?.views).toBe(120);
+      expect(bySlug.get('heart')?.views).toBe(30);
+      // No DB row for "smile" — should default to 0
+      expect(bySlug.get('smile')?.views).toBe(0);
+      expect(bySlug.get('smile')?.lastViewedAt).toBeNull();
+    });
+
+    it('falls back to zeroed catalog when Neon throws', async () => {
+      process.env.DATABASE_URL = 'postgresql://test';
+      const origErr = console.error;
+      console.error = () => {};
+      mockSql.mockImplementation(async () => {
+        throw new Error('boom');
+      });
+      try {
+        const { getAllEmojiViewCounts } = await import('@/lib/analytics-queries');
+        const result = await getAllEmojiViewCounts(sampleSummaries);
+        expect(result).toHaveLength(sampleSummaries.length);
+        expect(result.every((entry) => entry.views === 0)).toBe(true);
+      } finally {
+        console.error = origErr;
+      }
+    });
+
+    it('returns empty array when catalog is empty', async () => {
+      process.env.DATABASE_URL = 'postgresql://test';
+      const { getAllEmojiViewCounts } = await import('@/lib/analytics-queries');
+      const result = await getAllEmojiViewCounts([]);
+      expect(result).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `/admin/analytics` — an admin-only dashboard that surfaces emoji page-view telemetry recorded in Neon (`emoji_page_views`).
- New `src/lib/analytics-queries.ts` with three safe accessors (`getAnalyticsOverview`, `getTopEmojisByViews`, `getLeastViewedTrackedEmojis`, `getAllEmojiViewCounts`) that fall back to zeroed/catalog-only data when `DATABASE_URL` is unset, mirroring the pattern used by `emoji-popularity.ts`.
- New `src/components/admin/admin-analytics-dashboard.tsx` client component with summary cards, a ranked top-10 list with relative bars, a lowest-traffic list, and a searchable, sortable catalog table.
- New `src/components/admin/admin-nav.tsx` adds a tabbed admin nav (Emojis / Analytics) shared by `/admin/emojis` and `/admin/analytics`.
- Page route is `force-dynamic` and `robots: noindex` so it stays out of search engines.

## Test plan
- `bun run test:coverage` — 3727 tests pass, coverage thresholds (99.3% functions / 99.4% lines) met.
- `bun run lint` — clean.
- `bun run typecheck` — clean.
- New unit tests:
  - `tests/unit/lib/analytics-queries.test.ts` (14 cases): neon happy paths, no-DB fallback, neon error fallback, invalid slug filtering, empty limit short-circuits, all-query catalog join.
  - `tests/unit/components/admin/admin-analytics-dashboard.test.tsx` (11 cases): heading, summary card, live vs. unavailable banner, top-emoji ranking + fallback, search filter, sort toggle, empty-state copy.
  - `tests/unit/components/admin/admin-nav.test.tsx` (3 cases): link rendering, active state, nested route matching.

Fixes #78