### PR TITLE
feat(guides): add standalone face-with-hand-over-mouth emoji guide

### DIFF
--- a/content/guides/what-does-face-with-hand-over-mouth-mean.md
+++ b/content/guides/what-does-face-with-hand-over-mouth-mean.md
@@ -1,0 +1,93 @@
+---
+title: 🤭 is the "hehe" emoji that quietly became flirty
+slug: what-does-face-with-hand-over-mouth-mean
+description: 🤭 shipped in 2017 as a polite "oops." In 2026 it is doing four different jobs at once — a bashful giggle, a flirty seal, a gossiper's handshake, and a soft-rejection — and most senders do not realize they are picking one.
+publishedAt: 2026-08-20
+updatedAt: 2026-08-20
+author: KnowYourEmoji Editorial
+tags: [gen-z, dating, slang, tea, bashful, gossip]
+relatedEmojis: [face-with-hand-over-mouth, see-no-evil, smirk, smiling-face-with-smiling-eyes]
+relatedCombos: [shy-blush, smirk-wink, blush-rose, soft-smile]
+heroEmoji: 🤭
+readingTimeMinutes: 7
+seoTitle: What does 🤭 actually mean? The hand-over-mouth emoji's quiet takeover of flirty and gossip threads
+seoDescription: 🤭 used to mean "oops." In 2026 it is a bashful giggle, a flirty seal, a gossiper's handshake, and a soft-rejection — and the same emoji reads completely differently on Hinge than in the family group chat. Here is how to read it.
+draft: false
+---
+
+🤭 used to be the politest emoji on the keyboard. A yellow face with a hand covering its mouth, smiling eyes, the universal "oops, sorry, I should not have said that." Send 🤭, and the message said "excuse me" or "I am being cheeky." That is the emoji's official meaning and the meaning most older users still read it as. In 2026 the same emoji is doing four different jobs at once, and most of the people sending it have not noticed they are choosing.
+
+The hand-over-mouth gesture is the body language of a reaction you cannot quite commit to out loud — a stifled laugh, a flirty "hehe," a "did they really just say that." The emoji absorbed all of those readings, and then absorbed a few it was never designed for. A 🤭 in a dating-app thread reads as flirty. A 🤭 in a group chat reads as a gossip tag. A 🤭 after a mild insult reads as soft-rejection. The send is cheap; the read depends on who is on the other end.
+
+This is what 🤭 actually means now, and where it quietly misfires.
+
+## How 🤭 ended up everywhere
+
+The face-with-hand-over-mouth was added to Unicode in 2017 (codepoint U+1F92D) under the name "face with hand over mouth." The artwork is the standard yellow face with smiling eyes, but with one hand drawn across the lower face — the gesture every aunt, every coworker, and every polite person has been doing since at least the 1950s. The codepoint shipped alongside 🤫 (shushing face), 🤥 (lying face), and 🧐 (monocle face). The shift came from how the gesture became a single tap:
+
+- **The polite-oops era, 2017–2019.** 🤭 landed on iOS, Android, and Windows keyboards in the same year, and for about eighteen months the emoji did exactly one job: the bashful "oops, my bad." Users sent it after typos, accidental @-mentions, and minor social fumbles. The hand-over-mouth was the visual equivalent of "excuse me."
+- **The TikTok-gossip era, 2020–2022.** Creators started stacking 🤭 under tea drops and drama callouts. "I am not going to say anything but 🤭" became the universal gossip tag. The hand-over-mouth stopped being a single mistake and became the gesture of "I know something I am not going to say out loud." The emoji absorbed a lot of the territory the 👀 eyes emoji had been quietly losing on younger platforms.
+- **The dating-app-warmth era, 2022–2025.** 🤭 quietly became the flirty bashful reply on Hinge, Bumble, and Tinder. The same hand-over-mouth that meant "oops" in a work thread meant "you are making me blush" in a dating thread. The emoji got warmer than its Unicode name suggested.
+- **The soft-rejection era, 2024–present.** Younger users started using 🤭 to soft-reject without escalating. "haha okay 🤭" at the end of a flirty thread is the universal "thanks but no." The hand-over-mouth became the polite alternative to the block, and the smiling eyes made it impossible to call out as rude.
+
+In 2026, 🤭 sits in the top forty most-used emojis globally, and the read depends entirely on who is sending it and what they are reacting to. The contradiction is the whole story.
+
+## What 🤭 is doing in a message
+
+🤭 has a stable technical meaning — a face with a hand covering its mouth, smiling eyes — and a wildly unstable read. The same emoji lands as:
+
+- **Polite oops.** "sent that to the wrong person 🤭" → the sender is acknowledging a small social fumble. The hand-over-mouth is the visual equivalent of an embarrassed laugh. This reading survives mostly in work threads, family group chats, and any context where the sender is signaling "I did something silly and I am owning it."
+- **Bashful giggle.** "did you just say that 🤭" → the sender is reacting to a charming or flirty line. The hand-over-mouth is the gesture of "I cannot believe you just said that and I am delighted." This reading is dominant on TikTok and in early dating-app threads in 2026.
+- **Flirty seal.** "you are too sweet 🤭" from a Hinge match → the sender is performing bashful flirtation. The hand-over-mouth reads warmer than 😊 and softer than 😘, which is exactly the gap the emoji was designed to fill.
+- **Gossiper's handshake.** "I am not going to say anything but 🤭" → the sender is tagging tea. The hand-over-mouth is the universal "I know something and you know I know something." This reading is dominant on Twitter, TikTok, and Instagram stories.
+- **Soft-rejection.** "haha okay 🤭" at the end of a flirty thread → the sender is gently closing the conversation. The hand-over-mouth is performing politeness while signaling zero romantic energy. The smiling eyes make the rejection impossible to call out as rude.
+- **Reaction without commentary.** "🤭" alone under a post → the sender is reacting without words. The hand-over-mouth is doing the work of "I see this and I have an emotion about it that I am not going to spell out."
+- **End-of-thread warmer.** "see you tomorrow 🤭" → the sender is closing the conversation. The 🤭 is the period at the end of the message, but warmer than a 👍 and softer than a ❤️.
+
+## Where 🤭 flips on you
+
+🤭 misfires more than it used to, mostly because the read depends entirely on the audience:
+
+1. **In a work thread where the sender expected professional acknowledgment.** A 🤭 from a manager or coworker in a Slack thread reads as unprofessional. The hand-over-mouth does not have a work register; it is doing too much smiling. Use a 👍, a 🙌, or a sentence. 🤭 in a work thread is the move that gets you filed under "trying too hard."
+2. **At someone who is venting or sharing a problem.** "I just had the worst day 🤭" replied to with "🤭" reads as "I have categorized your pain and I am giggling about it." Use ❤️, "I'm sorry," or just a sentence. The hand-over-mouth has no business near real feeling.
+3. **In a flirty thread if you mean it romantically.** A 🤭 in a flirty DM reads as warm but ambiguous. It is softer than ❤️ and softer than 😘, which means it does not commit. If you mean it romantically, send ❤️ or 😘 or a sentence. 🤭 in a flirty thread is the friend-zone reply.
+4. **In a grief thread.** Even if you have used 🤭 casually everywhere else, dropping it in a grief or condolence thread is going to land as tone-deaf at best. The hand-over-mouth is warm; grief needs something that can hold weight. Skip the emoji entirely.
+5. **From an older sender to a younger recipient.** A 58-year-old 🤭 to a 22-year-old reads as "polite oops" — sincere, but the younger recipient is reading the hand-over-mouth as gossip or flirty. The mismatch is the entire problem with the emoji across generations.
+6. **In a customer-service reply from a brand.** A brand sending 🤭 in a support thread reads as "our marketing team wrote this and a human did not." The corporate hand-over-mouth has become its own microgenre of customer-service non-engagement.
+7. **As a soft-rejection when you actually want to commit.** "haha okay 🤭" at the end of a thread where you want to escalate reads as "I am closing this." The 🤭 is not the right move if you want the thread to keep going. Reach for a sentence, a question, or a 🔥.
+
+## Replies that volley back
+
+A few reliable options:
+
+- **Match with 🤭.** Universal acknowledgment. Both of you are reacting at the same energy level. Use this when you genuinely want to register a bashful reaction without escalating.
+- **Escalate to [😊🙈 shy blush combo](/combo/shy-blush).** The combo is the "double-confirmed bashful" beat. Useful when a single 🤭 reads as too cold and a sentence reads as too much. The smiling face and the see-no-evil monkey together land as the maximum-bashful reply.
+- **Match the flirty with [😏😉 smirk wink combo](/combo/smirk-wink).** When the sender's 🤭 clearly read as flirty, the combo returns the energy. The smirk and the wink are the universal "oh I see you" reply — flirty without committing to a smile.
+- **Match the soft with [🙂🤍 soft smile combo](/combo/soft-smile).** When the sender's 🤭 read as warm but you want to land as soft-affection rather than bashful, the combo is the equal-and-opposite reply. It says "yes, warm, but quiet."
+- **Defuse with a sentence.** If the 🤭 arrived ambiguously and you want to be sure the recipient reads it as warm, follow it up. "🤭 honestly that was so sweet of you" is a 🤭 that cannot be misread. The sentence is doing the work the hand-over-mouth cannot.
+- **Push back with [🌹😊 blush rose combo](/combo/blush-rose).** When the sender's 🤭 was clearly bashful and you want to escalate the warmth without forcing either side to commit to a heart, the combo is the move. It lands as "yes, bashful, and a little more."
+
+The 🤭 in 2026 is the emoji equivalent of a reaction you cannot quite commit to out loud. The send is cheap, the read is expensive, and the cost is paid by the person on the other end. The safest rule is still the simplest: 🤭 in a friend thread is fine, 🤭 in a flirty thread is almost never enough, and 🤭 in a work thread is the move that gets you filed under "trying too hard."
+
+## FAQ
+
+**What does 🤭 mean?**
+🤭 means bashfulness, embarrassment, flirty warmth, or gossip — depending on who is sending it and where. The base meaning is a face with a hand over its mouth. The contextual meaning depends entirely on the surrounding text and the sender's age.
+
+**What does 🤭 mean from a guy?**
+From a guy or anyone else, 🤭 means bashful reaction, flirty warmth, or gossip — depending on context. There is no gendered meaning; the emoji is about the gesture, not about who is sending it.
+
+**Is 🤭 flirty?**
+It can be. A 🤭 in a dating-app thread or a flirty DM reads as warm and bashful. A 🤭 in a friend thread or a work thread reads as a polite oops. The context does the work.
+
+**What does 🤭 mean on TikTok?**
+On TikTok 🤭 is the gossip tag and the bashful reaction. Creators paste it under tea drops, drama callouts, and any context where the sender wants to signal "I know something" without naming it. The emoji is doing the work of a reaction the sender cannot quite commit to out loud.
+
+**What does 🤭 mean from a girl?**
+The same thing it means from anyone else: bashful reaction, flirty warmth, or gossip, depending on the surrounding sentence. There is no gendered meaning; the read is about tone, not sender.
+
+**Why do younger people use 🤭 so much?**
+Younger users absorbed 🤭 as the flirty-bashful reply and the gossip tag. Older users still read it as a polite oops. The mismatch is the entire problem with the emoji across generations.
+
+**What can I send instead of 🤭?**
+In friend threads: 😊, 🙈, or a sentence. In flirty threads: ❤️, 😘, or a sentence. In gossip threads: 👀, 🤐, or 🤭 stacked. In work threads: literally anything except 🤭.

--- a/tests/unit/lib/guide-data-integration.test.ts
+++ b/tests/unit/lib/guide-data-integration.test.ts
@@ -183,6 +183,50 @@ describe('guide-data (live loader)', () => {
     });
   });
 
+  describe('face-with-hand-over-mouth guide', () => {
+    it('loads with the expected frontmatter fields', () => {
+      const guide = getPublishedGuideBySlug('what-does-face-with-hand-over-mouth-mean');
+      expect(guide).toBeDefined();
+      expect(guide?.title).toBe('🤭 is the "hehe" emoji that quietly became flirty');
+      expect(guide?.tags).toContain('bashful');
+      expect(guide?.tags).toContain('dating');
+      expect(guide?.readingTimeMinutes).toBe(7);
+      expect(guide?.heroEmoji).toBe('🤭');
+      expect(guide?.draft).toBe(false);
+    });
+
+    it('resolves the relatedEmojis slugs to known emoji records', () => {
+      const guide = getPublishedGuideBySlug('what-does-face-with-hand-over-mouth-mean');
+      expect(guide?.relatedEmojis).toContain('face-with-hand-over-mouth');
+      expect(guide?.relatedEmojis).toContain('smiling-face-with-smiling-eyes');
+      expect(guide?.relatedEmojis).toContain('see-no-evil');
+      expect(guide?.relatedEmojis).toContain('smirk');
+    });
+
+    it('resolves the relatedCombos slugs to known combo records', () => {
+      const guide = getPublishedGuideBySlug('what-does-face-with-hand-over-mouth-mean');
+      expect(guide?.relatedCombos).toContain('shy-blush');
+      expect(guide?.relatedCombos).toContain('smirk-wink');
+      expect(guide?.relatedCombos).toContain('blush-rose');
+      expect(guide?.relatedCombos).toContain('soft-smile');
+    });
+
+    it('renders Markdown body to HTML with section headings', () => {
+      const guide = getPublishedGuideBySlug('what-does-face-with-hand-over-mouth-mean');
+      expect(guide?.html.length).toBeGreaterThan(0);
+      expect(guide?.html.toLowerCase()).toMatch(/<h[1-6]/);
+    });
+
+    it('appears in published slugs and summaries', () => {
+      expect(getPublishedGuideSlugs()).toContain('what-does-face-with-hand-over-mouth-mean');
+      const summary = getPublishedGuideSummaries().find(
+        (s) => s.slug === 'what-does-face-with-hand-over-mouth-mean'
+      );
+      expect(summary).toBeDefined();
+      expect(summary?.heroEmoji).toBe('🤭');
+    });
+  });
+
   describe('getAllGuideSummaries', () => {
     it('includes drafts and sorts newest first', () => {
       const summaries = getAllGuideSummaries();


### PR DESCRIPTION
Adds a new editorial guide covering 🤭 (face-with-hand-over-mouth) and follow-up loader integration tests.

**What this guide covers**
- The contradiction between 🤭's 2017 "polite oops" meaning and its 2026 use as a flirty seal, gossiper's handshake, and soft-rejection
- Four historical eras that shifted the emoji's read (polite oops → TikTok gossip → dating warmth → soft rejection)
- Where 🤭 quietly misfires (work threads, grief threads, flirty threads where commitment is wanted)
- Reply patterns that volley back, cross-linking to `/combo/shy-blush`, `/combo/smirk-wink`, `/combo/blush-rose`, and `/combo/soft-smile`
- FAQ mirroring the thumbs-up / heart-hands structure

**Implementation notes**
- New file: `content/guides/what-does-face-with-hand-over-mouth-mean.md` (frontmatter + sectioned body + FAQ)
- Frontmatter follows the established pattern: title, slug, description, dates, author, tags, `relatedEmojis`, `relatedCombos`, `heroEmoji`, `readingTimeMinutes`, `seoTitle`, `seoDescription`, `draft: false`
- Two commits match the heart-hands PR pattern: `feat(guides)` for the content, `test(guides)` for the integration describe block
- All 3,738 tests pass; coverage stays above the 99.4% line / 99.5% function thresholds

🤖 Generated with [Claude Code](https://claude.ai/code)