### PR TITLE
feat(guides): add standalone heart-hands emoji guide

### DIFF
--- a/content/guides/what-does-heart-hands-mean.md
+++ b/content/guides/what-does-heart-hands-mean.md
@@ -1,0 +1,91 @@
+---
+title: 🫶 is the hug emoji that became a fandom signal
+slug: what-does-heart-hands-mean
+description: 🫶 shipped in 2021 as a universal "love you." In 2026 it is three different emojis at once — a fandom handshake, a soft-launch seal, and a friend-zone beat — and most senders do not realize they are choosing.
+publishedAt: 2026-08-19
+updatedAt: 2026-08-19
+author: KnowYourEmoji Editorial
+tags: [kpop, fandom, dating, slang, gen-z, soft-launch]
+relatedEmojis: [heart-hands, heart-red, sparkling-heart, thumbs-up]
+relatedCombos: [double-hearts, hand-heart-love, sparkle-heart]
+heroEmoji: 🫶
+readingTimeMinutes: 7
+seoTitle: 🫶 is the hug emoji that became a fandom signal — what heart-hands actually means
+seoDescription: 🫶 shipped as a universal hug emoji. By 2026 it is a K-pop handshake, a soft-launch seal, and a friend-zone reply — and the read depends on who is sending it. Here is how to read it.
+draft: false
+---
+
+The heart-hands emoji was added to Unicode in 2021 (codepoint U+1FAF6) as a picture of two hands making a heart shape. The artwork is small, sweet, and unambiguous: it is the gesture K-pop idols had been throwing at fans since the late 2000s, the one that appears on graduation cards, on birthday-cake Instagram stories, on the front of a thousand text messages that just say "love you." For about eighteen months, 🫶 was the cleanest love emoji on the keyboard. By 2026 it is doing three different jobs at once, and most of the people sending it have not noticed.
+
+This is what 🫶 actually means now, and where it quietly misfires.
+
+## How 🫶 ended up everywhere
+
+The heart-hands gesture has been around since the late 2000s — South Korean and Japanese idols were already throwing it at fans before Unicode bothered to encode it. The shift was when the gesture became available as a single tap:
+
+- **K-pop adoption, late 2000s–present.** 🫶 is the gesture an idol makes at a fan meeting. BTS, BLACKPINK, Twice, and most of the major groups had been doing it on stage for a decade before the emoji shipped. The gesture predates the emoji by about a generation.
+- **Unicode 14, 2021.** Codepoint U+1FAF6 landed in September 2021, alongside the melting face, the biting lip, and the troll. The official name is "heart hands." Apple, Google, and Microsoft all shipped their variants within six months.
+- **TikTok virality, 2022–2023.** Creators used 🫶 on celebratory text overlays — graduations, new apartments, pride posts, soft-launches. The emoji absorbed a lot of the territory the red heart ❤️ had been quietly losing on younger platforms.
+- **The fandom-handshake era, 2024–present.** 🫶🫶🫶 in a row became the universal "I am a fan of this person, this album, this show." It now sits next to a user's display name in fan accounts the way the 🅱️ used to in Blood-style bios.
+
+In 2026, 🫶 is in the top twenty most-used emojis globally and still rising. The reason is that the gesture is doing three jobs at once and the keyboard finally caught up.
+
+## What 🫶 is doing in a message
+
+🫶 has a stable technical meaning — two hands forming a heart — and a wildly unstable read. The same emoji lands as:
+
+- **Genuine affection.** "love you so much 🫶" from a close friend or a partner → the sender is sincere. The heart-hands are doing the work of a hug over text. This reading survives mostly in close friendships, family threads, and any DM where the sender and recipient already have warm rapport.
+- **Fandom handshake.** "new album dropped 🫶🫶🫶" → the sender is performing fan identity. The heart-hands are the visual tag for "I am in this community, I love this thing." The emoji reads as tribal, not romantic.
+- **Soft-launch seal.** "great weekend 🫶" attached to a story with a single blurred-out figure in the second slide → the sender is signaling a new partner without naming them. 🫶 has quietly taken over the job the white heart 🤍 was doing on soft-launch posts two years ago.
+- **Dating-app warmth.** "had the best time with you 🫶" → the sender is performing "this was a date and I liked it." The heart-hands read warmer than a 👍 and softer than ❤️, which is exactly the gap they were designed to fill.
+- **Birthday and celebration default.** "HAPPY BIRTHDAY 🫶🫶🫶" in a group chat → the canonical love-bomb. The heart-hands are the modern default for any celebratory moment that needs more energy than a single emoji can hold.
+- **Apology softening.** "sorry I missed it 🫶" → the sender is using 🫶 to soften an otherwise dry apology. The emoji is doing the work of "I still care about you" without making the apology longer.
+- **End-of-thread closer.** "see you tomorrow 🫶" → the sender is closing the conversation. The 🫶 is the period at the end of the message. Adding anything after it would feel like over-engaging.
+
+## Where 🫶 flips on you
+
+🫶 misfires more than it used to, mostly because the read depends on the sender and the recipient:
+
+1. **In a flirty thread if you mean it romantically.** A 🫶 in a flirty DM reads as warm but ambiguous. It is softer than ❤️ and softer than 😘, which means it does not commit. If you mean it romantically, send ❤️ or 😘 or a sentence. 🫶 in a flirty thread is the friend-zone reply.
+2. **At someone who is venting or sharing pain.** "I just had the worst day 🫶" replied to with "🫶" reads as "I have categorized your pain and I am sending air-kisses." Use ❤️, "I'm sorry," or just a sentence. Heart-hands have no business near real feeling.
+3. **From a manager in a work thread.** "great work everyone 🫶" from a manager reads as performative. The heart-hands are doing the work of a manager trying to seem friendly. Use 🙌 instead — it celebrates without cosplaying as a fan.
+4. **In a condolence thread.** Even if you have used 🫶 casually everywhere else, dropping it in a grief thread is going to land as tone-deaf at best. Heart-hands are warm; grief needs something that can hold weight. Skip the emoji entirely.
+5. **From a younger sender to an older recipient.** A 22-year-old 🫶 to a 58-year-old reads as fandom-coded or soft-launch-coded, not sincere. The older recipient is reading the heart-hands as a hug; the younger sender is using them as a casual closer. The mismatch is the entire problem with the emoji across generations.
+6. **In a customer-service reply from a brand.** A brand sending 🫶 in a support thread reads as "our marketing team wrote this and a human did not." The corporate heart-hands have become their own microgenre of customer-service non-engagement.
+7. **At the end of an apology.** "sorry for the late reply 🫶" reads as not sorry. Apologies need sentences, not heart-hands. The 🫶 at the end of an apology quietly undoes the apology.
+
+## Replies that volley back
+
+A few reliable options:
+
+- **Match with 🫶.** Universal acknowledgment. Both of you are closing the thread at the same energy level. Use this when you genuinely have nothing to add.
+- **Match with [🫶❤️ hand heart love combo](/combo/hand-heart-love).** The combo is the "double-confirmed love" beat. Useful in friend threads where a single 🫶 reads as too cold and a sentence reads as too much.
+- **Stack with [🫶💖 sparkle heart combo](/combo/sparkle-heart).** The combo returns the fandom energy. When the sender's 🫶 was clearly a fandom handshake, the combo is the matching beat. It says "yes, I am also in this."
+- **Match the romance with [❤️💕 double hearts combo](/combo/double-hearts).** When the sender's 🫶 clearly read as romantic, the double-hearts combo is the equal-and-opposite reply. It escalates the warmth without forcing either side to commit to a single heart.
+- **Defuse with a sentence.** If the 🫶 arrived ambiguously and you want to be sure the recipient reads it as warm, follow it up. "🫶 sounds good, see you Sunday" is a 🫶 that cannot be misread. The sentence is doing the work the heart-hands cannot.
+- **Push back with a single ❤️.** When the sender's 🫶 was clearly too soft for the moment — a flirty thread, a real apology, a romantic beat that needed commitment — a single ❤️ returned escalates the energy without forcing the sender to commit first.
+
+The 🫶 in 2026 is the emoji equivalent of sending "love you" without naming who you mean. The send is cheap, the read is expensive, and the cost is paid by the person on the other end. The safest rule is still the simplest: 🫶 in a friend thread is fine, 🫶 in a flirty thread is almost never enough, and 🫶 in a work thread is the move that gets you filed under "trying too hard."
+
+## FAQ
+
+**What does 🫶 mean?**
+🫶 means affection, appreciation, or fandom — depending on who is sending it and where. The base meaning is "two hands forming a heart." The contextual meaning depends entirely on the surrounding text and the sender's age.
+
+**What does 🫶 mean from a guy?**
+From a guy or anyone else, 🫶 means warmth, fandom, or soft-launch — depending on context. There is no gendered meaning; the emoji is about the gesture, not about who is sending it.
+
+**Is 🫶 flirty?**
+It can be. A 🫶 in a dating-app thread or a flirty DM reads as warm and ambiguous. A 🫶 in a friend thread reads as platonic. The context does the work.
+
+**What does 🫶 mean on TikTok?**
+On TikTok 🫶 is the fandom handshake and the celebratory default. Creators paste it on graduation posts, new-job announcements, pride content, and album-drop reactions. The emoji is doing the work of "I love this thing and I want you to know I love it."
+
+**What does 🫶 mean from a girl?**
+The same thing it means from anyone else: affection, fandom, or soft-launch, depending on the surrounding sentence. There is no gendered meaning; the read is about tone, not sender.
+
+**Why is 🫶 used so much in K-pop?**
+The heart-hands gesture originated as a K-pop idol move in the late 2000s. By the time Unicode shipped the emoji in 2021, the gesture was already coded as "fan love." The emoji is just the keyboard catching up to a decade of stage choreography.
+
+**What can I send instead of 🫶?**
+In friend threads: 🙌, ❤️, or a sentence. In flirty threads: ❤️, 😘, or a sentence. In fandom threads: 🫶🫶🫶 stacked, or [🫶💖](/combo/sparkle-heart). In work threads: literally anything except 🫶.

--- a/tests/unit/lib/guide-data-integration.test.ts
+++ b/tests/unit/lib/guide-data-integration.test.ts
@@ -140,6 +140,49 @@ describe('guide-data (live loader)', () => {
     });
   });
 
+  describe('heart-hands guide', () => {
+    it('loads with the expected frontmatter fields', () => {
+      const guide = getPublishedGuideBySlug('what-does-heart-hands-mean');
+      expect(guide).toBeDefined();
+      expect(guide?.title).toBe('🫶 is the hug emoji that became a fandom signal');
+      expect(guide?.tags).toContain('fandom');
+      expect(guide?.tags).toContain('kpop');
+      expect(guide?.readingTimeMinutes).toBe(7);
+      expect(guide?.heroEmoji).toBe('🫶');
+      expect(guide?.draft).toBe(false);
+    });
+
+    it('resolves the relatedEmojis slugs to known emoji records', () => {
+      const guide = getPublishedGuideBySlug('what-does-heart-hands-mean');
+      expect(guide?.relatedEmojis).toContain('heart-hands');
+      expect(guide?.relatedEmojis).toContain('heart-red');
+      expect(guide?.relatedEmojis).toContain('sparkling-heart');
+      expect(guide?.relatedEmojis).toContain('thumbs-up');
+    });
+
+    it('resolves the relatedCombos slugs to known combo records', () => {
+      const guide = getPublishedGuideBySlug('what-does-heart-hands-mean');
+      expect(guide?.relatedCombos).toContain('double-hearts');
+      expect(guide?.relatedCombos).toContain('hand-heart-love');
+      expect(guide?.relatedCombos).toContain('sparkle-heart');
+    });
+
+    it('renders Markdown body to HTML with section headings', () => {
+      const guide = getPublishedGuideBySlug('what-does-heart-hands-mean');
+      expect(guide?.html.length).toBeGreaterThan(0);
+      expect(guide?.html.toLowerCase()).toMatch(/<h[1-6]/);
+    });
+
+    it('appears in published slugs and summaries', () => {
+      expect(getPublishedGuideSlugs()).toContain('what-does-heart-hands-mean');
+      const summary = getPublishedGuideSummaries().find(
+        (s) => s.slug === 'what-does-heart-hands-mean'
+      );
+      expect(summary).toBeDefined();
+      expect(summary?.heroEmoji).toBe('🫶');
+    });
+  });
+
   describe('getAllGuideSummaries', () => {
     it('includes drafts and sorts newest first', () => {
       const summaries = getAllGuideSummaries();


### PR DESCRIPTION
## Summary

- Adds a long-form editorial guide for the heart-hands emoji (🫶, U+1FAF6) under `content/guides/what-does-heart-hands-mean.md`.
- Extends `tests/unit/lib/guide-data-integration.test.ts` with a describe block that exercises the new guide's frontmatter, related emoji/combo slugs, rendered HTML, and appearance in the published summaries.

## Why

The guides index has solid coverage of single-emoji deep dives (👍, 💀, 🫠, 🥺, etc.) but no entry for 🫶 — the gesture that shipped in Unicode 14 and quietly split into three different jobs (fandom handshake, soft-launch seal, friend-zone beat). The guide follows the same editorial shape as the recent 👍 and 💀 guides: history → contextual readings → misfires → replies → FAQ.

## Validation

- `bun run typecheck` — clean
- `bun run lint` — clean
- `bun run test:coverage` — 3733 tests, 0 fail, coverage 99.30% / 99.49% (thresholds met)
- `bun run validate:emojis` — clean
- `bun run build` — guide statically generated at `/guides/what-does-heart-hands-mean`

## Notes

- Related emoji slugs (`heart-hands`, `heart-red`, `sparkling-heart`, `thumbs-up`) and combo slugs (`double-hearts`, `hand-heart-love`, `sparkle-heart`) all verified to exist on disk before authoring.
- Test-only commit used `--no-verify` to bypass the existing repo quirk where oxlint's `tests/**` ignore pattern causes lint-staged's oxlint pass to fail with "No files found to lint" (see e.g. `852d347 test(guide-data): cover deriveSeoTitle fallback paths`).